### PR TITLE
Switch to Steam API for inventory and schema

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,9 +57,9 @@ Use `ResolveVanityURL` or manual conversion logic as needed.
 - `IPlayerService/GetOwnedGames` – extract TF2 playtime (appid 440)
 
 ### 🎒 Steam Inventory:
-- `https://steamcommunity.com/inventory/{steamid}/440/2`
-  - No API key required
-  - Fails for private accounts or invalid SteamIDs
+- `https://api.steampowered.com/IEconItems_440/GetPlayerItems/v1/?key=<STEAM_API_KEY>&steamid={steamid}`
+  - Returns `status: 1` for public inventories
+  - Returns `status: 15` for private or empty inventories
 
 ### 💰 backpack.tf API (requires BACKPACK_API_KEY):
 - `https://backpack.tf/api/IGetPrices/v4?key=<BACKPACK_API_KEY>`

--- a/app.py
+++ b/app.py
@@ -167,7 +167,7 @@ def fetch_inventory(steamid64: str) -> Dict[str, Any]:
     if status == "parsed":
         items = enrich_inventory(data)
         for item in items:
-            price = BACKPACK_PRICES.get(item["name"])
+            price = BACKPACK_PRICES.get(item["item_name"])
             item["price"] = f"{price:.2f}" if price is not None else "?"
     return {"items": items, "status": status}
 

--- a/inventory_scanner.py
+++ b/inventory_scanner.py
@@ -1,21 +1,26 @@
+import os
 import requests
 import sys
 
 API_URL_TEMPLATE = (
-    "https://steamcommunity.com/inventory/{steamid}/440/2?l=english&count=5000"
+    "https://api.steampowered.com/IEconItems_440/GetPlayerItems/v1/"
+    "?key={key}&steamid={steamid}"
 )
 
 
 def fetch_inventory(steamid: str) -> dict:
-    """Fetch a user's TF2 inventory from the Steam Community API."""
-    url = API_URL_TEMPLATE.format(steamid=steamid)
+    """Fetch a user's TF2 inventory via the Steam Web API."""
+    api_key = os.getenv("STEAM_API_KEY")
+    if not api_key:
+        raise ValueError("STEAM_API_KEY is required")
+    url = API_URL_TEMPLATE.format(key=api_key, steamid=steamid)
     try:
         response = requests.get(url, timeout=10)
         response.raise_for_status()
     except requests.RequestException as exc:
         print(f"Failed to fetch inventory: {exc}")
         return {}
-    return response.json()
+    return response.json().get("result", {})
 
 
 def main(args: list[str]) -> None:

--- a/tests/test_utils_extras.py
+++ b/tests/test_utils_extras.py
@@ -22,4 +22,4 @@ def test_process_inventory_sorting():
     }
     sf.QUALITIES = {}
     items = ip.process_inventory(data)
-    assert [item["name"] for item in items] == ["A", "B"]
+    assert [item["item_name"] for item in items] == ["A", "B"]

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -48,7 +48,7 @@ def enrich_inventory(data: Dict[str, Any]) -> List[Dict[str, Any]]:
         items.append(
             {
                 "defindex": defindex,
-                "name": name,
+                "item_name": name,
                 "quality": quality,
                 "image_url": image_url,
             }
@@ -59,4 +59,4 @@ def enrich_inventory(data: Dict[str, Any]) -> List[Dict[str, Any]]:
 def process_inventory(data: Dict[str, Any]) -> List[Dict[str, Any]]:
     """Public wrapper that sorts items by name."""
     items = enrich_inventory(data)
-    return sorted(items, key=lambda i: i["name"])
+    return sorted(items, key=lambda i: i["item_name"])

--- a/utils/schema_fetcher.py
+++ b/utils/schema_fetcher.py
@@ -1,10 +1,13 @@
 import json
+import logging
 import os
 import time
 from pathlib import Path
 from typing import Any, Dict
 
 import requests
+
+logger = logging.getLogger(__name__)
 
 CACHE_FILE = Path("data/item_schema.json")
 TTL = 48 * 60 * 60  # 48 hours
@@ -67,7 +70,7 @@ def ensure_schema_cached(api_key: str | None = None) -> Dict[str, Any]:
                 cached = json.load(f)
             SCHEMA = cached.get("items", {})
             QUALITIES = cached.get("qualities", {})
-            print(f"CACHE HIT ({len(SCHEMA)} items)")
+            logger.info("Schema cache HIT: %s items", len(SCHEMA))
             return SCHEMA
 
     fetched = _fetch_schema(api_key)
@@ -76,5 +79,5 @@ def ensure_schema_cached(api_key: str | None = None) -> Dict[str, Any]:
         json.dump(fetched, f)
     SCHEMA = fetched["items"]
     QUALITIES = fetched["qualities"]
-    print(f"CACHE MISS ({len(SCHEMA)} items)")
+    logger.info("Schema cache MISS, fetched %s items", len(SCHEMA))
     return SCHEMA


### PR DESCRIPTION
## Summary
- fetch inventories exclusively via `IEconItems_440/GetPlayerItems`
- enrich items with `item_name` field and update price lookup
- cache the item schema with logging on hit/miss
- update command line scanner and documentation
- adjust tests for new endpoints and fields

## Testing
- `pre-commit run --files utils/steam_api_client.py utils/schema_fetcher.py utils/inventory_processor.py inventory_scanner.py app.py AGENTS.md tests/test_inventory_processor.py tests/test_utils_extras.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ed8d7bc5c8326a5cc192425c9a3aa