### PR TITLE
Fix item names and images

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -22,3 +22,13 @@
   height: 24px;
   background: #eee;
 }
+
+.item-name {
+  font-size: 10px;
+  color: #fff;
+  text-align: center;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  max-width: 36px;
+}

--- a/templates/_user.html
+++ b/templates/_user.html
@@ -28,6 +28,7 @@
           {% else %}
             <div class="missing-icon"></div>
           {% endif %}
+          <div class="item-name">{{ item.name }}</div>
         </div>
       {% endfor %}
     </div>

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -41,12 +41,18 @@ def enrich_inventory(data: Dict[str, Any]) -> List[Dict[str, Any]]:
     schema_map = schema_fetcher.SCHEMA or {}
 
     for asset in items_raw:
-        defindex = asset.get("defindex")
-        if defindex is None:
-            continue
-        entry = schema_map.get(str(defindex), {})
-        icon = entry.get("icon_url") or entry.get("image_url") or ""
+        defindex = str(asset.get("defindex", "0"))
+        entry = schema_map.get(defindex, {})
+
+        icon = (
+            entry.get("icon_url")
+            or entry.get("image_url_large")
+            or entry.get("image_url")
+            or ""
+        )
         img_url = f"{CLOUD}{icon}" if icon else ""
+
+        name = entry.get("item_name") or entry.get("name") or f"Item #{defindex}"
 
         quality_id = asset.get("quality", 0)
         q_name, q_col = QUALITY_MAP.get(quality_id, ("Unknown", "#B2B2B2"))
@@ -54,7 +60,7 @@ def enrich_inventory(data: Dict[str, Any]) -> List[Dict[str, Any]]:
         items.append(
             {
                 "defindex": defindex,
-                "name": entry.get("item_name", f"#{defindex}"),
+                "name": name,
                 "quality": q_name,
                 "quality_color": q_col,
                 "image_url": img_url,


### PR DESCRIPTION
## Summary
- update `enrich_inventory` so schema names and icons are found
- display item names in the user card
- style item name text under item cards

## Testing
- `pre-commit run --files utils/inventory_processor.py templates/_user.html static/style.css`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ee87d22f48326ab061a4932ee2c26