### PR TITLE
Fix schema image URLs

### DIFF
--- a/templates/_user.html
+++ b/templates/_user.html
@@ -23,8 +23,8 @@
     <div class="items">
       {% for item in user.items %}
         <div class="item-card" style="background-color: {{ item.quality_color }}20; border-color: {{ item.quality_color }};">
-          {% if item.image_url %}
-            <img src="{{ item.image_url }}" alt="{{ item.name }}" width="32" height="32">
+          {% if item.final_url %}
+            <img src="{{ item.final_url }}" alt="{{ item.name }}" width="32" height="32">
           {% else %}
             <div class="missing-icon"></div>
           {% endif %}

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -14,7 +14,7 @@ def test_enrich_inventory():
     assert items[0]["name"] == "Test Item"
     assert items[0]["quality"] == "Normal"
     assert items[0]["quality_color"] == "#B2B2B2"
-    assert items[0]["image_url"].startswith(
+    assert items[0]["final_url"].startswith(
         "https://steamcommunity.cloudflare.steamstatic.com/economy/image/"
     )
 
@@ -30,11 +30,20 @@ def test_process_inventory_handles_missing_icon():
     assert {i["name"] for i in items} == {"One", "Two"}
     for item in items:
         if item["name"] == "One":
-            assert item["image_url"].startswith(
+            assert item["final_url"].startswith(
                 "https://steamcommunity.cloudflare.steamstatic.com/economy/image/"
             )
         else:
-            assert item["image_url"] == ""
+            assert item["final_url"] == ""
+
+
+def test_enrich_inventory_preserves_absolute_url():
+    data = {"items": [{"defindex": 5, "quality": 0}]}
+    url = "http://example.com/icon.png"
+    sf.SCHEMA = {"5": {"defindex": 5, "item_name": "Abs", "image_url": url}}
+    sf.QUALITIES = {"0": "Normal"}
+    items = ip.enrich_inventory(data)
+    assert items[0]["final_url"] == url
 
 
 def test_enrich_inventory_skips_unknown_defindex():
@@ -121,7 +130,7 @@ def test_user_template_safe(monkeypatch, status):
         avatar="",
         playtime=0.0,
         profile="#",
-        items=[{"image_url": ""}] if status == "parsed" else [],
+        items=[{"final_url": ""}] if status == "parsed" else [],
         status=status,
     )
 

--- a/tests/test_user_template.py
+++ b/tests/test_user_template.py
@@ -19,7 +19,7 @@ def app(monkeypatch):
 @pytest.mark.parametrize(
     "context",
     [
-        {"user": {"items": [{"name": "Foo", "image_url": ""}]}},
+        {"user": {"items": [{"name": "Foo", "final_url": ""}]}},
         {"user": {"items": []}},
         {"user": {}},
     ],

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -46,8 +46,11 @@ def enrich_inventory(data: Dict[str, Any]) -> List[Dict[str, Any]]:
         if not entry:
             continue
 
-        image_path = entry.get("image_url")
-        img_url = f"{CLOUD}{image_path}" if image_path else ""
+        image_path = entry.get("image_url") or ""
+        if image_path.startswith("http"):
+            final_url = image_path
+        else:
+            final_url = f"{CLOUD}{image_path}" if image_path else ""
 
         name = entry.get("item_name") or entry.get("name") or f"Item #{defindex}"
 
@@ -60,7 +63,8 @@ def enrich_inventory(data: Dict[str, Any]) -> List[Dict[str, Any]]:
                 "name": name,
                 "quality": q_name,
                 "quality_color": q_col,
-                "image_url": img_url,
+                "image_url": image_path,
+                "final_url": final_url,
             }
         )
     return items


### PR DESCRIPTION
## Summary
- handle image URLs that already contain an http/https prefix
- display the corrected `final_url` in the user card
- adjust tests for the new field

## Testing
- `pre-commit run --files utils/inventory_processor.py templates/_user.html tests/test_inventory_processor.py tests/test_user_template.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f1fe79d788326b3bbe2d48578be23