### PR TITLE
Refactor inventory rendering to use schema

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -15,7 +15,7 @@ def test_enrich_inventory():
     assert items[0]["quality"] == "Normal"
     assert items[0]["quality_color"] == "#B2B2B2"
     assert items[0]["image_url"].startswith(
-        "https://steamcommunity.cloudflare.steamstatic.com/economy/image/"
+        "https://steamcommunity-a.akamaihd.net/economy/image/"
     )
 
 
@@ -31,7 +31,7 @@ def test_process_inventory_handles_missing_icon():
     for item in items:
         if item["name"] == "One":
             assert item["image_url"].startswith(
-                "https://steamcommunity.cloudflare.steamstatic.com/economy/image/"
+                "https://steamcommunity-a.akamaihd.net/economy/image/"
             )
         else:
             assert item["image_url"] == ""

--- a/tests/test_schema_fetcher.py
+++ b/tests/test_schema_fetcher.py
@@ -33,19 +33,20 @@ def test_schema_cache_miss(tmp_path, monkeypatch):
             return self.payload
 
     responses = [
-        {"result": {"qualities": {"Normal": 0}}},
         {
             "result": {
+                "qualities": {"Normal": 0},
                 "items": [
                     {
                         "defindex": 2,
                         "name": "Other",
+                        "item_name": "Other",
                         "image_url": "u",
                         "image_url_large": None,
                     }
-                ]
+                ],
             }
-        },
+        }
     ]
     captured = []
 
@@ -59,10 +60,10 @@ def test_schema_cache_miss(tmp_path, monkeypatch):
         "2": {
             "defindex": 2,
             "name": "Other",
+            "item_name": "Other",
             "image_url": "u",
             "image_url_large": None,
         }
     }
     assert cache.exists()
-    assert any("GetSchemaOverview" in u for u in captured)
-    assert any("GetSchemaItems" in u for u in captured)
+    assert any("GetSchema" in u for u in captured)

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -6,7 +6,7 @@ from . import steam_api_client, schema_fetcher
 logger = logging.getLogger(__name__)
 
 # Base URL for item images
-CLOUD = "https://steamcommunity.cloudflare.steamstatic.com/economy/image/"
+CLOUD = "https://steamcommunity-a.akamaihd.net/economy/image/"
 
 # Map of quality ID to (name, background color)
 QUALITY_MAP = {
@@ -46,10 +46,12 @@ def enrich_inventory(data: Dict[str, Any]) -> List[Dict[str, Any]]:
         if not entry:
             continue
 
-        image_path = entry.get("image_url")
+        image_path = entry.get("image_url") or entry.get("image_url_large")
         img_url = f"{CLOUD}{image_path}" if image_path else ""
 
-        name = entry.get("item_name") or entry.get("name") or f"Item #{defindex}"
+        name = entry.get("item_name") or entry.get("name")
+        if not name or str(name).startswith("#"):
+            name = "Unknown Item"
 
         quality_id = asset.get("quality", 0)
         q_name, q_col = QUALITY_MAP.get(quality_id, ("Unknown", "#B2B2B2"))

--- a/utils/schema_fetcher.py
+++ b/utils/schema_fetcher.py
@@ -18,40 +18,30 @@ QUALITIES: Dict[str | int, str] = {}
 
 
 def _fetch_schema(api_key: str) -> Dict[str, Any]:
-    """Fetch schema overview and all items from Steam."""
+    """Fetch the full TF2 item schema in one request."""
 
-    overview_url = (
-        "https://api.steampowered.com/IEconItems_440/GetSchemaOverview/v1/"
-        f"?key={api_key}"
+    url = (
+        "https://api.steampowered.com/IEconItems_440/GetSchema/v0001/" f"?key={api_key}"
     )
-    r = requests.get(overview_url, timeout=20)
+    r = requests.get(url, timeout=30)
     r.raise_for_status()
-    overview = r.json()["result"]
-    qualities = {str(v): k for k, v in overview.get("qualities", {}).items()}
+    data = r.json()["result"]
+    qualities = {str(v): k for k, v in data.get("qualities", {}).items()}
 
     items: Dict[str, Any] = {}
-    start = 0
-    while True:
-        items_url = (
-            "https://api.steampowered.com/IEconItems_440/GetSchemaItems/v1/"
-            f"?key={api_key}&start={start}"
-        )
-        r = requests.get(items_url, timeout=20)
-        r.raise_for_status()
-        data = r.json()["result"]
-        for item in data.get("items", []):
-            defindex = str(item.get("defindex"))
-            if not defindex or "name" not in item:
-                continue
-            items[defindex] = {
-                "defindex": item.get("defindex"),
-                "name": item.get("name"),
-                "image_url": item.get("image_url"),
-                "image_url_large": item.get("image_url_large"),
-            }
-        if not data.get("next"):
-            break
-        start = data["next"]
+    for item in data.get("items", []):
+        defindex = str(item.get("defindex"))
+        if not defindex:
+            continue
+        if "name" not in item and "item_name" not in item:
+            continue
+        items[defindex] = {
+            "defindex": item.get("defindex"),
+            "name": item.get("name"),
+            "item_name": item.get("item_name"),
+            "image_url": item.get("image_url"),
+            "image_url_large": item.get("image_url_large"),
+        }
 
     return {"items": items, "qualities": qualities}
 


### PR DESCRIPTION
## Summary
- load item schema with GetSchema endpoint and cache globally
- use new image base URL and sanitize item names
- adjust schema tests for new API

## Testing
- `pre-commit run --files utils/schema_fetcher.py utils/inventory_processor.py tests/test_inventory_processor.py tests/test_schema_fetcher.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f126264a88326afb79be917e6e52c