### PR TITLE
Switch schema source from Steam to schema.autobot.tf for enriched item data

### DIFF
--- a/tests/test_app_import.py
+++ b/tests/test_app_import.py
@@ -2,7 +2,9 @@ import importlib
 
 
 def test_app_uses_mock_schema(monkeypatch):
-    mock_schema = {"5": {"defindex": 5, "name": "Five"}}
+    mock_schema = {
+        "5;0;1": {"defindex": 5, "name": "Five", "quality": 0, "craftable": True}
+    }
 
     def fake_ensure():
         return mock_schema

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -13,8 +13,15 @@ import pytest
 
 def test_enrich_inventory():
     data = {"items": [{"defindex": 111, "quality": 0}]}
-    sf.SCHEMA = {"111": {"defindex": 111, "item_name": "Test Item", "image_url": "img"}}
-    sf.QUALITIES = {"0": "Normal"}
+    sf.SCHEMA = {
+        "111;0;1": {
+            "defindex": 111,
+            "name": "Test Item",
+            "image_url": "img",
+            "quality": 0,
+            "craftable": True,
+        }
+    }
     items = ip.enrich_inventory(data)
     assert items[0]["name"] == "Test Item"
     assert items[0]["quality"] == "Normal"
@@ -27,10 +34,21 @@ def test_enrich_inventory():
 def test_process_inventory_handles_missing_icon():
     data = {"items": [{"defindex": 1}, {"defindex": 2}]}
     sf.SCHEMA = {
-        "1": {"defindex": 1, "item_name": "One", "image_url": "a"},
-        "2": {"defindex": 2, "item_name": "Two", "image_url": ""},
+        "1;0;1": {
+            "defindex": 1,
+            "name": "One",
+            "image_url": "a",
+            "quality": 0,
+            "craftable": True,
+        },
+        "2;0;1": {
+            "defindex": 2,
+            "name": "Two",
+            "image_url": "",
+            "quality": 0,
+            "craftable": True,
+        },
     }
-    sf.QUALITIES = {}
     items = ip.process_inventory(data)
     assert {i["name"] for i in items} == {"One", "Two"}
     for item in items:
@@ -45,16 +63,30 @@ def test_process_inventory_handles_missing_icon():
 def test_enrich_inventory_preserves_absolute_url():
     data = {"items": [{"defindex": 5, "quality": 0}]}
     url = "http://example.com/icon.png"
-    sf.SCHEMA = {"5": {"defindex": 5, "item_name": "Abs", "image_url": url}}
-    sf.QUALITIES = {"0": "Normal"}
+    sf.SCHEMA = {
+        "5;0;1": {
+            "defindex": 5,
+            "name": "Abs",
+            "image_url": url,
+            "quality": 0,
+            "craftable": True,
+        }
+    }
     items = ip.enrich_inventory(data)
     assert items[0]["final_url"] == url
 
 
 def test_enrich_inventory_skips_unknown_defindex():
     data = {"items": [{"defindex": 1}, {"defindex": 2}]}
-    sf.SCHEMA = {"1": {"defindex": 1, "item_name": "One", "image_url": "a"}}
-    sf.QUALITIES = {}
+    sf.SCHEMA = {
+        "1;0;1": {
+            "defindex": 1,
+            "name": "One",
+            "image_url": "a",
+            "quality": 0,
+            "craftable": True,
+        }
+    }
     items = ip.enrich_inventory(data)
     assert len(items) == 1
     assert items[0]["name"] == "One"

--- a/tests/test_utils_extras.py
+++ b/tests/test_utils_extras.py
@@ -16,9 +16,20 @@ def test_convert_to_steam64():
 def test_process_inventory_sorting():
     data = {"items": [{"defindex": 2}, {"defindex": 1}]}
     sf.SCHEMA = {
-        "1": {"defindex": 1, "item_name": "A", "image_url": "b"},
-        "2": {"defindex": 2, "item_name": "B", "image_url": "a"},
+        "1;0;1": {
+            "defindex": 1,
+            "name": "A",
+            "image_url": "b",
+            "quality": 0,
+            "craftable": True,
+        },
+        "2;0;1": {
+            "defindex": 2,
+            "name": "B",
+            "image_url": "a",
+            "quality": 0,
+            "craftable": True,
+        },
     }
-    sf.QUALITIES = {}
     items = ip.process_inventory(data)
     assert [item["name"] for item in items] == ["A", "B"]

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -46,7 +46,10 @@ def enrich_inventory(
 
     for asset in items_raw:
         defindex = str(asset.get("defindex", "0"))
-        entry = schema_map.get(defindex)
+        quality_id = asset.get("quality", 0)
+        craftable_bool = not asset.get("flag_cannot_craft", False)
+        key = f"{defindex};{quality_id};{1 if craftable_bool else 0}"
+        entry = schema_map.get(key)
         if not entry:
             continue
 
@@ -63,7 +66,6 @@ def enrich_inventory(
             or f"Item #{defindex}"
         )
 
-        quality_id = asset.get("quality", 0)
         q_name, q_col = QUALITY_MAP.get(quality_id, ("Unknown", "#B2B2B2"))
 
         item = {
@@ -85,9 +87,9 @@ def enrich_inventory(
             if price_data:
                 quality = "6"
                 tradable = "Tradable"
-                craftable = "Craftable"
+                craftable_state = "Craftable"
                 try:
-                    entry = price_data["prices"][quality][tradable][craftable][0]
+                    entry = price_data["prices"][quality][tradable][craftable_state][0]
                     from .valuation_service import format_price
 
                     item["price"] = format_price(entry, key_price_ref)

--- a/utils/schema_fetcher.py
+++ b/utils/schema_fetcher.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import os
 import time
 from pathlib import Path
 from typing import Any, Dict
@@ -9,76 +8,52 @@ import requests
 
 logger = logging.getLogger(__name__)
 
+# cache file location and refresh interval
 CACHE_FILE = Path("data/item_schema.json")
 TTL = 48 * 60 * 60  # 48 hours
 
+# remote schema endpoint
+SCHEMA_URL = "https://schema.autobot.tf/v1/schema"
+
 
 SCHEMA: Dict[str, Any] | None = None
-QUALITIES: Dict[str | int, str] = {}
 
 
-def _fetch_schema(api_key: str) -> Dict[str, Any]:
-    """Fetch schema overview and all items from Steam."""
+def _fetch_schema() -> Dict[str, Any]:
+    """Fetch enriched TF2 schema from schema.autobot.tf."""
 
-    overview_url = (
-        "https://api.steampowered.com/IEconItems_440/GetSchemaOverview/v1/"
-        f"?key={api_key}"
-    )
-    r = requests.get(overview_url, timeout=20)
+    r = requests.get(SCHEMA_URL, timeout=20)
     r.raise_for_status()
-    overview = r.json()["result"]
-    qualities = {str(v): k for k, v in overview.get("qualities", {}).items()}
-
-    items: Dict[str, Any] = {}
-    start = 0
-    while True:
-        items_url = (
-            "https://api.steampowered.com/IEconItems_440/GetSchemaItems/v1/"
-            f"?key={api_key}&start={start}"
-        )
-        r = requests.get(items_url, timeout=20)
-        r.raise_for_status()
-        data = r.json()["result"]
-        for item in data.get("items", []):
-            defindex = str(item.get("defindex"))
-            if not defindex or "name" not in item:
-                continue
-            items[defindex] = {
-                "defindex": item.get("defindex"),
-                "name": item.get("name"),
-                "image_url": item.get("image_url"),
-                "image_url_large": item.get("image_url_large"),
-            }
-        if not data.get("next"):
-            break
-        start = data["next"]
-
-    return {"items": items, "qualities": qualities}
+    return r.json()
 
 
-def ensure_schema_cached(api_key: str | None = None) -> Dict[str, Any]:
+def ensure_schema_cached() -> Dict[str, Any]:
     """Return cached item schema mapping."""
-    if api_key is None:
-        api_key = os.getenv("STEAM_API_KEY")
-    if not api_key:
-        raise ValueError("STEAM_API_KEY is required to fetch item schema")
 
-    global SCHEMA, QUALITIES
+    global SCHEMA
     if CACHE_FILE.exists():
-        age = time.time() - CACHE_FILE.stat().st_mtime
-        if age < TTL:
-            with CACHE_FILE.open() as f:
-                cached = json.load(f)
+        with CACHE_FILE.open() as f:
+            cached = json.load(f)
+        ts = cached.get("fetched", 0)
+        if time.time() - ts < TTL:
             SCHEMA = cached.get("items", {})
-            QUALITIES = cached.get("qualities", {})
             logger.info("Schema cache HIT: %s items", len(SCHEMA))
             return SCHEMA
 
-    fetched = _fetch_schema(api_key)
+    fetched = _fetch_schema()
+    items: Dict[str, Any] = {}
+    for item in fetched.get("items", []):
+        defindex = item.get("defindex")
+        if defindex is None:
+            continue
+        quality = item.get("quality", 0)
+        craftable = item.get("craftable", True)
+        key = f"{defindex};{quality};{1 if craftable else 0}"
+        items[key] = item
+
     CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
     with CACHE_FILE.open("w") as f:
-        json.dump(fetched, f)
-    SCHEMA = fetched["items"]
-    QUALITIES = fetched["qualities"]
+        json.dump({"fetched": time.time(), "items": items}, f)
+    SCHEMA = items
     logger.info("Schema cache MISS, fetched %s items", len(SCHEMA))
     return SCHEMA


### PR DESCRIPTION
## Summary
- replace the old Steam schema endpoint with schema.autobot.tf
- update `schema_fetcher` to store items keyed by `defindex;quality;craftable`
- adjust inventory enrichment to use the new keys
- refresh cache with timestamp and 48‑hour TTL
- update unit tests for the new schema structure

## Testing
- `pre-commit run --files utils/schema_fetcher.py utils/inventory_processor.py tests/test_schema_fetcher.py tests/test_inventory_processor.py tests/test_utils_extras.py tests/test_app_import.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f4a489ccc83269220cda218da2113