### PR TITLE
Fix schema download handling from schema.autobot.tf

### DIFF
--- a/tests/test_schema_fetcher.py
+++ b/tests/test_schema_fetcher.py
@@ -6,30 +6,27 @@ from unittest.mock import Mock
 
 os.environ.setdefault("BACKPACK_API_KEY", "x")
 
-import time
-
 import utils.schema_fetcher as sf
 
 
 def test_schema_cache_hit(tmp_path, monkeypatch):
     cache = tmp_path / "cached_schema.json"
     sample = {
-        "timestamp": time.time(),
-        "items": {
-            "1;0;1": {
+        "items": [
+            {
                 "defindex": 1,
                 "name": "Item",
                 "image_url": "i",
                 "quality": 0,
                 "craftable": True,
             }
-        },
+        ]
     }
     cache.write_text(json.dumps(sample))
     monkeypatch.setattr(sf, "CACHE_FILE", cache)
     monkeypatch.setattr(sf, "requests", Mock())
     schema = sf.ensure_schema_cached()
-    assert schema == sample["items"]
+    assert schema == {"1;0;1": sample["items"][0]}
 
 
 def test_schema_cache_miss(tmp_path, monkeypatch):
@@ -38,13 +35,10 @@ def test_schema_cache_miss(tmp_path, monkeypatch):
 
     class DummyResp:
         def __init__(self, payload):
-            self.payload = payload
+            self.content = json.dumps(payload).encode()
 
         def raise_for_status(self):
             pass
-
-        def json(self):
-            return self.payload
 
     payload = {
         "items": [
@@ -58,9 +52,9 @@ def test_schema_cache_miss(tmp_path, monkeypatch):
         ]
     }
 
-    def fake_get(url, headers=None):
+    def fake_get(url, stream=False, timeout=20):
         assert url == sf.SCHEMA_URL
-        assert headers == {"Accept": "*/*"}
+        assert stream is True
         return DummyResp(payload)
 
     monkeypatch.setattr(sf.requests, "get", fake_get)


### PR DESCRIPTION
## Summary
- fix schema download logic (raw file, not JSON API)
- update schema caching and loading
- update tests for new schema handling

## Testing
- `pre-commit run --files utils/schema_fetcher.py tests/test_schema_fetcher.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fec643c808326bf683362baec2827