### PR TITLE
Improve items_game loading and merge speed

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -91,6 +91,9 @@
         <span>
             Team Fortress 2 © Valve Corporation. Steam and the Steam logo are trademarks of Valve Corporation.
         </span>
+        {% if debug_ms %}
+          <div>Longest merge: {{ debug_ms }} ms</div>
+        {% endif %}
     </footer>
 
     <script>

--- a/tests/test_app_import.py
+++ b/tests/test_app_import.py
@@ -1,4 +1,5 @@
 import importlib
+import asyncio
 
 
 def test_app_uses_mock_schema(monkeypatch):
@@ -8,6 +9,10 @@ def test_app_uses_mock_schema(monkeypatch):
         return mock_schema
 
     monkeypatch.setattr("utils.schema_fetcher.ensure_schema_cached", fake_ensure)
+    monkeypatch.setattr(
+        "utils.items_game_cache.ensure_future",
+        lambda *a, **k: asyncio.get_event_loop().create_future(),
+    )
     monkeypatch.setenv("STEAM_API_KEY", "x")
     app = importlib.import_module("app")
     assert app.SCHEMA == mock_schema

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -10,6 +10,7 @@ import pytest
 @pytest.fixture(autouse=True)
 def no_items_game(monkeypatch):
     monkeypatch.setattr(ig, "ensure_items_game_cached", lambda: {})
+    monkeypatch.setattr(ig, "ITEM_BY_DEFINDEX", {}, False)
 
 
 def test_enrich_inventory():

--- a/tests/test_item_name_preference.py
+++ b/tests/test_item_name_preference.py
@@ -8,6 +8,7 @@ def test_enrich_inventory_prefers_items_game(monkeypatch):
     monkeypatch.setattr(
         ig, "ensure_items_game_cached", lambda: {"items": {"111": {"name": "Correct"}}}
     )
+    monkeypatch.setattr(ig, "ITEM_BY_DEFINDEX", {"111": {"name": "Correct"}}, False)
     data = {"items": [{"defindex": 111, "quality": 6}]}
     items = ip.enrich_inventory(data)
     assert items[0]["name"].endswith("Correct")

--- a/tests/test_utils_extras.py
+++ b/tests/test_utils_extras.py
@@ -13,6 +13,7 @@ def test_convert_to_steam64():
 @pytest.fixture(autouse=True)
 def no_items_game(monkeypatch):
     monkeypatch.setattr(ig, "ensure_items_game_cached", lambda: {})
+    monkeypatch.setattr(ig, "ITEM_BY_DEFINDEX", {}, False)
 
 
 def test_process_inventory_sorting():

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -19,17 +19,6 @@ WARPAINT_MAP: Dict[str, str] = {}
 if MAPPING_FILE.exists():
     with MAPPING_FILE.open() as f:
         WARPAINT_MAP = json.load(f)
-
-
-def _load_items_game() -> Dict[str, Any]:
-    """Return cached items_game data or an empty mapping."""
-    try:
-        return items_game_cache.ensure_items_game_cached()
-    except Exception as exc:  # pragma: no cover - network failure
-        logger.info("Failed to load items_game: %s", exc)
-        return {}
-
-
 # Map of quality ID to (name, background color)
 QUALITY_MAP = {
     0: ("Normal", "#B2B2B2"),
@@ -115,12 +104,7 @@ def enrich_inventory(data: Dict[str, Any]) -> List[Dict[str, Any]]:
                 final_url = f"{CLOUD}{image_path}" if image_path else ""
 
         # Prefer name from items_game if available
-        ig_data = _load_items_game()
-        ig_item = (
-            ig_data.get("items", {}).get(defindex, {})
-            if isinstance(ig_data, dict)
-            else {}
-        )
+        ig_item = items_game_cache.ITEM_BY_DEFINDEX.get(defindex, {})
         base_name = (
             WARPAINT_MAP.get(defindex)
             or ig_item.get("name")

--- a/utils/items_game_cache.py
+++ b/utils/items_game_cache.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import time
@@ -14,6 +15,10 @@ JSON_FILE = Path("cache/items_game.json")
 TTL = 48 * 60 * 60  # 48 hours
 
 ITEMS_GAME: Dict[str, Any] | None = None
+ITEM_BY_DEFINDEX: Dict[str, Any] = {}
+KILLSTREAK_BY_ID: Dict[str, Any] = {}
+PARSE_MS: int = 0
+_ITEMS_GAME_FUTURE: asyncio.Future | None = None
 
 
 def update_items_game() -> Dict[str, Any]:
@@ -37,22 +42,66 @@ def update_items_game() -> Dict[str, Any]:
     return reduced
 
 
+def _populate_maps(data: Dict[str, Any]) -> None:
+    """Populate fast lookup dictionaries for items and killstreaks."""
+    ITEM_BY_DEFINDEX.clear()
+    KILLSTREAK_BY_ID.clear()
+    for idx, meta in data.get("items", {}).items():
+        ITEM_BY_DEFINDEX[str(idx)] = meta
+    for attr_id, info in data.get("attributes", {}).items():
+        name = str(info.get("name", "")).lower()
+        if "killstreak" in name:
+            KILLSTREAK_BY_ID[str(attr_id)] = info
+
+
 def ensure_items_game_cached() -> Dict[str, Any]:
     """Return cached items_game data as a dict."""
-    global ITEMS_GAME
+    global ITEMS_GAME, PARSE_MS
     if JSON_FILE.exists():
         age = time.time() - JSON_FILE.stat().st_mtime
         if age < TTL:
             with JSON_FILE.open() as f:
                 ITEMS_GAME = json.load(f)
+            _populate_maps(ITEMS_GAME)
             logger.info(
                 "items_game cache HIT: %s items",
                 len(ITEMS_GAME.get("items", {})),
             )
             return ITEMS_GAME
+    start = time.perf_counter()
     ITEMS_GAME = update_items_game()
+    PARSE_MS = int((time.perf_counter() - start) * 1000)
+    _populate_maps(ITEMS_GAME)
     logger.info(
         "items_game cache MISS, fetched %s items",
         len(ITEMS_GAME.get("items", {})),
     )
+    logger.info("schema ready")
+    logger.info("items_game_parse_ms=%s", PARSE_MS)
     return ITEMS_GAME
+
+
+def ensure_future(loop: asyncio.AbstractEventLoop | None = None) -> asyncio.Future:
+    """Return a future that loads items_game in the background."""
+    global _ITEMS_GAME_FUTURE
+    if _ITEMS_GAME_FUTURE is None:
+        if loop is None:
+            loop = asyncio.get_event_loop()
+        _ITEMS_GAME_FUTURE = loop.create_task(
+            asyncio.to_thread(ensure_items_game_cached)
+        )
+    return _ITEMS_GAME_FUTURE
+
+
+async def wait_until_ready(timeout: float = 10.0) -> None:
+    """Await the items_game cache, falling back on existing file if needed."""
+    fut = ensure_future()
+    try:
+        await asyncio.wait_for(fut, timeout=timeout)
+    except Exception as exc:  # pragma: no cover - network failure
+        logger.info("items_game load failed: %s", exc)
+        if JSON_FILE.exists() and not ITEM_BY_DEFINDEX:
+            with JSON_FILE.open() as f:
+                cached = json.load(f)
+            _populate_maps(cached)
+            logger.info("Using previous item schema")


### PR DESCRIPTION
## Summary
- cache and parse items_game on startup
- store fast lookup maps for items and killstreaks
- build user data asynchronously and wait for the cache
- surface merge timing when debug is enabled
- update tests for new cache globals

## Testing
- `pre-commit run --files utils/items_game_cache.py app.py utils/inventory_processor.py templates/index.html tests/test_app_import.py tests/test_item_name_preference.py tests/test_inventory_processor.py tests/test_utils_extras.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68605c98544483269512c90640afec33