### PR TITLE
Add warpaint mapping utility

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -309,6 +309,10 @@ PyYAML==6.0.2 \
 responses==0.25.0 \
     --hash=sha256:2f0b9c2b6437db4b528619a77e5d565e4ec2a9532162ac1a131a83529db7be1a \
     # via -r requirements.txt
+vdf==3.4 \
+    --hash=sha256:fd5419f41e07a1009e5ffd027c7dcbe43d1f7e8ef453aeaa90d9d04b807de2af 
+    --hash=sha256:68c1a125cc49e343d535af2dd25074e9cb0908c6607f073947c4a04bbe234534 
+    # via -r requirements.txt
 werkzeug==3.1.3 \
     --hash=sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e \
     --hash=sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ python-dotenv==1.1.1
 pytest==8.4.0
 pytest-cov==6.2.1
 responses==0.25.0
+
+vdf==3.4

--- a/tests/test_warpaint_mapping.py
+++ b/tests/test_warpaint_mapping.py
@@ -1,0 +1,14 @@
+from utils.warpaint_mapping import generate_warpaint_mapping
+
+
+def test_generate_warpaint_mapping():
+    data = {
+        "items": {"15013": {"item_name": "Scattergun", "paintkit": "1"}},
+        "paintkits": {"1": {"name": "Macabre Web"}},
+    }
+    mapping = generate_warpaint_mapping(data)
+    assert (
+        mapping["15013;decorated;5"]
+        == "War-painted Scattergun (Macabre Web) (Factory New)"
+    )
+    assert len(mapping) == 5

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,13 @@
+"""Utility package for TF2 inventory scanner."""
+
+from . import id_parser, inventory_processor, schema_fetcher, steam_api_client
+from .warpaint_mapping import generate_warpaint_mapping, load_items_game
+
+__all__ = [
+    "id_parser",
+    "inventory_processor",
+    "schema_fetcher",
+    "steam_api_client",
+    "generate_warpaint_mapping",
+    "load_items_game",
+]

--- a/utils/warpaint_mapping.json
+++ b/utils/warpaint_mapping.json
@@ -1,0 +1,7 @@
+{
+  "15013;decorated;1": "War-painted Scattergun (Macabre Web) (Battle-Scarred)",
+  "15013;decorated;2": "War-painted Scattergun (Macabre Web) (Well-Worn)",
+  "15013;decorated;3": "War-painted Scattergun (Macabre Web) (Field-Tested)",
+  "15013;decorated;4": "War-painted Scattergun (Macabre Web) (Minimal Wear)",
+  "15013;decorated;5": "War-painted Scattergun (Macabre Web) (Factory New)"
+}

--- a/utils/warpaint_mapping.py
+++ b/utils/warpaint_mapping.py
@@ -1,0 +1,75 @@
+"""Utilities for building a decorated weapon name mapping."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+import vdf
+
+WEAR_TIERS = {
+    1: "Battle-Scarred",
+    2: "Well-Worn",
+    3: "Field-Tested",
+    4: "Minimal Wear",
+    5: "Factory New",
+}
+
+
+def load_items_game(path: str | Path) -> Dict[str, Any]:
+    """Load items_game data from JSON or VDF file."""
+    p = Path(path)
+    text = p.read_text()
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        data = vdf.loads(text)
+    return data.get("items_game", data)
+
+
+def generate_warpaint_mapping(items_game: Dict[str, Any]) -> Dict[str, str]:
+    """Return mapping of decorated weapons to display names."""
+    items = items_game.get("items", {})
+    paintkits = items_game.get("paintkits", {})
+    kit_names = {
+        str(k): v.get("name") or v.get("description_string", str(k))
+        for k, v in paintkits.items()
+    }
+
+    mapping: Dict[str, str] = {}
+    for defindex, item in items.items():
+        paintkit = item.get("paintkit")
+        if not paintkit:
+            continue
+        base_name = item.get("item_name") or item.get("name") or f"Item #{defindex}"
+        kit_name = kit_names.get(str(paintkit), str(paintkit))
+        for wear_id, wear_name in WEAR_TIERS.items():
+            key = f"{defindex};decorated;{wear_id}"
+            display = f"War-painted {base_name} ({kit_name}) ({wear_name})"
+            mapping[key] = display
+    return mapping
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Generate warpaint mapping")
+    parser.add_argument("items_game", type=Path)
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=Path("utils/warpaint_mapping.json"),
+    )
+    args = parser.parse_args(argv)
+
+    data = load_items_game(args.items_game)
+    mapping = generate_warpaint_mapping(data)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("w") as f:
+        json.dump(mapping, f, indent=2, sort_keys=True)
+    print(f"Wrote {len(mapping)} entries to {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a small utility to parse items_game and build decorated weapon names
- export the new helper in `utils.__init__`
- add sample mapping json file
- add tests for `generate_warpaint_mapping`
- include `vdf` dependency

## Testing
- `pre-commit run --files utils/warpaint_mapping.py utils/__init__.py tests/test_warpaint_mapping.py requirements.txt requirements.lock utils/warpaint_mapping.json`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68600c76422c832682932933b2e01974