### PR TITLE
feat: robust Steam-ID parser to ignore names/pings

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -24,6 +24,13 @@
 </head>
 <body>
     <h1>TF2 Inventory Checker</h1>
+    {% with msgs = get_flashed_messages() %}
+        {% if msgs %}
+            <ul class="flash">
+            {% for m in msgs %}<li>{{ m }}</li>{% endfor %}
+            </ul>
+        {% endif %}
+    {% endwith %}
     <form method="post">
         <label for="steamids">Enter SteamIDs (separated by space, comma or newline):</label><br>
         <textarea id="steamids" name="steamids">{{ steamids|default('') }}</textarea><br>

--- a/tests/test_id_parser.py
+++ b/tests/test_id_parser.py
@@ -1,0 +1,22 @@
+import utils.steam_api_client as sac
+from utils.id_parser import extract_steam_ids
+
+
+def test_extract_ids_from_status_block():
+    text = """
+    hostname: my tf2 server
+    version : 123
+    # userid name uniqueid connected ping loss state
+    #   314 "Xanmangamer" [U:1:876151635] 00:26 94 74 spawning
+    #   315 "Tester" [U:1:1137042230] 01:11 88 0 active
+    #   316 "Short" [U:1:2] 00:01 50 0 active
+    """
+    ids = extract_steam_ids(text)
+    steam64 = [sac.convert_to_steam64(i) for i in ids]
+    assert steam64 == [
+        sac.convert_to_steam64("[U:1:876151635]"),
+        sac.convert_to_steam64("[U:1:1137042230]"),
+        sac.convert_to_steam64("[U:1:2]"),
+    ]
+    assert "Xanmangamer" not in ids
+    assert "active" not in ids

--- a/utils/id_parser.py
+++ b/utils/id_parser.py
@@ -1,0 +1,32 @@
+import re
+from typing import List
+
+STEAMID2_RE = re.compile(r"STEAM_0:[01]:\d+")
+STEAMID3_RE = re.compile(r"\[U:1:\d+\]")
+STEAMID64_RE = re.compile(r"\b\d{17}\b")
+
+
+def extract_steam_ids(raw_text: str) -> List[str]:
+    """Extract valid SteamID tokens from free-form text.
+
+    The function splits the input on whitespace and returns unique IDs in
+    the order encountered. Only strings matching SteamID2, SteamID3 or
+    SteamID64 formats are kept.
+    """
+
+    tokens = re.split(r"\s+", raw_text.strip())
+    ids: List[str] = []
+    seen: set[str] = set()
+
+    for token in tokens:
+        if not token:
+            continue
+        if (
+            STEAMID2_RE.fullmatch(token)
+            or STEAMID3_RE.fullmatch(token)
+            or STEAMID64_RE.fullmatch(token)
+        ):
+            if token not in seen:
+                seen.add(token)
+                ids.append(token)
+    return ids


### PR DESCRIPTION
## Summary
- add `utils/id_parser.py` for parsing raw text for Steam IDs
- use parser in `index` route with early error flash
- show flash messages in the template
- add unit test for extracting IDs from TF2 status lines

## Testing
- `black .`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ef6274c7c832698334c75c1be6327