### PR TITLE
Fix user.items bug causing template error

### DIFF
--- a/app.py
+++ b/app.py
@@ -225,11 +225,19 @@ def index():
         fetch_prices()
         for sid64 in ids:
             user = build_user_data(sid64)
+            items = user.get("items")
+            status = user.get("status")
+            if status == "failed":
+                status = "incomplete"
+            elif status != "parsed":
+                status = "private"
+            if not isinstance(items, list):
+                items = []
+            if status != "parsed":
+                items = []
+            user["items"] = items
+            user["status"] = status
             users.append(user)
-
-        for user in users:
-            if not isinstance(user.get("items"), list):
-                user["items"] = []
     return render_template(
         "index.html",
         users=users,

--- a/templates/_user.html
+++ b/templates/_user.html
@@ -14,11 +14,18 @@
       {% endif %}
     </span>
   </h2>
-  {% if user.items %}
-  <div class="items">
-    {% for item in user.items %}
-      <img src="{{ item.image_url }}" width="48" height="48">
-    {% endfor %}
+  <div class="card-body">
+    {% if user.status == 'incomplete' %}
+      <span class="badge bg-warning text-dark">Fetched but unparsed</span>
+    {% elif user.status == 'private' %}
+      <span class="badge bg-secondary">Private</span>
+    {% endif %}
+    {% if user.items %}
+    <div class="items">
+      {% for item in user.items | default([]) %}
+        <img src="{{ item.image_url }}" width="48" height="48">
+      {% endfor %}
+    </div>
+    {% endif %}
   </div>
-  {% endif %}
 </div>

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -107,3 +107,29 @@ def test_fetch_inventory_statuses(monkeypatch, pub_status, key_status, expected)
             rsps.add(responses.GET, key_url, **key_status)
         status, data = sac.fetch_inventory("1")
     assert status == expected
+
+
+@pytest.mark.parametrize("status", ["parsed", "incomplete", "private"])
+def test_user_template_safe(monkeypatch, status):
+    monkeypatch.setenv("STEAM_API_KEY", "x")
+    monkeypatch.setenv("BACKPACK_API_KEY", "x")
+    monkeypatch.setattr("utils.schema_fetcher.ensure_schema_cached", lambda: {})
+    import importlib
+
+    app = importlib.import_module("app")
+    importlib.reload(app)
+
+    from types import SimpleNamespace
+
+    user = SimpleNamespace(
+        steamid="1",
+        username="User",
+        avatar="",
+        playtime=0.0,
+        profile="#",
+        items=[{"image_url": ""}] if status == "parsed" else [],
+        status=status,
+    )
+
+    with app.app.app_context():
+        app.render_template("_user.html", user=user)


### PR DESCRIPTION
## Summary
- ensure `user.items` key always exists in `index()`
- display badges for incomplete and private inventories
- default item loop to `user.items | default([])` in `_user.html`
- test template rendering with parsed, incomplete and private cases

## Testing
- `pre-commit run --files app.py templates/_user.html tests/test_inventory_processor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ebac00ac483268b1a7698131178d7