### PR TITLE
Improve schema and price cache handling

### DIFF
--- a/tests/test_app_import.py
+++ b/tests/test_app_import.py
@@ -10,6 +10,14 @@ def test_app_uses_mock_schema(monkeypatch):
         return mock_schema
 
     monkeypatch.setattr("utils.schema_fetcher.ensure_schema_cached", fake_ensure)
+    monkeypatch.setattr(
+        "utils.price_fetcher.ensure_prices_cached",
+        lambda: {"5;0": {"value": 100, "currency": "metal", "last_update": 1}},
+    )
+    monkeypatch.setattr(
+        "utils.price_fetcher.ensure_currencies_cached",
+        lambda: {"metal": {"value": 1}, "keys": {"value": 1}},
+    )
     monkeypatch.setenv("STEAM_API_KEY", "x")
     monkeypatch.setenv("BACKPACK_API_KEY", "x")
     app = importlib.import_module("app")

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -153,7 +153,18 @@ def test_fetch_inventory_statuses(monkeypatch, payload, expected):
 def test_user_template_safe(monkeypatch, status):
     monkeypatch.setenv("STEAM_API_KEY", "x")
     monkeypatch.setenv("BACKPACK_API_KEY", "x")
-    monkeypatch.setattr("utils.schema_fetcher.ensure_schema_cached", lambda: {})
+    monkeypatch.setattr(
+        "utils.schema_fetcher.ensure_schema_cached",
+        lambda: {"1;0;1": {"defindex": 1, "quality": 0, "craftable": True}},
+    )
+    monkeypatch.setattr(
+        "utils.price_fetcher.ensure_prices_cached",
+        lambda: {"1;0": {"value": 1, "currency": "metal", "last_update": 0}},
+    )
+    monkeypatch.setattr(
+        "utils.price_fetcher.ensure_currencies_cached",
+        lambda: {"metal": {"value": 1}, "keys": {"value": 1}},
+    )
     import importlib
 
     app = importlib.import_module("app")

--- a/tests/test_schema_fetcher.py
+++ b/tests/test_schema_fetcher.py
@@ -33,10 +33,13 @@ def test_schema_cache_miss(tmp_path, monkeypatch):
 
     class DummyResp:
         def __init__(self, payload):
-            self.content = json.dumps(payload).encode()
+            self.payload = payload
 
         def raise_for_status(self):
             pass
+
+        def json(self):
+            return self.payload
 
     payload = {
         "items": [
@@ -50,9 +53,8 @@ def test_schema_cache_miss(tmp_path, monkeypatch):
         ]
     }
 
-    def fake_get(url, stream=False, timeout=20):
+    def fake_get(url, timeout=20):
         assert url == sf.SCHEMA_URL
-        assert stream is True
         return DummyResp(payload)
 
     monkeypatch.setattr(sf.requests, "get", fake_get)

--- a/tests/test_user_template.py
+++ b/tests/test_user_template.py
@@ -10,7 +10,18 @@ HTML = '{% include "_user.html" %}'
 def app(monkeypatch):
     monkeypatch.setenv("STEAM_API_KEY", "x")
     monkeypatch.setenv("BACKPACK_API_KEY", "x")
-    monkeypatch.setattr("utils.schema_fetcher.ensure_schema_cached", lambda: {})
+    monkeypatch.setattr(
+        "utils.schema_fetcher.ensure_schema_cached",
+        lambda: {"1;0;1": {"defindex": 1, "quality": 0, "craftable": True}},
+    )
+    monkeypatch.setattr(
+        "utils.price_fetcher.ensure_prices_cached",
+        lambda: {"1;0": {"value": 1, "currency": "metal", "last_update": 0}},
+    )
+    monkeypatch.setattr(
+        "utils.price_fetcher.ensure_currencies_cached",
+        lambda: {"metal": {"value": 1}, "keys": {"value": 1}},
+    )
     mod = importlib.import_module("app")
     importlib.reload(mod)
     return mod.app

--- a/utils/price_fetcher.py
+++ b/utils/price_fetcher.py
@@ -1,21 +1,29 @@
+"""Backpack.tf price caching utilities."""
+
+from __future__ import annotations
+
 import os
 import json
 import time
 import logging
+from pathlib import Path
+from typing import Any, Dict
+
 import requests
 
-PRICE_TTL = 48 * 60 * 60  # 48 hours
-CACHE_DIR = "data"
-PRICE_CACHE = f"{CACHE_DIR}/cached_prices.json"
-CURR_CACHE = f"{CACHE_DIR}/cached_currencies.json"
-KEY = os.getenv("BACKPACK_API_KEY")
-if not KEY:
-    raise RuntimeError("BACKPACK_API_KEY not set. Please set it in .env or export it.")
+PRICE_TTL = 48 * 60 * 60  # refresh every other day
+CACHE_DIR = Path("data")
+PRICE_CACHE = CACHE_DIR / "backpack_prices.json"
+CURR_CACHE = CACHE_DIR / "backpack_currencies.json"
 
 logger = logging.getLogger(__name__)
 
+PRICES_RAW: Dict[str, Any] | None = None
+CURRENCIES: Dict[str, Any] | None = None
+KEY_RATE: float | None = None
 
-def _parse_prices(payload: dict) -> dict[str, dict]:
+
+def _parse_prices(payload: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
     items: dict[str, dict] = {}
     response = payload.get("response", {})
     for info in response.get("items", {}).values():
@@ -41,47 +49,131 @@ def _parse_prices(payload: dict) -> dict[str, dict]:
     return items
 
 
-def ensure_prices_cached():
-    fresh = (
-        os.path.exists(PRICE_CACHE)
-        and time.time() - os.path.getmtime(PRICE_CACHE) < PRICE_TTL
-    )
-    if fresh:
-        with open(PRICE_CACHE) as f:
-            data = json.load(f)
-        logger.info("Price cache HIT: %s entries", len(data))
-        return data
-
-    logger.info("Fetching prices from backpack.tf")
-    url = f"https://backpack.tf/api/IGetPrices/v4?key={KEY}&compress=1"
+def _fetch_json(url: str) -> Dict[str, Any]:
     r = requests.get(url, timeout=20)
     r.raise_for_status()
-    payload = r.json()
-    items = _parse_prices(payload)
-
-    os.makedirs(CACHE_DIR, exist_ok=True)
-    with open(PRICE_CACHE, "w") as f:
-        json.dump(items, f)
-    logger.info("Price cache updated: %s entries", len(items))
-    return items
+    return r.json()
 
 
-def ensure_currencies_cached():
-    if (
-        os.path.exists(CURR_CACHE)
-        and time.time() - os.path.getmtime(CURR_CACHE) < PRICE_TTL
-    ):
-        with open(CURR_CACHE) as f:
-            data = json.load(f)
-        logger.info("Currency cache HIT: %s entries", len(data))
-        return data
-    logger.info("Fetching currency rates from backpack.tf")
-    url = f"https://backpack.tf/api/IGetCurrencies/v1?key={KEY}"
-    r = requests.get(url, timeout=10)
-    r.raise_for_status()
-    data = r.json()["response"]["currencies"]
-    os.makedirs(CACHE_DIR, exist_ok=True)
-    with open(CURR_CACHE, "w") as f:
-        json.dump(data, f)
-    logger.info("Currency cache updated: %s entries", len(data))
-    return data
+def ensure_prices_cached() -> Dict[str, Any]:
+    """Load or refresh item price cache."""
+
+    global PRICES_RAW
+
+    if PRICES_RAW is not None:
+        return PRICES_RAW
+
+    api_key = os.getenv("BACKPACK_API_KEY")
+    if not api_key:
+        raise RuntimeError("BACKPACK_API_KEY not set")
+
+    fresh = (
+        PRICE_CACHE.exists() and time.time() - PRICE_CACHE.stat().st_mtime < PRICE_TTL
+    )
+    if fresh:
+        try:
+            with PRICE_CACHE.open() as f:
+                PRICES_RAW = json.load(f)
+            logger.info("Price cache HIT: %s entries", len(PRICES_RAW))
+            return PRICES_RAW
+        except Exception:
+            logger.warning("Price cache malformed, refetching")
+
+    try:
+        payload = _fetch_json(
+            f"https://backpack.tf/api/IGetPrices/v4?key={api_key}&compress=1"
+        )
+        PRICES_RAW = _parse_prices(payload)
+        PRICE_CACHE.parent.mkdir(parents=True, exist_ok=True)
+        with PRICE_CACHE.open("w") as f:
+            json.dump(PRICES_RAW, f)
+        logger.info("Fetched prices: %s entries", len(PRICES_RAW))
+    except Exception as exc:
+        logger.error("Price fetch failed: %s", exc)
+        if PRICE_CACHE.exists():
+            with PRICE_CACHE.open() as f:
+                PRICES_RAW = json.load(f)
+            logger.warning("Using cached price data (%s entries)", len(PRICES_RAW))
+        else:
+            raise RuntimeError("No price data available") from exc
+
+    return PRICES_RAW
+
+
+def ensure_currencies_cached() -> Dict[str, Any]:
+    """Load or refresh currency rates."""
+
+    global CURRENCIES, KEY_RATE
+
+    if CURRENCIES is not None:
+        return CURRENCIES
+
+    api_key = os.getenv("BACKPACK_API_KEY")
+    if not api_key:
+        raise RuntimeError("BACKPACK_API_KEY not set")
+
+    fresh = CURR_CACHE.exists() and time.time() - CURR_CACHE.stat().st_mtime < PRICE_TTL
+    if fresh:
+        try:
+            with CURR_CACHE.open() as f:
+                CURRENCIES = json.load(f)
+            logger.info("Currency cache HIT")
+        except Exception:
+            logger.warning("Currency cache malformed, refetching")
+            CURRENCIES = None
+
+    if CURRENCIES is None:
+        try:
+            payload = _fetch_json(
+                f"https://backpack.tf/api/IGetCurrencies/v1?key={api_key}"
+            )
+            CURRENCIES = payload.get("response", {}).get("currencies", {})
+            CURR_CACHE.parent.mkdir(parents=True, exist_ok=True)
+            with CURR_CACHE.open("w") as f:
+                json.dump(CURRENCIES, f)
+            logger.info("Fetched currency rates")
+        except Exception as exc:
+            logger.error("Currency fetch failed: %s", exc)
+            if CURR_CACHE.exists():
+                with CURR_CACHE.open() as f:
+                    CURRENCIES = json.load(f)
+                logger.warning("Using cached currency data")
+            else:
+                raise RuntimeError("No currency data available") from exc
+
+    metal_val = CURRENCIES.get("metal", {}).get("value")
+    key_val = CURRENCIES.get("keys", {}).get("value")
+    KEY_RATE = key_val / metal_val if metal_val else 0.0
+    return CURRENCIES
+
+
+def get_price_for_sku(sku: str) -> str:
+    """Return formatted price for the given SKU."""
+
+    if PRICES_RAW is None:
+        ensure_prices_cached()
+    if KEY_RATE is None:
+        ensure_currencies_cached()
+
+    price = PRICES_RAW.get(sku) if PRICES_RAW else None
+    if not price:
+        return "Unknown Value"
+
+    value = price.get("value", 0)
+    currency = price.get("currency", "metal")
+
+    if currency == "keys":
+        keys = int(value)
+        ref = round((value - keys) * KEY_RATE, 2)
+    else:
+        keys = int(value // KEY_RATE) if KEY_RATE else 0
+        ref = round(value - keys * KEY_RATE, 2)
+
+    parts = []
+    if keys:
+        parts.append(f"{keys} key{'s' if keys != 1 else ''}")
+    if ref:
+        parts.append(f"{ref:.2f} ref")
+    if not parts:
+        return "0 ref"
+    return " ".join(parts)


### PR DESCRIPTION
## Summary
- refresh schema daily and improve caching logic
- add retries and fallbacks for schema and price fetching
- support formatted price lookup
- verify caches during app startup
- adjust unit tests for new behavior

## Testing
- `black app.py tests/test_schema_fetcher.py tests/test_app_import.py tests/test_user_template.py tests/test_inventory_processor.py utils/schema_fetcher.py utils/price_fetcher.py`
- `ruff check app.py utils/schema_fetcher.py utils/price_fetcher.py tests/test_schema_fetcher.py tests/test_app_import.py tests/test_user_template.py tests/test_inventory_processor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ffb1a040c8326ab8fa7b6f5a32593