### PR TITLE
Fix schema loader: extract 'items' list from autobot schema

### DIFF
--- a/utils/schema_fetcher.py
+++ b/utils/schema_fetcher.py
@@ -40,16 +40,14 @@ def _load_schema() -> Dict[str, Any]:
 
     logger.debug("Schema cache loaded: type=%s", type(data).__name__)
 
-    if isinstance(data, dict):
-        items_raw = data.get("items", [])
-    elif isinstance(data, list):
-        items_raw = data
-    else:
-        items_raw = []
+    if not isinstance(data, dict):
+        logger.error("Schema cache not an object; type=%s", type(data).__name__)
+        return {}
 
+    items_raw = data.get("items", [])
     if not isinstance(items_raw, list):
-        logger.warning("Schema cache not a list; type=%s", type(data).__name__)
-        items_raw = []
+        logger.error("Schema 'items' not a list; type=%s", type(items_raw).__name__)
+        return {}
 
     logger.debug(
         "Schema items structure: type=%s count=%s",
@@ -69,7 +67,6 @@ def _load_schema() -> Dict[str, Any]:
         key = f"{defindex};{quality};{1 if craftable else 0}"
         items[key] = item
 
-    logger.info("Loaded %s schema items", len(items))
     return items
 
 
@@ -86,6 +83,7 @@ def ensure_schema_cached() -> Dict[str, Any]:
         logger.info("Schema cache is still fresh")
 
     SCHEMA = _load_schema()
+    logger.info("Loaded %s schema items", len(SCHEMA))
     return SCHEMA
 
 


### PR DESCRIPTION
## Summary
- parse cached schema expecting a dict with 'items'
- log and return empty mapping if schema file doesn't match expected shape
- move item count logging into `ensure_schema_cached`

## Testing
- `pre-commit run --files utils/schema_fetcher.py tests/test_schema_fetcher.py tests/test_inventory_processor.py tests/test_app_import.py tests/test_user_template.py tests/test_utils_extras.py tests/test_pricing_service.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ff76a70b48326b5d3aa9cdb25494f