### PR TITLE
Add items_game cleaning helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,9 @@ want to refresh the cache:
 python scripts/update_items_game.py
 ```
 
-The processed JSON is stored under `cache/items_game.json` and reused for 48
-hours.
+This downloads `items_game.txt`, stores a reduced copy under `cache/items_game.json`,
+and writes the cleaned map to `data/items_game_cleaned.json` for the app to use.
+The cache is reused for 48 hours.
 
 ### Deploy
 

--- a/scripts/update_items_game.py
+++ b/scripts/update_items_game.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import sys
 from pathlib import Path
@@ -14,10 +15,15 @@ def main() -> None:
     sys.path.insert(0, str(root))
 
     from utils import items_game_cache  # local import after path tweak
+    from utils import local_data
 
     logging.basicConfig(level=logging.INFO)
     data = items_game_cache.update_items_game()
+    cleaned = local_data.clean_items_game(data)
+    dest = root / "data/items_game_cleaned.json"
+    dest.write_text(json.dumps(cleaned))
     print(f"Fetched {len(data.get('items', {}))} items")
+    print(f"Wrote {len(cleaned)} cleaned items to {dest}")
 
 
 if __name__ == "__main__":

--- a/tests/test_local_data.py
+++ b/tests/test_local_data.py
@@ -25,3 +25,17 @@ def test_load_files_missing(tmp_path, monkeypatch):
     monkeypatch.setattr(ld, "ITEMS_GAME_FILE", tmp_path / "missing2.json")
     with pytest.raises(RuntimeError):
         ld.load_files()
+
+
+def test_clean_items_game_parses_all():
+    sample = {
+        "items_game": {
+            "items": {
+                "111": {"name": "Correct"},
+                "30607": {"name": "Pump"},
+            }
+        }
+    }
+    cleaned = ld.clean_items_game(sample)
+    assert cleaned["111"]["name"] == "Correct"
+    assert cleaned["30607"]["name"] == "Pump"

--- a/utils/local_data.py
+++ b/utils/local_data.py
@@ -2,12 +2,33 @@ import json
 from pathlib import Path
 from typing import Any, Dict, Tuple
 
+import vdf
+
 TF2_SCHEMA: Dict[str, Any] = {}
 ITEMS_GAME_CLEANED: Dict[str, Any] = {}
 EFFECT_NAMES: Dict[str, str] = {}
 
 SCHEMA_FILE = Path("data/tf2_schema.json")
 ITEMS_GAME_FILE = Path("data/items_game_cleaned.json")
+
+
+def clean_items_game(raw: dict | str) -> Dict[str, Any]:
+    """Return a simplified map of defindex -> item info."""
+
+    if isinstance(raw, str):
+        parsed = vdf.loads(raw)
+    else:
+        parsed = raw
+
+    data = parsed.get("items_game", parsed)
+    items = data.get("items", {})
+
+    cleaned: Dict[str, Any] = {}
+    for key, info in items.items():
+        if not str(key).isdigit() or not isinstance(info, dict):
+            continue
+        cleaned[str(key)] = info
+    return cleaned
 
 
 def load_files() -> Tuple[Dict[str, Any], Dict[str, Any]]:


### PR DESCRIPTION
## Summary
- implement `clean_items_game` for loading the full TF2 item list
- extend update script to write cleaned JSON
- document the new behavior in README
- add regression tests

## Testing
- `pre-commit run --files utils/local_data.py scripts/update_items_game.py README.md tests/test_local_data.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68606aaf1c388326bc9757c2d3fe4ec0