### PR TITLE
Update inventory endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ Use `ResolveVanityURL` or manual conversion logic as needed.
 - `IPlayerService/GetOwnedGames` – extract TF2 playtime (appid 440)
 
 ### 🎒 Steam Inventory:
-- `https://api.steampowered.com/IEconItems_440/GetPlayerItems/v1/?key=<STEAM_API_KEY>&steamid={steamid}`
+ - `https://api.steampowered.com/IEconItems_440/GetPlayerItems/v0001/?key=<STEAM_API_KEY>&steamid={steamid}`
   - Returns `status: 1` for public inventories
   - Returns `status: 15` for private or empty inventories
 

--- a/inventory_scanner.py
+++ b/inventory_scanner.py
@@ -3,7 +3,7 @@ import requests
 import sys
 
 API_URL_TEMPLATE = (
-    "https://api.steampowered.com/IEconItems_440/GetPlayerItems/v1/"
+    "https://api.steampowered.com/IEconItems_440/GetPlayerItems/v0001/"
     "?key={key}&steamid={steamid}"
 )
 

--- a/static/style.css
+++ b/static/style.css
@@ -10,7 +10,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border: 1px solid #ccc;
+  border: 2px solid #ccc;
   border-radius: 3px;
   margin: 2px;
 }

--- a/templates/_user.html
+++ b/templates/_user.html
@@ -22,7 +22,7 @@
     {% endif %}
     <div class="items">
       {% for item in user.items %}
-        <div class="item-card" style="background-color: {{ item.quality_color }}20;">
+        <div class="item-card" style="background-color: {{ item.quality_color }}20; border-color: {{ item.quality_color }};">
           {% if item.image_url %}
             <img src="{{ item.image_url }}" alt="{{ item.name }}" width="32" height="32">
           {% else %}

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -85,7 +85,7 @@ def test_fetch_inventory_handles_http_error(monkeypatch):
 def test_fetch_inventory_statuses(monkeypatch, payload, expected):
     monkeypatch.setattr(sac, "STEAM_API_KEY", "x")
     url = (
-        "https://api.steampowered.com/IEconItems_440/GetPlayerItems/v1/"
+        "https://api.steampowered.com/IEconItems_440/GetPlayerItems/v0001/"
         "?key=x&steamid=1"
     )
     with responses.RequestsMock() as rsps:

--- a/tests/test_schema_fetcher.py
+++ b/tests/test_schema_fetcher.py
@@ -34,7 +34,18 @@ def test_schema_cache_miss(tmp_path, monkeypatch):
 
     responses = [
         {"result": {"qualities": {"Normal": 0}}},
-        {"result": {"items": [{"defindex": 2, "name": "Other", "image_url": "u"}]}},
+        {
+            "result": {
+                "items": [
+                    {
+                        "defindex": 2,
+                        "name": "Other",
+                        "image_url": "u",
+                        "image_url_large": None,
+                    }
+                ]
+            }
+        },
     ]
     captured = []
 
@@ -44,7 +55,14 @@ def test_schema_cache_miss(tmp_path, monkeypatch):
 
     monkeypatch.setattr(sf.requests, "get", fake_get)
     schema = sf.ensure_schema_cached(api_key="k")
-    assert schema == {"2": {"defindex": 2, "name": "Other", "image_url": "u"}}
+    assert schema == {
+        "2": {
+            "defindex": 2,
+            "name": "Other",
+            "image_url": "u",
+            "image_url_large": None,
+        }
+    }
     assert cache.exists()
     assert any("GetSchemaOverview" in u for u in captured)
     assert any("GetSchemaItems" in u for u in captured)

--- a/utils/schema_fetcher.py
+++ b/utils/schema_fetcher.py
@@ -47,6 +47,7 @@ def _fetch_schema(api_key: str) -> Dict[str, Any]:
                 "defindex": item.get("defindex"),
                 "name": item.get("name"),
                 "image_url": item.get("image_url"),
+                "image_url_large": item.get("image_url_large"),
             }
         if not data.get("next"):
             break


### PR DESCRIPTION
## Summary
- switch Steam API calls to `GetPlayerItems` v0001
- include large image URLs when caching schema data
- show item border based on item quality
- update docs and tests for new endpoint

## Testing
- `pre-commit run --files utils/steam_api_client.py inventory_scanner.py tests/test_inventory_processor.py templates/_user.html static/style.css utils/schema_fetcher.py AGENTS.md tests/test_schema_fetcher.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ef197536c832687b57755343ce6a6