### PR TITLE
Fix TF2 playtime retrieval and improve item cards

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -5,11 +5,12 @@
 }
 
 .item-card {
-  width: 36px;
-  height: 36px;
-  display: inline-flex;
+  display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
+  min-width: 120px;
+  padding: 4px;
   border: 2px solid #ccc;
   border-radius: 3px;
   margin: 2px;
@@ -18,17 +19,18 @@
   display: block;
 }
 .missing-icon {
-  width: 24px;
-  height: 24px;
+  width: 32px;
+  height: 32px;
   background: #eee;
 }
 
 .item-name {
-  font-size: 10px;
+  font-size: 12px;
   color: #fff;
   text-align: center;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  max-width: 36px;
+  margin-top: 4px;
+  width: 100%;
+  word-break: break-word;
 }
+
+.tf2-hours { margin-left: 6px; font-size: 0.9em; }

--- a/templates/_user.html
+++ b/templates/_user.html
@@ -3,7 +3,8 @@
     <a href="{{ user.profile }}" target="_blank">
       <img src="{{ user.avatar }}" width="64" style="vertical-align: middle; border-radius: 8px;">
     </a>
-    {{ user.username }} ({{ user.playtime }} hrs)
+    {{ user.username }}
+    <span class="tf2-hours">TF2 Playtime: {{ user.playtime }} hrs</span>
     <span class="pill {{ user.status }}{% if user.status == 'failed' %} retry-pill{% endif %}" {% if user.status == 'failed' %}data-steamid="{{ user.steamid }}" title="click to retry"{% endif %}>
       {% if user.status == 'parsed' %}
         ✅ Public

--- a/utils/steam_api_client.py
+++ b/utils/steam_api_client.py
@@ -138,11 +138,14 @@ def convert_to_steam64(id_str: str) -> str:
 
 def get_tf2_playtime_hours(steamid: str) -> float:
     """Return TF2 playtime in hours for a Steam user."""
-    url = (
-        "https://api.steampowered.com/IPlayerService/GetOwnedGames/v1/"
-        f"?key={STEAM_API_KEY}&steamid={steamid}&appids_filter[0]=440"
-    )
-    r = requests.get(url, timeout=10)
+    url = "https://api.steampowered.com/IPlayerService/GetOwnedGames/v0001/"
+    params = {
+        "key": STEAM_API_KEY,
+        "steamid": steamid,
+        "include_played_free_games": 1,
+        "format": "json",
+    }
+    r = requests.get(url, params=params, timeout=10)
     r.raise_for_status()
     data = r.json().get("response", {})
     for game in data.get("games", []):


### PR DESCRIPTION
## Summary
- fetch TF2 playtime using the correct Steam API endpoint
- show playtime next to username in user cards
- vertically stack item names below item images with better spacing

## Testing
- `pre-commit run --files utils/steam_api_client.py templates/_user.html static/style.css`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f2435e494832682a76a5b62372b60