### PR TITLE
Add Backpack.tf pricing integration with conversion support

### DIFF
--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,3 @@
+from . import pricing_service
+
+__all__ = ["pricing_service"]

--- a/services/pricing_service.py
+++ b/services/pricing_service.py
@@ -1,0 +1,116 @@
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Any, Dict
+
+import requests
+
+from utils.cache_manager import read_json, write_json
+
+logger = logging.getLogger(__name__)
+
+PRICE_CACHE_FILE = Path("data/price_cache.json")
+CURRENCY_FILE = Path("data/currency_rates.json")
+TTL = 6 * 60 * 60  # 6 hours
+
+PRICES: Dict[str, Any] | None = None
+KEY_REF_RATE: float | None = None
+
+
+def _fetch_prices(api_key: str) -> Dict[str, Any]:
+    url = "https://backpack.tf/api/IGetPrices/v4?key=" f"{api_key}&compress=1&appid=440"
+    r = requests.get(url, timeout=20)
+    r.raise_for_status()
+    data = r.json().get("response", {})
+    if data.get("success") != 1:
+        raise ValueError("Invalid response from backpack.tf")
+
+    items: Dict[str, Any] = {}
+    for sku, info in data.get("items", {}).items():
+        entry = {
+            "defindex": info.get("defindex"),
+            "quality": info.get("quality"),
+            "value": info.get("value"),
+            "currency": info.get("currency"),
+            "last_update": info.get("last_update"),
+        }
+        if "value_high" in info:
+            entry["value_high"] = info["value_high"]
+        items[sku] = entry
+    return items
+
+
+def _fetch_currencies(api_key: str) -> Dict[str, Any]:
+    url = f"https://backpack.tf/api/IGetCurrencies/v1?key={api_key}&appid=440"
+    r = requests.get(url, timeout=10)
+    r.raise_for_status()
+    data = r.json().get("response", {})
+    return data.get("currencies", {})
+
+
+def ensure_price_cache(api_key: str | None = None) -> Dict[str, Any]:
+    global PRICES
+    if PRICES is not None:
+        return PRICES
+    if api_key is None:
+        api_key = os.getenv("BACKPACK_API_KEY")
+    if not api_key:
+        raise ValueError("BACKPACK_API_KEY is required to fetch prices")
+
+    if PRICE_CACHE_FILE.exists():
+        age = time.time() - PRICE_CACHE_FILE.stat().st_mtime
+        if age < TTL:
+            PRICES = read_json(PRICE_CACHE_FILE)
+            logger.info("Price cache HIT: %s entries", len(PRICES))
+            return PRICES
+
+    fetched = _fetch_prices(api_key)
+    write_json(PRICE_CACHE_FILE, fetched)
+    PRICES = fetched
+    logger.info("Price cache MISS, fetched %s entries", len(PRICES))
+    return PRICES
+
+
+def ensure_currency_rates(api_key: str | None = None) -> float:
+    global KEY_REF_RATE
+    if KEY_REF_RATE is not None:
+        return KEY_REF_RATE
+    if api_key is None:
+        api_key = os.getenv("BACKPACK_API_KEY")
+    if not api_key:
+        raise ValueError("BACKPACK_API_KEY is required to fetch currency rates")
+
+    if CURRENCY_FILE.exists():
+        currencies = read_json(CURRENCY_FILE)
+        metal_val = currencies.get("metal", {}).get("value")
+        key_val = currencies.get("keys", {}).get("value")
+        if metal_val and key_val:
+            KEY_REF_RATE = key_val / metal_val
+            return KEY_REF_RATE
+
+    currencies = _fetch_currencies(api_key)
+    write_json(CURRENCY_FILE, currencies)
+
+    metal_val = currencies.get("metal", {}).get("value")
+    key_val = currencies.get("keys", {}).get("value")
+    KEY_REF_RATE = key_val / metal_val if metal_val else 0.0
+    return KEY_REF_RATE
+
+
+def convert_value(value: float, key_ref_rate: float) -> tuple[int, float]:
+    keys = int(value / key_ref_rate) if key_ref_rate else 0
+    refs = round((value % key_ref_rate) / 100, 2) if key_ref_rate else 0.0
+    return keys, refs
+
+
+def format_price(value: float, key_ref_rate: float) -> str:
+    keys, refs = convert_value(value, key_ref_rate)
+    parts = []
+    if keys:
+        parts.append(f"{keys} key{'s' if keys != 1 else ''}")
+    if refs:
+        parts.append(f"{refs:.2f} ref")
+    if not parts:
+        return "0.00 ref"
+    return " ".join(parts)

--- a/templates/_user.html
+++ b/templates/_user.html
@@ -23,7 +23,7 @@
     {% endif %}
     <div class="items">
       {% for item in user.items %}
-        <div class="item-card" style="border-color: {{ item.quality_color }};">
+        <div class="item-card{% if item.unknown %} unknown{% endif %}" style="border-color: {{ item.quality_color }};{% if item.unknown %} opacity:0.5;{% endif %}">
           {% if item.final_url %}
             <img src="{{ item.final_url }}" alt="{{ item.name }}" width="32" height="32">
           {% else %}

--- a/tests/test_pricing_service.py
+++ b/tests/test_pricing_service.py
@@ -1,11 +1,11 @@
-import utils.price_fetcher as pf
+import services.pricing_service as ps
 
 
 def test_price_cache_fetch(tmp_path, monkeypatch):
     price_file = tmp_path / "price_cache.json"
     curr_file = tmp_path / "currency_rates.json"
-    monkeypatch.setattr(pf, "PRICE_CACHE_FILE", price_file)
-    monkeypatch.setattr(pf, "CURRENCY_FILE", curr_file)
+    monkeypatch.setattr(ps, "PRICE_CACHE_FILE", price_file)
+    monkeypatch.setattr(ps, "CURRENCY_FILE", curr_file)
 
     class DummyResp:
         def __init__(self, payload):
@@ -40,11 +40,11 @@ def test_price_cache_fetch(tmp_path, monkeypatch):
             return DummyResp(prices_payload)
         return DummyResp(currencies_payload)
 
-    monkeypatch.setattr(pf.requests, "get", fake_get)
+    monkeypatch.setattr(ps.requests, "get", fake_get)
     monkeypatch.setenv("BACKPACK_API_KEY", "x")
 
-    prices = pf.ensure_price_cache()
-    rate = pf.ensure_currency_rates()
+    prices = ps.ensure_price_cache()
+    rate = ps.ensure_currency_rates()
 
     assert prices["30035;6"]["value"] == 5100
     assert rate == 51.0
@@ -53,5 +53,5 @@ def test_price_cache_fetch(tmp_path, monkeypatch):
 
 
 def test_format_price():
-    result = pf.format_price(5150, 5100)
+    result = ps.format_price(5150, 5100)
     assert "key" in result and "0.50" in result

--- a/update_prices.py
+++ b/update_prices.py
@@ -1,0 +1,28 @@
+import os
+
+from services import pricing_service
+from utils.cache_manager import read_json, write_json
+
+
+def main() -> None:
+    api_key = os.getenv("BACKPACK_API_KEY")
+    if not api_key:
+        raise ValueError("BACKPACK_API_KEY is required")
+
+    current = read_json(pricing_service.PRICE_CACHE_FILE)
+    fetched = pricing_service._fetch_prices(api_key)
+    updated = False
+    for sku, entry in fetched.items():
+        if current.get(sku, {}).get("last_update") != entry.get("last_update"):
+            current[sku] = entry
+            updated = True
+    if updated:
+        write_json(pricing_service.PRICE_CACHE_FILE, current)
+
+    currencies = pricing_service._fetch_currencies(api_key)
+    if currencies:
+        write_json(pricing_service.CURRENCY_FILE, currencies)
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/cache_manager.py
+++ b/utils/cache_manager.py
@@ -1,0 +1,16 @@
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+
+def read_json(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        return {}
+    with path.open() as f:
+        return json.load(f)
+
+
+def write_json(path: Path, data: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as f:
+        json.dump(data, f)

--- a/utils/price_fetcher.py
+++ b/utils/price_fetcher.py
@@ -1,121 +1,19 @@
-import json
-import logging
-import os
-import time
-from pathlib import Path
-from typing import Any, Dict
+"""Backward-compatible wrappers for pricing_service."""
 
-import requests
+from services.pricing_service import (
+    PRICE_CACHE_FILE,
+    CURRENCY_FILE,
+    ensure_price_cache,
+    ensure_currency_rates,
+    convert_value,
+    format_price,
+)
 
-logger = logging.getLogger(__name__)
-
-PRICE_CACHE_FILE = Path("data/price_cache.json")
-CURRENCY_FILE = Path("data/currency_rates.json")
-TTL = 6 * 60 * 60  # 6 hours
-
-PRICES: Dict[str, Any] | None = None
-KEY_REF_RATE: float | None = None
-
-
-def _fetch_prices(api_key: str) -> Dict[str, Any]:
-    url = "https://backpack.tf/api/IGetPrices/v4?key=" f"{api_key}&compress=1&appid=440"
-    r = requests.get(url, timeout=20)
-    r.raise_for_status()
-    data = r.json().get("response", {})
-    if data.get("success") != 1:
-        raise ValueError("Invalid response from backpack.tf")
-
-    items: Dict[str, Any] = {}
-    for sku, info in data.get("items", {}).items():
-        entry = {
-            "defindex": info.get("defindex"),
-            "quality": info.get("quality"),
-            "value": info.get("value"),
-            "currency": info.get("currency"),
-            "last_update": info.get("last_update"),
-        }
-        if "value_high" in info:
-            entry["value_high"] = info["value_high"]
-        items[sku] = entry
-    return items
-
-
-def _fetch_currencies(api_key: str) -> Dict[str, Any]:
-    url = f"https://backpack.tf/api/IGetCurrencies/v1?key={api_key}&appid=440"
-    r = requests.get(url, timeout=10)
-    r.raise_for_status()
-    data = r.json().get("response", {})
-    return data.get("currencies", {})
-
-
-def ensure_price_cache(api_key: str | None = None) -> Dict[str, Any]:
-    global PRICES
-    if PRICES is not None:
-        return PRICES
-    if api_key is None:
-        api_key = os.getenv("BACKPACK_API_KEY")
-    if not api_key:
-        raise ValueError("BACKPACK_API_KEY is required to fetch prices")
-
-    if PRICE_CACHE_FILE.exists():
-        age = time.time() - PRICE_CACHE_FILE.stat().st_mtime
-        if age < TTL:
-            with PRICE_CACHE_FILE.open() as f:
-                PRICES = json.load(f)
-            logger.info("Price cache HIT: %s entries", len(PRICES))
-            return PRICES
-
-    fetched = _fetch_prices(api_key)
-    PRICE_CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
-    with PRICE_CACHE_FILE.open("w") as f:
-        json.dump(fetched, f)
-    PRICES = fetched
-    logger.info("Price cache MISS, fetched %s entries", len(PRICES))
-    return PRICES
-
-
-def ensure_currency_rates(api_key: str | None = None) -> float:
-    global KEY_REF_RATE
-    if KEY_REF_RATE is not None:
-        return KEY_REF_RATE
-    if api_key is None:
-        api_key = os.getenv("BACKPACK_API_KEY")
-    if not api_key:
-        raise ValueError("BACKPACK_API_KEY is required to fetch currency rates")
-
-    if CURRENCY_FILE.exists():
-        with CURRENCY_FILE.open() as f:
-            currencies = json.load(f)
-        metal_val = currencies.get("metal", {}).get("value")
-        key_val = currencies.get("keys", {}).get("value")
-        if metal_val and key_val:
-            KEY_REF_RATE = key_val / metal_val
-            return KEY_REF_RATE
-
-    currencies = _fetch_currencies(api_key)
-    CURRENCY_FILE.parent.mkdir(parents=True, exist_ok=True)
-    with CURRENCY_FILE.open("w") as f:
-        json.dump(currencies, f)
-
-    metal_val = currencies.get("metal", {}).get("value")
-    key_val = currencies.get("keys", {}).get("value")
-    KEY_REF_RATE = key_val / metal_val if metal_val else 0.0
-    return KEY_REF_RATE
-
-
-def convert_value(value: float, key_ref_rate: float) -> tuple[int, float]:
-    keys = int(value / key_ref_rate) if key_ref_rate else 0
-    refs = round((value % key_ref_rate) / 100, 2) if key_ref_rate else 0.0
-    return keys, refs
-
-
-def format_price(value: float, key_ref_rate: float) -> str:
-    keys, refs = convert_value(value, key_ref_rate)
-    parts = []
-    if keys:
-        parts.append(f"{keys} key{'s' if keys != 1 else ''}")
-    if refs:
-        parts.append(f"{refs:.2f} ref")
-    if not parts:
-        return "0.00 ref"
-    return " ".join(parts)
+__all__ = [
+    "PRICE_CACHE_FILE",
+    "CURRENCY_FILE",
+    "ensure_price_cache",
+    "ensure_currency_rates",
+    "convert_value",
+    "format_price",
+]


### PR DESCRIPTION
## Summary
- add pricing service and cache manager
- refresh unknown item styling
- create update_prices script
- add tests for pricing service
- wire pricing logic into app

## Testing
- `pre-commit run --files services/pricing_service.py utils/price_fetcher.py utils/cache_manager.py app.py templates/_user.html tests/test_pricing_service.py update_prices.py services/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f3197a110832698ad8c22e86b7785