### PR TITLE
Improve inventory UI layout and fix broken item rendering

### DIFF
--- a/static/img/steam_logo.svg
+++ b/static/img/steam_logo.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
+  <circle cx="128" cy="128" r="128" fill="black"/>
+  <circle cx="176" cy="80" r="60" fill="white"/>
+  <circle cx="176" cy="80" r="40" fill="black"/>
+  <circle cx="80" cy="176" r="40" fill="white"/>
+  <path d="M110 160 l50 -30" stroke="white" stroke-width="20" fill="none"/>
+</svg>

--- a/static/retry.js
+++ b/static/retry.js
@@ -8,6 +8,10 @@ function appendCard(html) {
 }
 
 function refreshCard(id) {
+  const pill = document.querySelector('#user-' + id + ' .status-pill');
+  if (pill) {
+    pill.innerHTML = '<i class="fa-solid fa-arrows-rotate fa-spin"></i>';
+  }
   return fetch('/retry/' + id, { method: 'POST' })
     .then(r => r.text())
     .then(html => {

--- a/static/style.css
+++ b/static/style.css
@@ -85,7 +85,19 @@ button {
 
 .refresh-btn {
     padding: 6px 12px;
+    margin-left: 8px;
+}
+
+.form-actions {
+    display: flex;
+    justify-content: center;
+    gap: 8px;
+    margin-top: 8px;
     margin-bottom: 16px;
+}
+
+#user-container {
+    margin-top: 16px;
 }
 
 .items {
@@ -94,14 +106,44 @@ button {
     gap: 4px;
 }
 
+.status-pill {
+    background: transparent;
+    border: 1px solid transparent;
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 0.8em;
+    margin-left: 4px;
+    cursor: default;
+    transition: background 0.2s;
+}
+
+.status-pill.parsed {
+    color: #6fdc6f;
+    border-color: #4caf50;
+}
+
+.status-pill.private {
+    color: #ccc;
+    border-color: #777;
+}
+
+.status-pill.failed {
+    color: #ffaaaa;
+    border-color: #c00;
+    cursor: pointer;
+}
+
+.status-pill.failed:hover {
+    background: rgba(255, 0, 0, 0.1);
+}
+
 
 .item-card {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: flex-end;
-  width: 120px;
-  aspect-ratio: 1 / 1;
+  width: 140px;
+  height: 200px;
   padding: 8px;
   border: 1px solid #333;
   border-radius: 4px;
@@ -109,21 +151,21 @@ button {
   background: rgba(40, 40, 40, 0.8);
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
   overflow: hidden;
-  transition: transform 0.1s, box-shadow 0.1s;
+  transition: transform 0.2s, box-shadow 0.2s;
 }
 
 .item-card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+  transform: translateY(-2px) scale(1.03);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.5);
 }
 .item-img {
   width: 100%;
-  height: 100%;
+  height: 50%;
   object-fit: contain;
 }
 .missing-icon {
   width: 100%;
-  height: 100%;
+  height: 50%;
   background: #444;
   display: flex;
   align-items: center;
@@ -134,7 +176,7 @@ button {
   font-size: 14px;
   font-weight: 600;
   text-align: center;
-  margin-top: 4px;
+  margin-top: 8px;
   width: 100%;
   word-break: break-word;
 }
@@ -148,10 +190,7 @@ button {
   color: #aaa;
 }
 
-.page-footer .fa-steam-symbol {
-  font-size: 1.5rem;
-  margin-bottom: 0.5rem;
-}
+
 
 @media (max-width: 600px) {
   body {

--- a/templates/_user.html
+++ b/templates/_user.html
@@ -5,13 +5,13 @@
     </a>
     {{ user.username }}
     <span class="tf2-hours">TF2 Playtime: {{ user.playtime }} hrs</span>
-    <span class="pill {{ user.status }}{% if user.status == 'failed' %} retry-pill{% endif %}" {% if user.status == 'failed' %}data-steamid="{{ user.steamid }}" title="click to retry"{% endif %}>
+    <span class="pill status-pill {{ user.status }}{% if user.status == 'failed' %} retry-pill{% endif %}" {% if user.status == 'failed' %}data-steamid="{{ user.steamid }}" title="Retry scan for this user"{% endif %}>
       {% if user.status == 'parsed' %}
-        ✅ Public
+        <i class="fa-solid fa-check"></i> Public
       {% elif user.status == 'private' %}
-        🔒 Private
+        <i class="fa-solid fa-lock"></i> Private
       {% else %}
-        🔄 Failed
+        <i class="fa-solid fa-arrows-rotate"></i> Failed
       {% endif %}
     </span>
   </h2>

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,18 +7,6 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SzlrxWUlpfUZ2x+pcUCos9rqPhtwzXubcjoCz1uyjq8q2+mZ4c4WxJJgAOQh2AnGkacD1x0gRhFeojVk51Pp1w==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <style>
         img { vertical-align: middle; }
-        .pill {
-            background: #666;
-            color: #fff;
-            padding: 2px 6px;
-            border-radius: 4px;
-            font-size: 0.8em;
-            margin-left: 4px;
-            cursor: default;
-        }
-        .parsed { background: #4caf50; }
-        .private { background: #999; }
-        .failed { background: #c00; cursor: pointer; }
     </style>
 </head>
 <body>
@@ -36,16 +24,17 @@
             <i class="fa-brands fa-steam steam-icon"></i>
             <textarea id="steamids" name="steamids" placeholder="Enter SteamID, vanity URL, or multiple IDs…">{{ steamids|default('') }}</textarea>
         </div>
-        <button type="submit" class="primary-btn"><i class="fa-solid fa-magnifying-glass"></i> Check Inventories</button>
+        <div class="form-actions">
+            <button type="submit" class="primary-btn"><i class="fa-solid fa-magnifying-glass"></i> Check Inventories</button>
+            <button id="retry-all" disabled class="refresh-btn"><i class="fa-solid fa-arrows-rotate"></i> Refresh Failed</button>
+        </div>
     </form>
-
-    <button id="retry-all" disabled class="refresh-btn"><i class="fa-solid fa-arrows-rotate"></i> Refresh Failed</button>
 
     <div id="user-container"></div>
 
     <footer class="page-footer">
-        <i class="fa-brands fa-steam-symbol"></i>
-        <div class="footer-text">This site is not affiliated with Valve Corporation.<br>Team Fortress 2 content © Valve Corporation.</div>
+        <img src="/static/img/steam_logo.svg" height="24" alt="Steam logo" />
+        Team Fortress 2 © Valve Corporation. Steam and the Steam logo are trademarks of Valve Corporation.
     </footer>
 
     <script>

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -46,7 +46,7 @@ def enrich_inventory(data: Dict[str, Any]) -> List[Dict[str, Any]]:
         if not entry:
             continue
 
-        image_path = entry.get("image_url") or ""
+        image_path = entry.get("image_url") or entry.get("image_url_large") or ""
         if image_path.startswith("http"):
             final_url = image_path
         else:


### PR DESCRIPTION
## Summary
- support `image_url_large` for missing schema icons
- update user template with FA icons and new status badges
- rearrange buttons and add Valve footer snippet
- redesign CSS for item cards and status pills
- show loading spinner during refresh

## Testing
- `pre-commit run --files utils/inventory_processor.py templates/index.html templates/_user.html static/style.css static/retry.js static/img/steam_logo.svg`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68601239c948832684611cd0a44536f7