### PR TITLE
Add dark theme and UI polish for inventory cards

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,3 +1,30 @@
+body {
+    background-color: #121212;
+    color: #e0e0e0;
+    font-family: "Inter", "Segoe UI", "Helvetica Neue", sans-serif;
+    margin: 2em;
+}
+
+input,
+textarea,
+button,
+.user-card {
+    background-color: #1e1e1e;
+    border: 1px solid #333;
+    color: #fff;
+}
+
+.user-card {
+    border-radius: 4px;
+    padding: 8px;
+    margin-bottom: 16px;
+}
+
+button {
+    padding: 6px 12px;
+    cursor: pointer;
+}
+
 .items {
     display: flex;
     overflow-x: auto;
@@ -10,10 +37,18 @@
   align-items: center;
   justify-content: flex-start;
   min-width: 120px;
-  padding: 4px;
-  border: 2px solid #ccc;
-  border-radius: 3px;
-  margin: 2px;
+  padding: 8px;
+  border: 1px solid #333;
+  border-radius: 4px;
+  margin: 4px;
+  background: rgba(40, 40, 40, 0.8);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+  transition: transform 0.1s, box-shadow 0.1s;
+}
+
+.item-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
 }
 .item-card img {
   display: block;
@@ -21,11 +56,11 @@
 .missing-icon {
   width: 32px;
   height: 32px;
-  background: #eee;
+  background: #444;
 }
 
 .item-name {
-  font-size: 12px;
+  font-size: 13px;
   color: #fff;
   text-align: center;
   margin-top: 4px;

--- a/templates/_user.html
+++ b/templates/_user.html
@@ -23,7 +23,7 @@
     {% endif %}
     <div class="items">
       {% for item in user.items %}
-        <div class="item-card" style="background-color: {{ item.quality_color }}20; border-color: {{ item.quality_color }};">
+        <div class="item-card" style="border-color: {{ item.quality_color }};">
           {% if item.final_url %}
             <img src="{{ item.final_url }}" alt="{{ item.name }}" width="32" height="32">
           {% else %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,8 +5,9 @@
     <title>TF2 Inventory Checker</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     <style>
-        body { font-family: Arial, sans-serif; margin: 2em; }
-        textarea { width: 100%; height: 100px; }
+        body { background-color: #121212; color: #e0e0e0; font-family: "Inter", "Segoe UI", "Helvetica Neue", sans-serif; margin: 2em; }
+        textarea { width: 100%; height: 100px; background-color: #1e1e1e; border: 1px solid #333; color: #fff; }
+        button { background-color: #1e1e1e; border: 1px solid #333; color: #fff; padding: 6px 12px; }
         img { vertical-align: middle; }
         .pill {
             background: #666;


### PR DESCRIPTION
## Summary
- globally style a dark theme via `style.css`
- polish form fields and user cards in `index.html`
- improve inventory card hover and look in `_user.html`

## Testing
- `pre-commit run --files static/style.css templates/index.html templates/_user.html`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f26c58a2c83269bd79731634818c3