### PR TITLE
Load .env automatically when running app.py and fail fast if keys missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ BACKPACK_API_KEY=your_backpack_key
 
 The application uses **python-dotenv** to load these values at runtime.
 
+## Running locally
+
+```bash
+cp .env.example .env   # then edit keys
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+python app.py
+```
+
 ## Usage
 
 ```bash

--- a/app.py
+++ b/app.py
@@ -5,6 +5,13 @@ from types import SimpleNamespace
 
 from dotenv import load_dotenv
 
+load_dotenv()
+if not os.getenv("STEAM_API_KEY") or not os.getenv("BACKPACK_API_KEY"):
+    raise RuntimeError(
+        "Required env vars missing: STEAM_API_KEY and/or BACKPACK_API_KEY. "
+        "Make sure you have a .env file or export them."
+    )
+
 import requests
 from flask import Flask, render_template, request, flash
 from utils.id_parser import extract_steam_ids
@@ -12,12 +19,8 @@ from utils.schema_fetcher import ensure_schema_cached
 from utils.inventory_processor import enrich_inventory
 from utils import steam_api_client as sac
 
-load_dotenv()
-STEAM_API_KEY = os.getenv("STEAM_API_KEY")
-BACKPACK_API_KEY = os.getenv("BACKPACK_API_KEY")
-
-if not STEAM_API_KEY or not BACKPACK_API_KEY:
-    raise ValueError("STEAM_API_KEY and BACKPACK_API_KEY must be set")
+STEAM_API_KEY = os.environ["STEAM_API_KEY"]
+BACKPACK_API_KEY = os.environ["BACKPACK_API_KEY"]
 
 app = Flask(__name__)
 

--- a/tests/test_env_loading.py
+++ b/tests/test_env_loading.py
@@ -1,0 +1,21 @@
+import importlib
+import sys
+
+import pytest
+
+
+def test_missing_env_vars_raises(monkeypatch):
+    monkeypatch.delenv("STEAM_API_KEY", raising=False)
+    monkeypatch.delenv("BACKPACK_API_KEY", raising=False)
+    monkeypatch.setattr("utils.schema_fetcher.ensure_schema_cached", lambda: {})
+    sys.modules.pop("app", None)
+    with pytest.raises(RuntimeError):
+        importlib.import_module("app")
+
+
+def test_env_present_allows_import(monkeypatch):
+    monkeypatch.setenv("STEAM_API_KEY", "x")
+    monkeypatch.setenv("BACKPACK_API_KEY", "y")
+    monkeypatch.setattr("utils.schema_fetcher.ensure_schema_cached", lambda: {})
+    sys.modules.pop("app", None)
+    importlib.import_module("app")

--- a/utils/schema_fetcher.py
+++ b/utils/schema_fetcher.py
@@ -60,8 +60,6 @@ def ensure_schema_cached(api_key: str | None = None) -> Dict[str, Any]:
     """Return cached item schema mapping."""
     if api_key is None:
         api_key = os.getenv("STEAM_API_KEY")
-    if not api_key:
-        raise ValueError("STEAM_API_KEY is required to fetch item schema")
 
     global SCHEMA, QUALITIES
     if CACHE_FILE.exists():

--- a/utils/steam_api_client.py
+++ b/utils/steam_api_client.py
@@ -6,9 +6,6 @@ import requests
 
 STEAM_API_KEY = os.getenv("STEAM_API_KEY")
 
-if not STEAM_API_KEY:
-    raise ValueError("STEAM_API_KEY is required")
-
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## Summary
- load environment from `.env` before importing local modules
- raise a clear `RuntimeError` if `STEAM_API_KEY` or `BACKPACK_API_KEY` are unset
- drop redundant env var checks in helper modules
- add tests for env loading behaviour
- document how to run the app locally

## Testing
- `pytest -q`
- `python app.py` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_686002810c908326a91bebb338016a0d