### PR TITLE
Fix item card layout

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -142,11 +142,12 @@ button {
   display: flex;
   flex-direction: column;
   align-items: center;
-  width: 140px;
-  height: 200px;
+  justify-content: space-between;
+  width: 100px;
+  height: 140px;
   padding: 8px;
-  border: 1px solid #333;
-  border-radius: 4px;
+  border: 1px solid;
+  border-radius: 10px;
   margin: 4px;
   background: rgba(40, 40, 40, 0.8);
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
@@ -159,9 +160,11 @@ button {
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.5);
 }
 .item-img {
-  width: 100%;
-  height: 50%;
+  width: 64px;
+  height: 64px;
+  display: block;
   object-fit: contain;
+  margin: 0 auto;
 }
 .missing-icon {
   width: 100%;
@@ -173,12 +176,10 @@ button {
 }
 
 .item-name {
-  font-size: 14px;
-  font-weight: 600;
+  font-size: 12px;
   text-align: center;
-  margin-top: 8px;
-  width: 100%;
   word-break: break-word;
+  max-width: 100%;
 }
 
 .tf2-hours { margin-left: 6px; font-size: 0.9em; }
@@ -198,5 +199,10 @@ button {
   }
   .items {
     gap: 2px;
+    overflow-x: auto;
+  }
+  .item-card {
+    width: 80px;
+    height: 120px;
   }
 }


### PR DESCRIPTION
## Summary
- fix `.item-img` so item icons show up
- simplify and resize item card layout
- improve `.item-name` readability
- tweak mobile layout for horizontal scrolling

## Testing
- `pre-commit run --files static/style.css`

------
https://chatgpt.com/codex/tasks/task_e_68601a09d94883269070ada5c5d73cc5