### PR TITLE
Improve UI layout and styling

### DIFF
--- a/app.py
+++ b/app.py
@@ -130,15 +130,12 @@ def index():
                 "index.html",
                 users=users,
                 steamids=steamids_input,
-                valid_count=0,
-                invalid_count=len(invalid),
+                ids=[],
             )
     return render_template(
         "index.html",
         users=users,
         steamids=steamids_input,
-        valid_count=len(ids) if request.method == "POST" else 0,
-        invalid_count=len(invalid) if request.method == "POST" else 0,
         ids=ids,
     )
 

--- a/static/style.css
+++ b/static/style.css
@@ -3,6 +3,7 @@ body {
     color: #e0e0e0;
     font-family: "Inter", "Segoe UI", "Helvetica Neue", sans-serif;
     margin: 2em;
+    line-height: 1.5;
 }
 
 input,
@@ -25,24 +26,89 @@ button {
     cursor: pointer;
 }
 
+.input-form {
+    text-align: center;
+    margin-bottom: 1rem;
+}
+
+.input-wrapper {
+    position: relative;
+    display: flex;
+    align-items: center;
+    max-width: 400px;
+    margin: 0 auto;
+}
+
+.input-wrapper textarea {
+    width: 100%;
+    padding: 8px 8px 8px 36px;
+    border-radius: 6px;
+    resize: vertical;
+}
+
+.steam-icon {
+    position: absolute;
+    left: 10px;
+    color: #888;
+    pointer-events: none;
+}
+
+.input-wrapper textarea:focus {
+    box-shadow: 0 0 0 2px #4285f4;
+    outline: none;
+}
+
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.primary-btn,
+.refresh-btn {
+    background-color: #333;
+    border: none;
+    border-radius: 6px;
+    color: #fff;
+}
+
+.primary-btn {
+    margin-top: 8px;
+    padding: 8px 12px;
+}
+
+.refresh-btn {
+    padding: 6px 12px;
+    margin-bottom: 16px;
+}
+
 .items {
     display: flex;
     overflow-x: auto;
     gap: 4px;
 }
 
+
 .item-card {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: flex-start;
-  min-width: 120px;
+  justify-content: flex-end;
+  width: 120px;
+  aspect-ratio: 1 / 1;
   padding: 8px;
   border: 1px solid #333;
   border-radius: 4px;
   margin: 4px;
   background: rgba(40, 40, 40, 0.8);
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+  overflow: hidden;
   transition: transform 0.1s, box-shadow 0.1s;
 }
 
@@ -50,18 +116,23 @@ button {
   transform: translateY(-2px);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
 }
-.item-card img {
-  display: block;
+.item-img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
 }
 .missing-icon {
-  width: 32px;
-  height: 32px;
+  width: 100%;
+  height: 100%;
   background: #444;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .item-name {
-  font-size: 13px;
-  color: #fff;
+  font-size: 14px;
+  font-weight: 600;
   text-align: center;
   margin-top: 4px;
   width: 100%;
@@ -69,3 +140,24 @@ button {
 }
 
 .tf2-hours { margin-left: 6px; font-size: 0.9em; }
+
+.page-footer {
+  margin-top: 2rem;
+  text-align: center;
+  font-size: 0.8rem;
+  color: #aaa;
+}
+
+.page-footer .fa-steam-symbol {
+  font-size: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+
+@media (max-width: 600px) {
+  body {
+    margin: 1em;
+  }
+  .items {
+    gap: 2px;
+  }
+}

--- a/templates/_user.html
+++ b/templates/_user.html
@@ -25,13 +25,13 @@
       {% for item in user.items %}
         <div class="item-card" style="border-color: {{ item.quality_color }};">
           {% if item.final_url %}
-            <img src="{{ item.final_url }}" alt="{{ item.name }}" width="32" height="32">
+            <img src="{{ item.final_url }}" alt="{{ item.name }}" class="item-img">
           {% else %}
             <div class="missing-icon"></div>
           {% endif %}
           <div class="item-name">{{ item.name }}</div>
         </div>
       {% endfor %}
-    </div>
+      </div>
   </div>
 </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,10 +4,8 @@
     <meta charset="UTF-8">
     <title>TF2 Inventory Checker</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SzlrxWUlpfUZ2x+pcUCos9rqPhtwzXubcjoCz1uyjq8q2+mZ4c4WxJJgAOQh2AnGkacD1x0gRhFeojVk51Pp1w==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <style>
-        body { background-color: #121212; color: #e0e0e0; font-family: "Inter", "Segoe UI", "Helvetica Neue", sans-serif; margin: 2em; }
-        textarea { width: 100%; height: 100px; background-color: #1e1e1e; border: 1px solid #333; color: #fff; }
-        button { background-color: #1e1e1e; border: 1px solid #333; color: #fff; padding: 6px 12px; }
         img { vertical-align: middle; }
         .pill {
             background: #666;
@@ -32,19 +30,23 @@
             </ul>
         {% endif %}
     {% endwith %}
-    <form method="post">
-        <label for="steamids">Enter SteamIDs (separated by space, comma or newline):</label><br>
-        <textarea id="steamids" name="steamids">{{ steamids|default('') }}</textarea><br>
-        <button type="submit">Check Inventories</button>
+    <form method="post" class="input-form">
+        <label for="steamids" class="visually-hidden">Steam IDs</label>
+        <div class="input-wrapper">
+            <i class="fa-brands fa-steam steam-icon"></i>
+            <textarea id="steamids" name="steamids" placeholder="Enter SteamID, vanity URL, or multiple IDs…">{{ steamids|default('') }}</textarea>
+        </div>
+        <button type="submit" class="primary-btn"><i class="fa-solid fa-magnifying-glass"></i> Check Inventories</button>
     </form>
 
-    {% if request.method == 'POST' %}
-        <p>Processed {{ valid_count }} valid IDs{% if invalid_count %} (ignored {{ invalid_count }} invalid){% endif %}.</p>
-    {% endif %}
-
-    <button id="retry-all" disabled>Refresh Failed</button>
+    <button id="retry-all" disabled class="refresh-btn"><i class="fa-solid fa-arrows-rotate"></i> Refresh Failed</button>
 
     <div id="user-container"></div>
+
+    <footer class="page-footer">
+        <i class="fa-brands fa-steam-symbol"></i>
+        <div class="footer-text">This site is not affiliated with Valve Corporation.<br>Team Fortress 2 content © Valve Corporation.</div>
+    </footer>
 
     <script>
       window.initialIds = {{ ids|tojson|safe }};


### PR DESCRIPTION
## Summary
- drop processed counts from the index page
- add Font Awesome and restyled inputs and buttons
- revamp inventory cards with larger images
- add attribution footer and responsive layout

## Testing
- `pre-commit run --files app.py templates/index.html templates/_user.html static/style.css`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68600effd260832683b381cc80b42539