### PR TITLE
Revert schema refactor

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -15,7 +15,7 @@ def test_enrich_inventory():
     assert items[0]["quality"] == "Normal"
     assert items[0]["quality_color"] == "#B2B2B2"
     assert items[0]["image_url"].startswith(
-        "https://steamcommunity.cloudflare.steamstatic.com/economy/image/"
+        "https://community.cloudflare.steamstatic.com/economy/image/"
     )
 
 
@@ -31,19 +31,10 @@ def test_process_inventory_handles_missing_icon():
     for item in items:
         if item["name"] == "One":
             assert item["image_url"].startswith(
-                "https://steamcommunity.cloudflare.steamstatic.com/economy/image/"
+                "https://community.cloudflare.steamstatic.com/economy/image/"
             )
         else:
             assert item["image_url"] == ""
-
-
-def test_enrich_inventory_skips_unknown_defindex():
-    data = {"items": [{"defindex": 1}, {"defindex": 2}]}
-    sf.SCHEMA = {"1": {"defindex": 1, "item_name": "One", "image_url": "a"}}
-    sf.QUALITIES = {}
-    items = ip.enrich_inventory(data)
-    assert len(items) == 1
-    assert items[0]["name"] == "One"
 
 
 def test_get_inventories_adds_user_agent(monkeypatch):

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -6,7 +6,7 @@ from . import steam_api_client, schema_fetcher
 logger = logging.getLogger(__name__)
 
 # Base URL for item images
-CLOUD = "https://steamcommunity.cloudflare.steamstatic.com/economy/image/"
+CLOUD = "https://community.cloudflare.steamstatic.com/economy/image/"
 
 # Map of quality ID to (name, background color)
 QUALITY_MAP = {
@@ -42,12 +42,15 @@ def enrich_inventory(data: Dict[str, Any]) -> List[Dict[str, Any]]:
 
     for asset in items_raw:
         defindex = str(asset.get("defindex", "0"))
-        entry = schema_map.get(defindex)
-        if not entry:
-            continue
+        entry = schema_map.get(defindex, {})
 
-        image_path = entry.get("image_url")
-        img_url = f"{CLOUD}{image_path}" if image_path else ""
+        icon = (
+            entry.get("icon_url")
+            or entry.get("image_url_large")
+            or entry.get("image_url")
+            or ""
+        )
+        img_url = f"{CLOUD}{icon}" if icon else ""
 
         name = entry.get("item_name") or entry.get("name") or f"Item #{defindex}"
 


### PR DESCRIPTION
## Summary
- revert inventory schema changes that broke the app
- restore previous image URL logic and tests

## Testing
- `pre-commit run --files tests/test_inventory_processor.py tests/test_schema_fetcher.py utils/inventory_processor.py utils/schema_fetcher.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f126264a88326afb79be917e6e52c