### PR TITLE
Fix item card images and quality colors

### DIFF
--- a/app.py
+++ b/app.py
@@ -167,7 +167,7 @@ def fetch_inventory(steamid64: str) -> Dict[str, Any]:
     if status == "parsed":
         items = enrich_inventory(data)
         for item in items:
-            price = BACKPACK_PRICES.get(item["item_name"])
+            price = BACKPACK_PRICES.get(item["name"])
             item["price"] = f"{price:.2f}" if price is not None else "?"
     return {"items": items, "status": status}
 

--- a/static/style.css
+++ b/static/style.css
@@ -3,3 +3,22 @@
     overflow-x: auto;
     gap: 4px;
 }
+
+.item-card {
+  width: 36px;
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  margin: 2px;
+}
+.item-card img {
+  display: block;
+}
+.missing-icon {
+  width: 24px;
+  height: 24px;
+  background: #eee;
+}

--- a/templates/_user.html
+++ b/templates/_user.html
@@ -22,9 +22,13 @@
     {% endif %}
     <div class="items">
       {% for item in user.items %}
-        <img src="{{ item.image_url }}" width="48" height="48">
-      {% else %}
-        <div class="empty">No items (inventory private or still parsing).</div>
+        <div class="item-card" style="background-color: {{ item.quality_color }}20;">
+          {% if item.image_url %}
+            <img src="{{ item.image_url }}" alt="{{ item.name }}" width="32" height="32">
+          {% else %}
+            <div class="missing-icon"></div>
+          {% endif %}
+        </div>
       {% endfor %}
     </div>
   </div>

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -8,10 +8,12 @@ import pytest
 
 def test_enrich_inventory():
     data = {"items": [{"defindex": 111, "quality": 0}]}
-    sf.SCHEMA = {"111": {"defindex": 111, "name": "Test Item", "image_url": "img"}}
+    sf.SCHEMA = {"111": {"defindex": 111, "item_name": "Test Item", "image_url": "img"}}
     sf.QUALITIES = {"0": "Normal"}
     items = ip.enrich_inventory(data)
-    assert items[0]["item_name"] == "Test Item"
+    assert items[0]["name"] == "Test Item"
+    assert items[0]["quality"] == "Normal"
+    assert items[0]["quality_color"] == "#B2B2B2"
     assert items[0]["image_url"].startswith(
         "https://community.cloudflare.steamstatic.com/economy/image/"
     )
@@ -20,14 +22,14 @@ def test_enrich_inventory():
 def test_process_inventory_handles_missing_icon():
     data = {"items": [{"defindex": 1}, {"defindex": 2}]}
     sf.SCHEMA = {
-        "1": {"defindex": 1, "name": "One", "image_url": "a"},
-        "2": {"defindex": 2, "name": "Two", "image_url": ""},
+        "1": {"defindex": 1, "item_name": "One", "image_url": "a"},
+        "2": {"defindex": 2, "item_name": "Two", "image_url": ""},
     }
     sf.QUALITIES = {}
     items = ip.process_inventory(data)
-    assert {i["item_name"] for i in items} == {"One", "Two"}
+    assert {i["name"] for i in items} == {"One", "Two"}
     for item in items:
-        if item["item_name"] == "One":
+        if item["name"] == "One":
             assert item["image_url"].startswith(
                 "https://community.cloudflare.steamstatic.com/economy/image/"
             )

--- a/tests/test_utils_extras.py
+++ b/tests/test_utils_extras.py
@@ -11,9 +11,9 @@ def test_convert_to_steam64():
 def test_process_inventory_sorting():
     data = {"items": [{"defindex": 2}, {"defindex": 1}]}
     sf.SCHEMA = {
-        "1": {"defindex": 1, "name": "A", "image_url": "b"},
-        "2": {"defindex": 2, "name": "B", "image_url": "a"},
+        "1": {"defindex": 1, "item_name": "A", "image_url": "b"},
+        "2": {"defindex": 2, "item_name": "B", "image_url": "a"},
     }
     sf.QUALITIES = {}
     items = ip.process_inventory(data)
-    assert [item["item_name"] for item in items] == ["A", "B"]
+    assert [item["name"] for item in items] == ["A", "B"]


### PR DESCRIPTION
## Summary
- add quality map and image base URL for item processing
- update enrichment to include item image URL and quality color
- render item cards with quality-tinted backgrounds
- style item cards and placeholders
- update tests for new item fields

## Testing
- `pre-commit run --files utils/inventory_processor.py templates/_user.html static/style.css app.py tests/test_inventory_processor.py tests/test_utils_extras.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ee244bf648326a0cbcf6566ee906b