### PR TITLE
Update schema loader to use schema.autobot.tf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,5 +11,5 @@ All notable changes to this project will be documented in this file.
 - Coverage and CI badges in the README.
 
 ### Changed
-- Updated schema caching logic and UI (previous releases).
+- Updated schema source to schema.autobot.tf with 48h caching.
 - Security audit using git-secrets and pip-audit.


### PR DESCRIPTION
## Summary
- fetch latest TF2 schema from `schema.autobot.tf`
- cache schema to `cached_schema.json` for 48h
- expose bulk name resolution helper
- adjust tests for new schema loader

## Testing
- `pre-commit run --files utils/schema_fetcher.py tests/test_schema_fetcher.py CHANGELOG.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f4d977c688326ab13565c75e7245e