### PR TITLE
Fix refresh button logic and stream user cards in real-time

### DIFF
--- a/app.py
+++ b/app.py
@@ -139,6 +139,7 @@ def normalize_user_payload(user: Dict[str, Any]) -> SimpleNamespace:
 
 
 def fetch_and_process_single_user(steamid64: int) -> str:
+    fetch_prices()
     user = build_user_data(str(steamid64))
     user = normalize_user_payload(user)
     return render_template("_user.html", user=user)
@@ -176,26 +177,13 @@ def index():
                 invalid_count=len(invalid),
             )
         fetch_prices()
-        for sid64 in ids:
-            user = build_user_data(sid64)
-            items = user.get("items")
-            status = user.get("status")
-            if status == "failed":
-                status = "incomplete"
-            elif status not in ("parsed", "incomplete"):
-                status = "private"
-            if status != "parsed":
-                items = []
-            user["status"] = status
-            user["items"] = items
-            user = normalize_user_payload(user)
-            users.append(user)
     return render_template(
         "index.html",
         users=users,
         steamids=steamids_input,
         valid_count=len(ids) if request.method == "POST" else 0,
         invalid_count=len(invalid) if request.method == "POST" else 0,
+        ids=ids,
     )
 
 

--- a/static/retry.js
+++ b/static/retry.js
@@ -1,10 +1,23 @@
+function appendCard(html) {
+  const wrapper = document.createElement('div');
+  wrapper.innerHTML = html;
+  const card = wrapper.firstElementChild;
+  if (card) {
+    document.getElementById('user-container').appendChild(card);
+  }
+}
+
 function refreshCard(id) {
-  fetch('/retry/' + id, {method: 'POST'})
+  return fetch('/retry/' + id, { method: 'POST' })
     .then(r => r.text())
     .then(html => {
-      const el = document.getElementById('user-' + id);
-      if (el) {
-        el.outerHTML = html;
+      const existing = document.getElementById('user-' + id);
+      if (existing) {
+        const wrapper = document.createElement('div');
+        wrapper.innerHTML = html;
+        existing.replaceWith(wrapper.firstElementChild);
+      } else {
+        appendCard(html);
       }
       attachHandlers();
     });
@@ -20,12 +33,35 @@ function attachHandlers() {
   }
 }
 
+function refreshAll() {
+  const btn = document.getElementById('retry-all');
+  if (!btn) return;
+  btn.disabled = true;
+  const original = btn.textContent;
+  btn.textContent = 'Refreshing…';
+  const promises = Array.from(document.querySelectorAll('.retry-pill')).map(el =>
+    refreshCard(el.dataset.steamid)
+  );
+  Promise.all(promises).finally(() => {
+    btn.disabled = false;
+    btn.textContent = original;
+    attachHandlers();
+  });
+}
+
+function loadUsers(ids) {
+  ids.forEach(id => {
+    refreshCard(id);
+  });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   attachHandlers();
   const btn = document.getElementById('retry-all');
   if (btn) {
-    btn.addEventListener('click', () => {
-      document.querySelectorAll('.retry-pill').forEach(el => refreshCard(el.dataset.steamid));
-    });
+    btn.addEventListener('click', refreshAll);
+  }
+  if (window.initialIds && window.initialIds.length) {
+    loadUsers(window.initialIds);
   }
 });

--- a/templates/index.html
+++ b/templates/index.html
@@ -42,16 +42,13 @@
         <p>Processed {{ valid_count }} valid IDs{% if invalid_count %} (ignored {{ invalid_count }} invalid){% endif %}.</p>
     {% endif %}
 
-    <button id="retry-all" disabled>Retry Failed</button>
+    <button id="retry-all" disabled>Refresh Failed</button>
 
-    <div id="results">
-    {% if users %}
-        {% for user in users %}
-            {% include '_user.html' with context %}
-        {% endfor %}
-    {% endif %}
-    </div>
+    <div id="user-container"></div>
 
+    <script>
+      window.initialIds = {{ ids|tojson|safe }};
+    </script>
     <script src="{{ url_for('static', filename='retry.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update `fetch_and_process_single_user` to always load prices
- return IDs to the template and let the client stream cards
- rename container and hook up refresh logic
- rewrite `retry.js` to load users and retry in the background

## Testing
- `pre-commit run --files static/retry.js templates/index.html app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f2ace50c48326a641e260c8c941d8