### PR TITLE
Integrate items_game.txt cache

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -309,6 +309,10 @@ PyYAML==6.0.2 \
 responses==0.25.0 \
     --hash=sha256:2f0b9c2b6437db4b528619a77e5d565e4ec2a9532162ac1a131a83529db7be1a \
     # via -r requirements.txt
+vdf==3.4 \
+    --hash=sha256:68c1a125cc49e343d535af2dd25074e9cb0908c6607f073947c4a04bbe234534 \
+    --hash=sha256:fd5419f41e07a1009e5ffd027c7dcbe43d1f7e8ef453aeaa90d9d04b807de2af \
+    # via -r requirements.txt
 werkzeug==3.1.3 \
     --hash=sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e \
     --hash=sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-dotenv==1.1.1
 pytest==8.4.0
 pytest-cov==6.2.1
 responses==0.25.0
+vdf==3.4

--- a/tests/test_item_name_preference.py
+++ b/tests/test_item_name_preference.py
@@ -1,0 +1,13 @@
+from utils import inventory_processor as ip
+from utils import schema_fetcher as sf
+from utils import items_game_cache as ig
+
+
+def test_enrich_inventory_prefers_items_game(monkeypatch):
+    sf.SCHEMA = {"111": {"defindex": 111, "item_name": "Wrong", "image_url": "i"}}
+    monkeypatch.setattr(
+        ig, "ensure_items_game_cached", lambda: {"items": {"111": {"name": "Correct"}}}
+    )
+    data = {"items": [{"defindex": 111, "quality": 6}]}
+    items = ip.enrich_inventory(data)
+    assert items[0]["name"].endswith("Correct")

--- a/tests/test_items_game_cache.py
+++ b/tests/test_items_game_cache.py
@@ -1,0 +1,32 @@
+import json
+
+import utils.items_game_cache as ig
+
+
+def test_items_game_cache_hit(tmp_path, monkeypatch):
+    json_file = tmp_path / "items_game.json"
+    sample = {"items": {"1": {"name": "One"}}}
+    json_file.write_text(json.dumps(sample))
+    monkeypatch.setattr(ig, "JSON_FILE", json_file)
+    monkeypatch.setattr(ig, "TXT_FILE", tmp_path / "items_game.txt")
+    ig.ITEMS_GAME = None
+    data = ig.ensure_items_game_cached()
+    assert data == sample
+
+
+class DummyResp:
+    def __init__(self, text='\nitems {\n "1" {\n  "name" "One"\n }\n}\n'):
+        self.text = text
+
+    def raise_for_status(self):
+        pass
+
+
+def test_items_game_cache_miss(tmp_path, monkeypatch):
+    monkeypatch.setattr(ig, "JSON_FILE", tmp_path / "items_game.json")
+    monkeypatch.setattr(ig, "TXT_FILE", tmp_path / "items_game.txt")
+    monkeypatch.setattr(ig.requests, "get", lambda url, timeout: DummyResp())
+    ig.ITEMS_GAME = None
+    data = ig.ensure_items_game_cached()
+    assert data.get("items", {}).get("1", {}).get("name") == "One"
+    assert ig.JSON_FILE.exists()

--- a/utils/items_game_cache.py
+++ b/utils/items_game_cache.py
@@ -1,0 +1,52 @@
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Any, Dict
+
+import requests
+import vdf
+
+logger = logging.getLogger(__name__)
+
+TXT_FILE = Path("cache/items_game.txt")
+JSON_FILE = Path("cache/items_game.json")
+TTL = 24 * 60 * 60  # 24 hours
+
+ITEMS_GAME: Dict[str, Any] | None = None
+
+
+def _fetch_items_game() -> Dict[str, Any]:
+    """Download and parse items_game.txt from SteamDatabase."""
+    url = (
+        "https://raw.githubusercontent.com/SteamDatabase/GameTracking-TF2/master/"
+        "tf/scripts/items/items_game.txt"
+    )
+    r = requests.get(url, timeout=30)
+    r.raise_for_status()
+    text = r.text
+    TXT_FILE.parent.mkdir(parents=True, exist_ok=True)
+    TXT_FILE.write_text(text)
+    data = vdf.loads(text)
+    JSON_FILE.write_text(json.dumps(data))
+    return data
+
+
+def ensure_items_game_cached() -> Dict[str, Any]:
+    """Return cached items_game data as a dict."""
+    global ITEMS_GAME
+    if JSON_FILE.exists():
+        age = time.time() - JSON_FILE.stat().st_mtime
+        if age < TTL:
+            ITEMS_GAME = json.loads(JSON_FILE.read_text())
+            logger.info(
+                "items_game cache HIT: %s items",
+                len(ITEMS_GAME.get("items", {})),
+            )
+            return ITEMS_GAME
+    ITEMS_GAME = _fetch_items_game()
+    logger.info(
+        "items_game cache MISS, fetched %s items",
+        len(ITEMS_GAME.get("items", {})),
+    )
+    return ITEMS_GAME


### PR DESCRIPTION
## Summary
- add a small cache helper for items_game.txt
- prefer items_game names in inventory processor
- update requirements for vdf
- test items_game cache and name preference

## Testing
- `pre-commit run --files utils/items_game_cache.py utils/inventory_processor.py tests/test_items_game_cache.py tests/test_item_name_preference.py requirements.txt requirements.lock`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686044a6ac2483269cdd35852d669d75