### PR TITLE
Improve schema loading and enrichment

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ This downloads `items_game.txt`, stores a reduced copy under `cache/items_game.j
 and writes the cleaned map to `data/items_game_cleaned.json` for the app to use.
 The cache is reused for 48 hours.
 
+Both `tf2_schema.json` and `items_game_cleaned.json` can be overridden via the
+`TF2_SCHEMA_FILE` and `TF2_ITEMS_GAME_FILE` environment variables if you want to
+store them elsewhere.
+
 ### Deploy
 
 The app can be deployed to any platform that supports Python 3.12. For Docker:

--- a/scripts/update_items_game.py
+++ b/scripts/update_items_game.py
@@ -20,10 +20,14 @@ def main() -> None:
     logging.basicConfig(level=logging.INFO)
     data = items_game_cache.update_items_game()
     cleaned = local_data.clean_items_game(data)
-    dest = root / "data/items_game_cleaned.json"
+    dest = (root / "data/items_game_cleaned.json").resolve()
     dest.write_text(json.dumps(cleaned))
     print(f"Fetched {len(data.get('items', {}))} items")
     print(f"Wrote {len(cleaned)} cleaned items to {dest}")
+    if len(cleaned) < 10000:
+        print(
+            "Warning: cleaned items_game has fewer than 10k entries. Check parsing logic."
+        )
 
 
 if __name__ == "__main__":

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -58,11 +58,47 @@ def _extract_unusual_effect(asset: Dict[str, Any]) -> str | None:
     return None
 
 
+_KILLSTREAK_TIER = {
+    1: "Killstreak",
+    2: "Specialized Killstreak",
+    3: "Professional Killstreak",
+}
+
+_SHEEN_NAMES = {
+    1: "Team Shine",
+    2: "Deadly Daffodil",
+    3: "Mandarin",
+    4: "Mean Green",
+    5: "Villainous Violet",
+    6: "Hot Rod",
+}
+
+
+def _extract_killstreak(asset: Dict[str, Any]) -> Tuple[str | None, str | None]:
+    """Return killstreak tier and sheen names if present."""
+
+    tier = None
+    sheen = None
+    for attr in asset.get("attributes", []):
+        idx = attr.get("defindex")
+        val = int(attr.get("float_value", 0))
+        if idx == 2025:
+            tier = _KILLSTREAK_TIER.get(val)
+        elif idx == 2014:
+            sheen = _SHEEN_NAMES.get(val)
+    return tier, sheen
+
+
 def _build_item_name(base: str, quality: str, asset: Dict[str, Any]) -> str:
     """Return the display name prefixed with quality/effect."""
 
     parts: List[str] = []
+    ks_tier, sheen = _extract_killstreak(asset)
     effect = _extract_unusual_effect(asset)
+
+    if ks_tier:
+        parts.append(ks_tier)
+
     if effect:
         parts.append(effect)
         if quality not in ("Unique", "Normal", "Unusual"):
@@ -70,7 +106,12 @@ def _build_item_name(base: str, quality: str, asset: Dict[str, Any]) -> str:
     else:
         if quality not in ("Unique", "Normal"):
             parts.append(quality)
+
     parts.append(base)
+
+    if sheen:
+        parts.append(f"({sheen})")
+
     return " ".join(parts)
 
 

--- a/utils/local_data.py
+++ b/utils/local_data.py
@@ -1,4 +1,5 @@
 import json
+import os
 from pathlib import Path
 from typing import Any, Dict, Tuple
 
@@ -9,8 +10,10 @@ ITEMS_GAME_CLEANED: Dict[str, Any] = {}
 EFFECT_NAMES: Dict[str, str] = {}
 
 BASE_DIR = Path(__file__).resolve().parent.parent
-SCHEMA_FILE = BASE_DIR / "data" / "tf2_schema.json"
-ITEMS_GAME_FILE = BASE_DIR / "data" / "items_game_cleaned.json"
+DEFAULT_SCHEMA_FILE = BASE_DIR / "data" / "tf2_schema.json"
+DEFAULT_ITEMS_GAME_FILE = BASE_DIR / "data" / "items_game_cleaned.json"
+SCHEMA_FILE = Path(os.getenv("TF2_SCHEMA_FILE", DEFAULT_SCHEMA_FILE))
+ITEMS_GAME_FILE = Path(os.getenv("TF2_ITEMS_GAME_FILE", DEFAULT_ITEMS_GAME_FILE))
 
 
 def clean_items_game(raw: dict | str) -> Dict[str, Any]:
@@ -32,31 +35,57 @@ def clean_items_game(raw: dict | str) -> Dict[str, Any]:
     return cleaned
 
 
-def load_files() -> Tuple[Dict[str, Any], Dict[str, Any]]:
+def load_files(*, auto_refetch: bool = False) -> Tuple[Dict[str, Any], Dict[str, Any]]:
     """Load local schema files and populate globals."""
+
     global TF2_SCHEMA, ITEMS_GAME_CLEANED, EFFECT_NAMES
 
-    if not SCHEMA_FILE.exists():
-        raise RuntimeError(f"Missing {SCHEMA_FILE}")
-    with SCHEMA_FILE.open() as f:
+    schema_path = SCHEMA_FILE.resolve()
+    if not schema_path.exists():
+        raise RuntimeError(f"Missing {schema_path}")
+    with schema_path.open() as f:
         data = json.load(f)
+
     items = data.get("items") or data
     if not isinstance(items, dict) or not items:
         raise RuntimeError("tf2_schema.json is empty or invalid")
+
+    if len(items) < 5000 and auto_refetch:
+        try:
+            from . import schema_fetcher
+
+            api_key = os.getenv("STEAM_API_KEY")
+            if not api_key:
+                raise RuntimeError("STEAM_API_KEY is required for refetch")
+            fetched = schema_fetcher._fetch_schema(api_key)
+            schema_path.write_text(json.dumps(fetched))
+            data = fetched
+            items = fetched.get("items") or fetched
+            print(f"Refetched TF2 schema: {len(items)} items -> {schema_path}")
+        except Exception as exc:  # pragma: no cover - network failure
+            print(f"Failed to refetch schema: {exc}")
+
     TF2_SCHEMA = items
     EFFECT_NAMES = data.get("effects", {}) if isinstance(data, dict) else {}
-    print(f"\N{CHECK MARK} Loaded {len(TF2_SCHEMA)} items from {SCHEMA_FILE}")
-    if len(TF2_SCHEMA) < 100:
+    print(f"\N{CHECK MARK} Loaded {len(TF2_SCHEMA)} items from {schema_path}")
+    if len(TF2_SCHEMA) < 5000:
         print(
             "\N{WARNING SIGN} tf2_schema.json may be stale or incomplete. "
             "Consider forcing a refetch."
         )
 
-    if not ITEMS_GAME_FILE.exists():
-        raise RuntimeError(f"Missing {ITEMS_GAME_FILE}")
-    with ITEMS_GAME_FILE.open() as f:
+    items_game_path = ITEMS_GAME_FILE.resolve()
+    if not items_game_path.exists():
+        raise RuntimeError(f"Missing {items_game_path}")
+    with items_game_path.open() as f:
         ITEMS_GAME_CLEANED = json.load(f)
     if not isinstance(ITEMS_GAME_CLEANED, dict) or not ITEMS_GAME_CLEANED:
         raise RuntimeError("items_game_cleaned.json is empty or invalid")
-    print(f"\N{CHECK MARK} Cleaned items_game has {len(ITEMS_GAME_CLEANED)} entries")
+    print(
+        f"\N{CHECK MARK} Cleaned items_game has {len(ITEMS_GAME_CLEANED)} entries from {items_game_path}"
+    )
+    if len(ITEMS_GAME_CLEANED) < 10000:
+        print(
+            "\N{WARNING SIGN} items_game_cleaned.json may be stale or incomplete. Consider a refresh."
+        )
     return TF2_SCHEMA, ITEMS_GAME_CLEANED


### PR DESCRIPTION
## Summary
- add env overrides to tf2 schema and items_game paths
- refetch schema if stale when requested
- warn if items_game_cleaned has few entries
- expand item name building for killstreak tiers
- document schema path overrides

## Testing
- `pre-commit run --files utils/local_data.py utils/inventory_processor.py scripts/update_items_game.py README.md tests/test_local_data.py tests/test_inventory_processor.py tests/test_user_template.py tests/test_app_import.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860741d959c8326b574b37c5331b47d