### PR TITLE
Integrate Backpack.tf pricing with key/ref formatting and raw=2 schema caching

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -4,6 +4,7 @@ from . import (
     schema_fetcher,
     inventory_processor,
     id_parser,
+    valuation_service,
 )
 
 __all__ = [
@@ -12,4 +13,5 @@ __all__ = [
     "schema_fetcher",
     "inventory_processor",
     "id_parser",
+    "valuation_service",
 ]

--- a/utils/price_fetcher.py
+++ b/utils/price_fetcher.py
@@ -1,19 +1,42 @@
-"""Backward-compatible wrappers for pricing_service."""
+import os
+import json
+import time
+import requests
 
-from services.pricing_service import (
-    PRICE_CACHE_FILE,
-    CURRENCY_FILE,
-    ensure_price_cache,
-    ensure_currency_rates,
-    convert_value,
-    format_price,
-)
+PRICE_TTL = 900
+CACHE_DIR = "data"
+PRICE_CACHE = f"{CACHE_DIR}/price_schema.json"
+CURR_CACHE = f"{CACHE_DIR}/currencies.json"
+KEY = os.getenv("BACKPACK_KEY")
 
-__all__ = [
-    "PRICE_CACHE_FILE",
-    "CURRENCY_FILE",
-    "ensure_price_cache",
-    "ensure_currency_rates",
-    "convert_value",
-    "format_price",
-]
+
+def ensure_prices_cached():
+    if (
+        os.path.exists(PRICE_CACHE)
+        and time.time() - os.path.getmtime(PRICE_CACHE) < PRICE_TTL
+    ):
+        with open(PRICE_CACHE) as f:
+            return json.load(f)
+    r = requests.get(f"https://backpack.tf/api/IGetPrices/v4?raw=2&key={KEY}")
+    r.raise_for_status()
+    data = r.json()["response"]
+    os.makedirs(CACHE_DIR, exist_ok=True)
+    with open(PRICE_CACHE, "w") as f:
+        json.dump(data, f)
+    return data
+
+
+def ensure_currencies_cached():
+    if (
+        os.path.exists(CURR_CACHE)
+        and time.time() - os.path.getmtime(CURR_CACHE) < PRICE_TTL
+    ):
+        with open(CURR_CACHE) as f:
+            return json.load(f)
+    r = requests.get(f"https://backpack.tf/api/IGetCurrencies/v1?key={KEY}")
+    r.raise_for_status()
+    data = r.json()["response"]["currencies"]
+    os.makedirs(CACHE_DIR, exist_ok=True)
+    with open(CURR_CACHE, "w") as f:
+        json.dump(data, f)
+    return data

--- a/utils/valuation_service.py
+++ b/utils/valuation_service.py
@@ -1,0 +1,15 @@
+def format_price(price_obj, key_price_ref):
+    cur, val = price_obj["currency"], price_obj["value"]
+    if cur == "metal":
+        keys = int(val // key_price_ref)
+        ref = round(val - keys * key_price_ref, 2)
+    elif cur == "keys":
+        keys = int(val)
+        ref = round((val - keys) * key_price_ref, 2)
+    else:
+        return ""
+    return (
+        f"{keys} key{'s' if keys != 1 else ''} {ref:.2f} ref"
+        if keys or ref
+        else "0 ref"
+    )


### PR DESCRIPTION
## Summary
- cache backpack.tf prices and currencies using v4 endpoints
- support TTL 15 minutes and use `raw=2`
- format prices as `keys` + `ref`
- enrich inventory items with formatted prices
- remove SKU based lookup from the app

## Testing
- `pre-commit run --files app.py utils/__init__.py utils/inventory_processor.py utils/price_fetcher.py utils/valuation_service.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f3f0a76ec8326b3110c0387fda0c1