### PR TITLE
Fix 500 error due to dict.items collision

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 import os
 import re
 from typing import List, Dict, Any, Tuple
+from types import SimpleNamespace
 
 from dotenv import load_dotenv
 
@@ -200,8 +201,17 @@ def build_user_data(steamid64: str) -> Dict[str, Any]:
     return summary
 
 
+def normalize_user_payload(user: Dict[str, Any]) -> SimpleNamespace:
+    """Return a namespace with ``items`` guaranteed to be a list."""
+
+    items = user.get("items", [])
+    user["items"] = items if isinstance(items, list) else []
+    return SimpleNamespace(**user)
+
+
 def fetch_and_process_single_user(steamid64: int) -> str:
     user = build_user_data(str(steamid64))
+    user = normalize_user_payload(user)
     return render_template("_user.html", user=user)
 
 
@@ -231,12 +241,11 @@ def index():
                 status = "incomplete"
             elif status != "parsed":
                 status = "private"
-            if not isinstance(items, list):
-                items = []
             if status != "parsed":
                 items = []
-            user["items"] = items
             user["status"] = status
+            user["items"] = items
+            user = normalize_user_payload(user)
             users.append(user)
     return render_template(
         "index.html",

--- a/templates/_user.html
+++ b/templates/_user.html
@@ -20,12 +20,12 @@
     {% elif user.status == 'private' %}
       <span class="badge bg-secondary">Private</span>
     {% endif %}
-    {% if user.items %}
     <div class="items">
-      {% for item in user.items | default([]) %}
+      {% for item in user.items %}
         <img src="{{ item.image_url }}" width="48" height="48">
+      {% else %}
+        <div class="empty">No items (inventory private or still parsing).</div>
       {% endfor %}
     </div>
-    {% endif %}
   </div>
 </div>

--- a/tests/test_user_template.py
+++ b/tests/test_user_template.py
@@ -1,0 +1,31 @@
+import importlib
+
+import pytest
+from flask import render_template_string
+
+HTML = '{% include "_user.html" %}'
+
+
+@pytest.fixture
+def app(monkeypatch):
+    monkeypatch.setenv("STEAM_API_KEY", "x")
+    monkeypatch.setenv("BACKPACK_API_KEY", "x")
+    monkeypatch.setattr("utils.schema_fetcher.ensure_schema_cached", lambda: {})
+    mod = importlib.import_module("app")
+    importlib.reload(mod)
+    return mod.app
+
+
+@pytest.mark.parametrize(
+    "context",
+    [
+        {"user": {"items": [{"name": "Foo", "image_url": ""}]}},
+        {"user": {"items": []}},
+        {"user": {}},
+    ],
+)
+def test_user_template_does_not_error(app, context):
+    with app.app_context():
+        app_module = importlib.import_module("app")
+        context["user"] = app_module.normalize_user_payload(context.get("user", {}))
+        render_template_string(HTML, **context)


### PR DESCRIPTION
## Summary
- normalize user payload so `items` is always a list and return a `SimpleNamespace`
- ensure reprocessing route and index use the normalized object
- update `_user.html` to show message when inventory is empty
- add regression test for template

## Testing
- `pre-commit run --files app.py templates/_user.html tests/test_user_template.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ec1e1a1d483269a21026525a86ea5