### PR TITLE
Fix Backpack API key loading

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
 STEAM_API_KEY=your_steam_key_here
-BACKPACK_API_KEY=your_backpack_key_here
+BACKPACK_API_KEY=your_key_here

--- a/README.md
+++ b/README.md
@@ -34,10 +34,17 @@ Edit `.env` to set your credentials:
 
 ```
 STEAM_API_KEY=your_steam_key
-BACKPACK_API_KEY=your_backpack_key
+BACKPACK_API_KEY=your_key_here
 ```
 
 The application uses **python-dotenv** to load these values at runtime.
+
+### Required Environment Variables
+
+| Variable           | Description                      |
+|--------------------|----------------------------------|
+| `STEAM_API_KEY`    | Your Steam Web API key           |
+| `BACKPACK_API_KEY` | Your Backpack.tf API key         |
 
 ## Usage
 

--- a/tests/test_id_parser.py
+++ b/tests/test_id_parser.py
@@ -1,3 +1,8 @@
+# ruff: noqa: E402
+import os
+
+os.environ.setdefault("BACKPACK_API_KEY", "x")
+
 import utils.steam_api_client as sac
 from utils.id_parser import extract_steam_ids
 

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -1,3 +1,8 @@
+# ruff: noqa: E402
+import os
+
+os.environ.setdefault("BACKPACK_API_KEY", "x")
+
 from utils import inventory_processor as ip
 from utils import schema_fetcher as sf
 from utils import steam_api_client as sac

--- a/tests/test_pricing_service.py
+++ b/tests/test_pricing_service.py
@@ -1,3 +1,8 @@
+# ruff: noqa: E402
+import os
+
+os.environ.setdefault("BACKPACK_API_KEY", "x")
+
 import services.pricing_service as ps
 
 

--- a/tests/test_schema_fetcher.py
+++ b/tests/test_schema_fetcher.py
@@ -1,6 +1,10 @@
+# ruff: noqa: E402
+import os
 import json
 
 from unittest.mock import Mock
+
+os.environ.setdefault("BACKPACK_API_KEY", "x")
 
 import utils.schema_fetcher as sf
 

--- a/tests/test_utils_extras.py
+++ b/tests/test_utils_extras.py
@@ -1,3 +1,8 @@
+# ruff: noqa: E402
+import os
+
+os.environ.setdefault("BACKPACK_API_KEY", "x")
+
 from utils import steam_api_client as sac
 from utils import inventory_processor as ip
 from utils import schema_fetcher as sf

--- a/utils/price_fetcher.py
+++ b/utils/price_fetcher.py
@@ -7,7 +7,9 @@ PRICE_TTL = 900
 CACHE_DIR = "data"
 PRICE_CACHE = f"{CACHE_DIR}/price_schema.json"
 CURR_CACHE = f"{CACHE_DIR}/currencies.json"
-KEY = os.getenv("BACKPACK_KEY")
+KEY = os.getenv("BACKPACK_API_KEY")
+if not KEY:
+    raise RuntimeError("BACKPACK_API_KEY not set. Please set it in .env or export it.")
 
 
 def ensure_prices_cached():


### PR DESCRIPTION
## Summary
- load `BACKPACK_API_KEY` from the environment in `price_fetcher`
- include `BACKPACK_API_KEY` in the sample `.env`
- document required environment variables in the README
- set `BACKPACK_API_KEY` in tests before importing modules

## Testing
- `pre-commit run --files utils/price_fetcher.py README.md .env.example tests/test_id_parser.py tests/test_inventory_processor.py tests/test_pricing_service.py tests/test_schema_fetcher.py tests/test_utils_extras.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f42a897b08326ab537927b741b400