### PR TITLE
Add horizontally scrollable inventory grid

### DIFF
--- a/templates/_user.html
+++ b/templates/_user.html
@@ -21,17 +21,25 @@
     {% elif user.status == 'private' %}
       <span class="badge bg-secondary">Private</span>
     {% endif %}
-    <div class="inventory-container">
-      {% for item in user.items %}
-        <div class="item-card" style="border-color: {{ item.quality_color }};">
-          {% if item.final_url %}
-            <img class="item-img" src="{{ item.final_url }}" alt="{{ item.name }}" onerror="this.style.display='none';">
-          {% else %}
-            <div class="missing-icon"></div>
-          {% endif %}
-          <div class="item-name">{{ item.name }}</div>
-        </div>
-      {% endfor %}
+    <div class="inventory-scroll">
+      <button class="scroll-arrow left" type="button" aria-label="Scroll left">
+        <i class="fa-solid fa-chevron-left"></i>
+      </button>
+      <div class="inventory-container">
+        {% for item in user.items %}
+          <div class="item-card" style="border-color: {{ item.quality_color }};">
+            {% if item.final_url %}
+              <img class="item-img" src="{{ item.final_url }}" alt="{{ item.name }}" width="64" height="64" onerror="this.style.display='none';">
+            {% else %}
+              <div class="missing-icon"></div>
+            {% endif %}
+            <div class="item-name">{{ item.name }}</div>
+          </div>
+        {% endfor %}
       </div>
+      <button class="scroll-arrow right" type="button" aria-label="Scroll right">
+        <i class="fa-solid fa-chevron-right"></i>
+      </button>
+    </div>
   </div>
 </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -16,6 +16,28 @@
             font-size: 0.8rem;
             color: #aaa;
         }
+        .inventory-scroll {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+        }
+        .inventory-scroll .inventory-container {
+            display: grid;
+            grid-template-rows: repeat(4, auto);
+            grid-auto-flow: column;
+            gap: 6px;
+            overflow-x: auto;
+            overflow-y: hidden;
+            scroll-behavior: smooth;
+        }
+        .scroll-arrow {
+            background: transparent;
+            border: none;
+            color: #fff;
+            cursor: pointer;
+            font-size: 1.4rem;
+            padding: 0 6px;
+        }
     </style>
 </head>
 <body>
@@ -52,5 +74,34 @@
       window.initialIds = {{ ids|tojson|safe }};
     </script>
     <script src="{{ url_for('static', filename='retry.js') }}"></script>
+    <script>
+      function attachScrollButtons() {
+        document.querySelectorAll('.inventory-scroll').forEach(wrapper => {
+          const container = wrapper.querySelector('.inventory-container');
+          if (!container) return;
+          const amount = container.clientWidth;
+          const left = wrapper.querySelector('.scroll-arrow.left');
+          const right = wrapper.querySelector('.scroll-arrow.right');
+          if (left) {
+            left.addEventListener('click', () => {
+              container.scrollBy({ left: -amount, behavior: 'smooth' });
+            });
+          }
+          if (right) {
+            right.addEventListener('click', () => {
+              container.scrollBy({ left: amount, behavior: 'smooth' });
+            });
+          }
+        });
+      }
+      if (window.attachHandlers) {
+        const oldAttach = window.attachHandlers;
+        window.attachHandlers = function () {
+          oldAttach();
+          attachScrollButtons();
+        };
+      }
+      document.addEventListener('DOMContentLoaded', attachScrollButtons);
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow 4-row grid for each user's inventory
- integrate left/right scroll buttons
- keep scroll handlers when cards refresh

## Testing
- `pre-commit run --files templates/_user.html templates/index.html`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68603283bc908326ba0339eeddc3c057