### PR TITLE
Improve logging for retries and cache modules

### DIFF
--- a/utils/price_fetcher.py
+++ b/utils/price_fetcher.py
@@ -1,6 +1,7 @@
 import os
 import json
 import time
+import logging
 import requests
 
 PRICE_TTL = 900
@@ -11,6 +12,8 @@ KEY = os.getenv("BACKPACK_API_KEY")
 if not KEY:
     raise RuntimeError("BACKPACK_API_KEY not set. Please set it in .env or export it.")
 
+logger = logging.getLogger(__name__)
+
 
 def ensure_prices_cached():
     if (
@@ -18,13 +21,17 @@ def ensure_prices_cached():
         and time.time() - os.path.getmtime(PRICE_CACHE) < PRICE_TTL
     ):
         with open(PRICE_CACHE) as f:
-            return json.load(f)
+            data = json.load(f)
+        logger.info("Price cache HIT: %s entries", len(data.get("items", {})))
+        return data
+    logger.info("Fetching prices from backpack.tf")
     r = requests.get(f"https://backpack.tf/api/IGetPrices/v4?raw=2&key={KEY}")
     r.raise_for_status()
     data = r.json()["response"]
     os.makedirs(CACHE_DIR, exist_ok=True)
     with open(PRICE_CACHE, "w") as f:
         json.dump(data, f)
+    logger.info("Price cache updated: %s entries", len(data.get("items", {})))
     return data
 
 
@@ -34,11 +41,15 @@ def ensure_currencies_cached():
         and time.time() - os.path.getmtime(CURR_CACHE) < PRICE_TTL
     ):
         with open(CURR_CACHE) as f:
-            return json.load(f)
+            data = json.load(f)
+        logger.info("Currency cache HIT: %s entries", len(data))
+        return data
+    logger.info("Fetching currency rates from backpack.tf")
     r = requests.get(f"https://backpack.tf/api/IGetCurrencies/v1?key={KEY}")
     r.raise_for_status()
     data = r.json()["response"]["currencies"]
     os.makedirs(CACHE_DIR, exist_ok=True)
     with open(CURR_CACHE, "w") as f:
         json.dump(data, f)
+    logger.info("Currency cache updated: %s entries", len(data))
     return data

--- a/utils/schema_fetcher.py
+++ b/utils/schema_fetcher.py
@@ -23,9 +23,12 @@ SCHEMA: Dict[str, Any] | None = None
 def _fetch_schema() -> Dict[str, Any]:
     """Fetch enriched TF2 schema from schema.autobot.tf."""
 
+    logger.info("Fetching schema from %s", SCHEMA_URL)
     r = requests.get(SCHEMA_URL, headers={"Accept": "*/*"})
     r.raise_for_status()
-    return r.json()
+    data = r.json()
+    logger.info("Fetched schema with %s items", len(data.get("items", [])))
+    return data
 
 
 def ensure_schema_cached() -> Dict[str, Any]:
@@ -33,6 +36,7 @@ def ensure_schema_cached() -> Dict[str, Any]:
 
     global SCHEMA
     if CACHE_FILE.exists():
+        logger.info("Loading schema from cache %s", CACHE_FILE)
         with CACHE_FILE.open() as f:
             cached = json.load(f)
         ts = cached.get("timestamp", 0)
@@ -57,6 +61,7 @@ def ensure_schema_cached() -> Dict[str, Any]:
         json.dump({"timestamp": time.time(), "items": items}, f)
     SCHEMA = items
     logger.info("Schema cache MISS, fetched %s items", len(SCHEMA))
+    logger.info("Schema cache updated at %s", CACHE_FILE)
     return SCHEMA
 
 


### PR DESCRIPTION
## Summary
- configure root logger for stdout
- add structured logging to `/retry/<steamid>` endpoint
- emit cache load/fetch logs in `price_fetcher`
- enhance schema logging during fetch and load
- replace print statements with logger calls

## Testing
- `pre-commit run --files app.py utils/price_fetcher.py utils/schema_fetcher.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fd96ade6083268bb5d1fbf1947f30