### PR TITLE
Refresh data loaders for schema and prices

### DIFF
--- a/app.py
+++ b/app.py
@@ -42,8 +42,7 @@ def fetch_prices() -> None:
     global PRICE_CACHE, KEY_REF_RATE
     if PRICE_CACHE and KEY_REF_RATE:
         return
-    data = price_fetcher.ensure_prices_cached()
-    PRICE_CACHE = data.get("items", {}) if isinstance(data, dict) else {}
+    PRICE_CACHE = price_fetcher.ensure_prices_cached()
     currencies = price_fetcher.ensure_currencies_cached()
     metal_val = currencies.get("metal", {}).get("value")
     key_val = currencies.get("keys", {}).get("value")

--- a/tests/test_pricing_service.py
+++ b/tests/test_pricing_service.py
@@ -26,12 +26,19 @@ def test_price_cache_fetch(tmp_path, monkeypatch):
         "response": {
             "success": 1,
             "items": {
-                "30035;6": {
-                    "defindex": 30035,
-                    "quality": 6,
-                    "value": 5100,
-                    "currency": "metal",
-                    "last_update": 1,
+                "Item": {
+                    "defindex": ["30035"],
+                    "prices": {
+                        "6": {
+                            "Tradable": {
+                                "0": {
+                                    "value": 5100,
+                                    "currency": "metal",
+                                    "last_update": 1,
+                                }
+                            }
+                        }
+                    },
                 }
             },
         }

--- a/tests/test_schema_fetcher.py
+++ b/tests/test_schema_fetcher.py
@@ -20,7 +20,7 @@ def test_schema_cache_hit(tmp_path, monkeypatch):
             "craftable": True,
         }
     ]
-    cache.write_text(json.dumps(sample))
+    cache.write_text(json.dumps({"items": sample}))
     monkeypatch.setattr(sf, "CACHE_FILE", cache)
     monkeypatch.setattr(sf, "requests", Mock())
     schema = sf.ensure_schema_cached()
@@ -38,15 +38,17 @@ def test_schema_cache_miss(tmp_path, monkeypatch):
         def raise_for_status(self):
             pass
 
-    payload = [
-        {
-            "defindex": 2,
-            "name": "Other",
-            "image_url": "u",
-            "quality": 0,
-            "craftable": True,
-        }
-    ]
+    payload = {
+        "items": [
+            {
+                "defindex": 2,
+                "name": "Other",
+                "image_url": "u",
+                "quality": 0,
+                "craftable": True,
+            }
+        ]
+    }
 
     def fake_get(url, stream=False, timeout=20):
         assert url == sf.SCHEMA_URL

--- a/utils/schema_fetcher.py
+++ b/utils/schema_fetcher.py
@@ -38,17 +38,14 @@ def _load_schema() -> Dict[str, Any]:
     with CACHE_FILE.open() as f:
         data = json.load(f)
 
-    logger.debug(
-        "Schema cache loaded: type=%s",
-        type(data).__name__,
-    )
+    logger.debug("Schema cache loaded: type=%s", type(data).__name__)
 
-    if isinstance(data, list):
+    if isinstance(data, dict):
+        items_raw = data.get("items", [])
+    elif isinstance(data, list):
         items_raw = data
     else:
-        items_raw = data.get("items") if isinstance(data, dict) else None
-        if items_raw is not None:
-            logger.warning("Unexpected object root in schema, using 'items' key")
+        items_raw = []
 
     if not isinstance(items_raw, list):
         logger.warning("Schema cache not a list; type=%s", type(data).__name__)


### PR DESCRIPTION
## Summary
- parse schema files from object root
- parse backpack.tf prices using defindex and quality
- adjust example tests for new formats
- update Flask app price loader

## Testing
- `pre-commit run --files utils/schema_fetcher.py utils/price_fetcher.py services/pricing_service.py tests/test_schema_fetcher.py tests/test_pricing_service.py app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ff4c751408326841b40c589793b91