### PR TITLE
Add items_game updater script and refine caching

### DIFF
--- a/scripts/update_items_game.py
+++ b/scripts/update_items_game.py
@@ -1,0 +1,7 @@
+import logging
+from utils import items_game_cache
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    data = items_game_cache.update_items_game()
+    print(f"Fetched {len(data.get('items', {}))} items")

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -1,9 +1,15 @@
 from utils import inventory_processor as ip
 from utils import schema_fetcher as sf
 from utils import steam_api_client as sac
+from utils import items_game_cache as ig
 import requests
 import responses
 import pytest
+
+
+@pytest.fixture(autouse=True)
+def no_items_game(monkeypatch):
+    monkeypatch.setattr(ig, "ensure_items_game_cached", lambda: {})
 
 
 def test_enrich_inventory():

--- a/tests/test_items_game_cache.py
+++ b/tests/test_items_game_cache.py
@@ -8,14 +8,17 @@ def test_items_game_cache_hit(tmp_path, monkeypatch):
     sample = {"items": {"1": {"name": "One"}}}
     json_file.write_text(json.dumps(sample))
     monkeypatch.setattr(ig, "JSON_FILE", json_file)
-    monkeypatch.setattr(ig, "TXT_FILE", tmp_path / "items_game.txt")
+    monkeypatch.setattr(ig, "RAW_FILE", tmp_path / "items_game_raw.txt")
     ig.ITEMS_GAME = None
     data = ig.ensure_items_game_cached()
     assert data == sample
 
 
 class DummyResp:
-    def __init__(self, text='\nitems {\n "1" {\n  "name" "One"\n }\n}\n'):
+    def __init__(
+        self,
+        text='"items_game"\n{\n "items"\n {\n  "1"\n  {\n   "name" "One"\n  }\n }\n}\n',
+    ):
         self.text = text
 
     def raise_for_status(self):
@@ -24,7 +27,7 @@ class DummyResp:
 
 def test_items_game_cache_miss(tmp_path, monkeypatch):
     monkeypatch.setattr(ig, "JSON_FILE", tmp_path / "items_game.json")
-    monkeypatch.setattr(ig, "TXT_FILE", tmp_path / "items_game.txt")
+    monkeypatch.setattr(ig, "RAW_FILE", tmp_path / "items_game_raw.txt")
     monkeypatch.setattr(ig.requests, "get", lambda url, timeout: DummyResp())
     ig.ITEMS_GAME = None
     data = ig.ensure_items_game_cached()

--- a/tests/test_utils_extras.py
+++ b/tests/test_utils_extras.py
@@ -1,11 +1,18 @@
 from utils import steam_api_client as sac
 from utils import inventory_processor as ip
 from utils import schema_fetcher as sf
+from utils import items_game_cache as ig
+import pytest
 
 
 def test_convert_to_steam64():
     assert sac.convert_to_steam64("STEAM_0:1:4") == "76561197960265737"
     assert sac.convert_to_steam64("[U:1:4]") == "76561197960265732"
+
+
+@pytest.fixture(autouse=True)
+def no_items_game(monkeypatch):
+    monkeypatch.setattr(ig, "ensure_items_game_cached", lambda: {})
 
 
 def test_process_inventory_sorting():


### PR DESCRIPTION
## Summary
- preprocess `items_game.txt` with a new helper `update_items_game`
- cache reduced data for 48 hours
- add script `scripts/update_items_game.py` for manual updates
- adjust tests to avoid network calls and cover new behaviour

## Testing
- `pre-commit run --files utils/items_game_cache.py scripts/update_items_game.py tests/test_items_game_cache.py tests/test_inventory_processor.py tests/test_utils_extras.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68604b0549748326867bbf74c37daf70