### PR TITLE
Implement Backpack.tf pricing integration with caching and currency conversion

### DIFF
--- a/services/pricing_service.py
+++ b/services/pricing_service.py
@@ -10,9 +10,9 @@ from utils.cache_manager import read_json, write_json
 
 logger = logging.getLogger(__name__)
 
-PRICE_CACHE_FILE = Path("data/price_cache.json")
-CURRENCY_FILE = Path("data/currency_rates.json")
-TTL = 6 * 60 * 60  # 6 hours
+PRICE_CACHE_FILE = Path("data/cached_prices.json")
+CURRENCY_FILE = Path("data/cached_currencies.json")
+TTL = 48 * 60 * 60  # 48 hours
 
 PRICES: Dict[str, Any] | None = None
 KEY_REF_RATE: float | None = None

--- a/tests/test_pricing_service.py
+++ b/tests/test_pricing_service.py
@@ -7,8 +7,8 @@ import services.pricing_service as ps
 
 
 def test_price_cache_fetch(tmp_path, monkeypatch):
-    price_file = tmp_path / "price_cache.json"
-    curr_file = tmp_path / "currency_rates.json"
+    price_file = tmp_path / "cached_prices.json"
+    curr_file = tmp_path / "cached_currencies.json"
     monkeypatch.setattr(ps, "PRICE_CACHE_FILE", price_file)
     monkeypatch.setattr(ps, "CURRENCY_FILE", curr_file)
 

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -83,20 +83,17 @@ def enrich_inventory(
         }
 
         if prices and key_price_ref:
-            price_data = prices.get(name)
-            if price_data:
-                quality = "6"
-                tradable = "Tradable"
-                craftable_state = "Craftable"
-                try:
-                    entry = price_data["prices"][quality][tradable][craftable_state][0]
-                    from .valuation_service import format_price
+            sku = f"{defindex};{quality_id}"
+            price_entry = prices.get(sku)
+            from .valuation_service import format_price
 
-                    item["price"] = format_price(entry, key_price_ref)
-                except Exception:
-                    item["price"] = ""
+            if price_entry:
+                item["price"] = format_price(price_entry, key_price_ref)
+                item["unknown"] = False
             else:
-                item["price"] = ""
+                logger.info("Price not found for %s", sku)
+                item["price"] = "Unknown Value"
+                item["unknown"] = True
 
         items.append(item)
     return items

--- a/utils/price_fetcher.py
+++ b/utils/price_fetcher.py
@@ -4,10 +4,10 @@ import time
 import logging
 import requests
 
-PRICE_TTL = 900
+PRICE_TTL = 48 * 60 * 60  # 48 hours
 CACHE_DIR = "data"
-PRICE_CACHE = f"{CACHE_DIR}/price_schema.json"
-CURR_CACHE = f"{CACHE_DIR}/currencies.json"
+PRICE_CACHE = f"{CACHE_DIR}/cached_prices.json"
+CURR_CACHE = f"{CACHE_DIR}/cached_currencies.json"
 KEY = os.getenv("BACKPACK_API_KEY")
 if not KEY:
     raise RuntimeError("BACKPACK_API_KEY not set. Please set it in .env or export it.")
@@ -22,17 +22,31 @@ def ensure_prices_cached():
     ):
         with open(PRICE_CACHE) as f:
             data = json.load(f)
-        logger.info("Price cache HIT: %s entries", len(data.get("items", {})))
+        logger.info("Price cache HIT: %s entries", len(data))
         return data
     logger.info("Fetching prices from backpack.tf")
-    r = requests.get(f"https://backpack.tf/api/IGetPrices/v4?raw=2&key={KEY}")
+    url = f"https://backpack.tf/api/IGetPrices/v4?key={KEY}&compress=1"
+    r = requests.get(url, timeout=20)
     r.raise_for_status()
-    data = r.json()["response"]
+    resp = r.json()["response"]
+    items: dict[str, dict] = {}
+    for sku, info in resp.get("items", {}).items():
+        entry = {
+            "defindex": info.get("defindex"),
+            "quality": info.get("quality"),
+            "value": info.get("value"),
+            "currency": info.get("currency"),
+            "last_update": info.get("last_update"),
+        }
+        if "value_high" in info:
+            entry["value_high"] = info["value_high"]
+        items[sku] = entry
+
     os.makedirs(CACHE_DIR, exist_ok=True)
     with open(PRICE_CACHE, "w") as f:
-        json.dump(data, f)
-    logger.info("Price cache updated: %s entries", len(data.get("items", {})))
-    return data
+        json.dump(items, f)
+    logger.info("Price cache updated: %s entries", len(items))
+    return items
 
 
 def ensure_currencies_cached():
@@ -45,7 +59,8 @@ def ensure_currencies_cached():
         logger.info("Currency cache HIT: %s entries", len(data))
         return data
     logger.info("Fetching currency rates from backpack.tf")
-    r = requests.get(f"https://backpack.tf/api/IGetCurrencies/v1?key={KEY}")
+    url = f"https://backpack.tf/api/IGetCurrencies/v1?key={KEY}"
+    r = requests.get(url, timeout=10)
     r.raise_for_status()
     data = r.json()["response"]["currencies"]
     os.makedirs(CACHE_DIR, exist_ok=True)


### PR DESCRIPTION
## Summary
- cache backpack.tf price & currency data for 48h
- fetch prices using compressed format and store to `data/cached_prices.json`
- fetch backpack.tf currencies to `data/cached_currencies.json`
- load prices by sku in inventory processor and mark unknown values
- adjust pricing service and tests for new cache files

## Testing
- `pre-commit run --files utils/price_fetcher.py services/pricing_service.py utils/inventory_processor.py tests/test_pricing_service.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fe87e7798832696cdae7c3974a3af