### PR TITLE
Switch inventory fetching to Steam API

### DIFF
--- a/app.py
+++ b/app.py
@@ -239,7 +239,7 @@ def index():
             status = user.get("status")
             if status == "failed":
                 status = "incomplete"
-            elif status != "parsed":
+            elif status not in ("parsed", "incomplete"):
                 status = "private"
             if status != "parsed":
                 items = []

--- a/inventory_scanner.py
+++ b/inventory_scanner.py
@@ -30,16 +30,13 @@ def main(args: list[str]) -> None:
 
     steamid = args[0]
     data = fetch_inventory(steamid)
-    items = data.get("assets", [])
+    items = data.get("items", [])
     print(f"Found {len(items)} items in inventory for {steamid}")
 
-    # Optionally, print item names if available
-    descriptions = {d["classid"]: d for d in data.get("descriptions", [])}
     for item in items:
-        classid = item.get("classid")
-        desc = descriptions.get(classid)
-        name = desc.get("market_hash_name") if desc else "Unknown Item"
-        print(f"- {name}")
+        defindex = item.get("defindex")
+        quality = item.get("quality")
+        print(f"- defindex={defindex} quality={quality}")
 
 
 if __name__ == "__main__":

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -7,18 +7,9 @@ import pytest
 
 
 def test_enrich_inventory():
-    data = {
-        "assets": [{"classid": "1"}],
-        "descriptions": [
-            {
-                "classid": "1",
-                "icon_url": "icon.png",
-                "app_data": {"def_index": "111"},
-            }
-        ],
-    }
+    data = {"items": [{"defindex": 111, "quality": 0}]}
     sf.SCHEMA = {"111": {"defindex": 111, "name": "Test Item", "image_url": "img"}}
-    sf.QUALITIES = {}
+    sf.QUALITIES = {"0": "Normal"}
     items = ip.enrich_inventory(data)
     assert items[0]["item_name"] == "Test Item"
     assert items[0]["image_url"].startswith(
@@ -27,13 +18,7 @@ def test_enrich_inventory():
 
 
 def test_process_inventory_handles_missing_icon():
-    data = {
-        "assets": [{"classid": "1"}, {"classid": "2"}],
-        "descriptions": [
-            {"classid": "1", "icon_url": "icon.png", "app_data": {"def_index": "1"}},
-            {"classid": "2", "app_data": {"def_index": "2"}},
-        ],
-    }
+    data = {"items": [{"defindex": 1}, {"defindex": 2}]}
     sf.SCHEMA = {
         "1": {"defindex": 1, "name": "One", "image_url": "a"},
         "2": {"defindex": 2, "name": "Two", "image_url": ""},
@@ -79,7 +64,7 @@ def test_fetch_inventory_handles_http_error(monkeypatch):
 
     monkeypatch.setattr(sac, "fetch_inventory", fake_fetch)
     data, status = ip.fetch_inventory("1")
-    assert data == {"assets": [], "descriptions": []}
+    assert data == {"items": []}
     assert status == "failed"
 
 
@@ -90,7 +75,7 @@ def test_fetch_inventory_handles_http_error(monkeypatch):
             {"status": 200, "json": {"result": {"status": 1, "items": [{"id": 1}]}}},
             "parsed",
         ),
-        ({"status": 200, "json": {"result": {"status": 1, "items": []}}}, "private"),
+        ({"status": 200, "json": {"result": {"status": 1, "items": []}}}, "incomplete"),
         ({"status": 200, "json": {"result": {"status": 15}}}, "private"),
         ({"body": requests.ConnectionError()}, "failed"),
     ],

--- a/tests/test_utils_extras.py
+++ b/tests/test_utils_extras.py
@@ -9,16 +9,10 @@ def test_convert_to_steam64():
 
 
 def test_process_inventory_sorting():
-    data = {
-        "assets": [{"classid": "1"}, {"classid": "2"}],
-        "descriptions": [
-            {"classid": "1", "icon_url": "a", "app_data": {"def_index": "2"}},
-            {"classid": "2", "icon_url": "b", "app_data": {"def_index": "1"}},
-        ],
-    }
+    data = {"items": [{"defindex": 2}, {"defindex": 1}]}
     sf.SCHEMA = {
-        "1": {"defindex": 1, "name": "B", "image_url": "a"},
-        "2": {"defindex": 2, "name": "A", "image_url": "b"},
+        "1": {"defindex": 1, "name": "A", "image_url": "b"},
+        "2": {"defindex": 2, "name": "B", "image_url": "a"},
     }
     sf.QUALITIES = {}
     items = ip.process_inventory(data)

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -11,39 +11,36 @@ def fetch_inventory(steamid: str) -> Tuple[Dict[str, Any], str]:
     """Return inventory data and status using the Steam API helper."""
 
     status, data = steam_api_client.fetch_inventory(steamid)
-    if status != "parsed":
-        data = data or {"assets": [], "descriptions": []}
+    if status not in ("parsed", "incomplete"):
+        data = {"items": []}
+    else:
+        data = data or {"items": []}
     return data, status
 
 
 def enrich_inventory(data: Dict[str, Any]) -> List[Dict[str, Any]]:
     """Return a list of inventory items enriched with schema info."""
-    if "descriptions" not in data:
+    items_raw = data.get("items")
+    if not isinstance(items_raw, list):
         return []
 
-    desc_map = {d.get("classid"): d for d in data.get("descriptions", [])}
     items: List[Dict[str, Any]] = []
     schema_items = schema_fetcher.SCHEMA or {}
     qualities = schema_fetcher.QUALITIES or {}
 
-    for asset in data.get("assets", []):
-        desc = desc_map.get(asset.get("classid"))
-        if not desc:
-            continue
-        defindex = str(
-            desc.get("app_data", {}).get("def_index") or desc.get("defindex")
-        )
+    for entry in items_raw:
+        defindex = str(entry.get("defindex"))
         schema_item = schema_items.get(defindex)
         if not schema_item:
             continue
         name = schema_item.get("name")
-        icon_url = desc.get("icon_url") or schema_item.get("image_url")
+        icon_url = schema_item.get("image_url")
         image_url = (
             f"https://community.cloudflare.steamstatic.com/economy/image/{quote(icon_url, safe='')}"
             if icon_url
             else ""
         )
-        quality_val = asset.get("quality")
+        quality_val = entry.get("quality")
         quality = qualities.get(str(quality_val), qualities.get(quality_val))
         items.append(
             {
@@ -51,6 +48,7 @@ def enrich_inventory(data: Dict[str, Any]) -> List[Dict[str, Any]]:
                 "item_name": name,
                 "quality": quality,
                 "image_url": image_url,
+                "attributes": entry.get("attributes", []),
             }
         )
     return items

--- a/utils/steam_api_client.py
+++ b/utils/steam_api_client.py
@@ -79,22 +79,19 @@ def fetch_inventory(steamid: str) -> Tuple[str, Dict[str, Any]]:
 
     result = data.get("result", data)
     status_code = result.get("status")
-    items = result.get("items") or data.get("items")
-    items_len = len(items) if items else 0
+    items = result.get("items") or []
 
     if status_code == 1:
-        if items_len:
-            logger.debug("Inventory %s: public & parsed (%s items)", steamid, items_len)
+        if items:
+            logger.debug(
+                "Inventory %s: public & parsed (%s items)", steamid, len(items)
+            )
             return "parsed", result
         logger.debug("Inventory %s: public but empty", steamid)
-        return "private", result
+        return "incomplete", result
 
-    if status_code == 15 or not items_len:
-        logger.debug("Inventory %s: private", steamid)
-        return "private", result
-
-    logger.debug("Inventory %s: failed", steamid)
-    return "failed", result
+    logger.debug("Inventory %s: private", steamid)
+    return "private", result
 
 
 def convert_to_steam64(id_str: str) -> str:


### PR DESCRIPTION
## Summary
- rely exclusively on the Steam Web API for item data
- parse `result.items` and classify inventory visibility
- update inventory processing helpers
- adjust CLI example script
- refresh tests for new structure

## Testing
- `pre-commit run --files utils/steam_api_client.py utils/inventory_processor.py inventory_scanner.py tests/test_inventory_processor.py tests/test_utils_extras.py app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685edea746a4832691cac5e560c636bc