### PR TITLE
Add --refresh flag for schema updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 __pycache__/
 data/
 !data/items_game_cleaned.json
+cache/
 .venv/

--- a/README.md
+++ b/README.md
@@ -106,22 +106,18 @@ Install hooks once:
 pre-commit install
 ```
 
-### Updating items_game cache
+### Updating item cache
 
-The application relies on a reduced copy of `items_game.txt` from SteamDatabase
-for improved item names. Fetch and preprocess this file manually whenever you
-want to refresh the cache:
+Run the application with the `--refresh` flag to download the latest TF2 schema
+and `items_game.txt`:
 
 ```bash
-python scripts/update_items_game.py
+python app.py --refresh
 ```
 
-This downloads `items_game.txt`, stores a reduced copy under `cache/items_game.json`,
-and writes the cleaned map to `data/items_game_cleaned.json` for the app to use.
-The cache is reused for 48 hours.
-Both `cache/tf2_schema.json` and `items_game_cleaned.json` can be overridden via the
-`TF2_SCHEMA_FILE` and `TF2_ITEMS_GAME_FILE` environment variables if you want to
-store them elsewhere.
+The files are stored under `cache/` as `tf2_schema.json`, `items_game.txt` and
+`items_game_cleaned.json`. Start the server normally without `--refresh` after
+the update completes.
 
 ### Deploy
 

--- a/scripts/update_items_game.py
+++ b/scripts/update_items_game.py
@@ -20,7 +20,7 @@ def main() -> None:
     logging.basicConfig(level=logging.INFO)
     data = items_game_cache.update_items_game()
     cleaned = local_data.clean_items_game(data)
-    dest = (root / "data/items_game_cleaned.json").resolve()
+    dest = (root / "cache/items_game_cleaned.json").resolve()
     dest.write_text(json.dumps(cleaned))
     print(f"Fetched {len(data.get('items', {}))} items")
     print(f"Wrote {len(cleaned)} cleaned items to {dest}")

--- a/tests/test_app_refresh.py
+++ b/tests/test_app_refresh.py
@@ -1,0 +1,28 @@
+import importlib
+import sys
+
+import pytest
+
+
+def test_refresh_flag_triggers_update(monkeypatch):
+    called = {"schema": False, "items": False}
+
+    monkeypatch.setenv("STEAM_API_KEY", "x")
+    monkeypatch.setattr("pathlib.Path.write_text", lambda self, text: None)
+    monkeypatch.setattr(
+        "pathlib.Path.mkdir", lambda self, parents=True, exist_ok=True: None
+    )
+    monkeypatch.setattr(
+        "utils.schema_fetcher._fetch_schema",
+        lambda k: called.__setitem__("schema", True) or {"items": {}},
+    )
+    monkeypatch.setattr(
+        "utils.items_game_cache.update_items_game",
+        lambda: called.__setitem__("items", True) or {},
+    )
+    monkeypatch.setattr("utils.local_data.clean_items_game", lambda d: {})
+    monkeypatch.setattr(sys, "argv", ["app.py", "--refresh"])
+    sys.modules.pop("app", None)
+    with pytest.raises(SystemExit):
+        importlib.import_module("app")
+    assert called["schema"] and called["items"]

--- a/tests/test_items_game_cache.py
+++ b/tests/test_items_game_cache.py
@@ -8,7 +8,7 @@ def test_items_game_cache_hit(tmp_path, monkeypatch):
     sample = {"items": {"1": {"name": "One"}}}
     json_file.write_text(json.dumps(sample))
     monkeypatch.setattr(ig, "JSON_FILE", json_file)
-    monkeypatch.setattr(ig, "RAW_FILE", tmp_path / "items_game_raw.txt")
+    monkeypatch.setattr(ig, "RAW_FILE", tmp_path / "items_game.txt")
     ig.ITEMS_GAME = None
     data = ig.ensure_items_game_cached()
     assert data == sample
@@ -27,7 +27,7 @@ class DummyResp:
 
 def test_items_game_cache_miss(tmp_path, monkeypatch):
     monkeypatch.setattr(ig, "JSON_FILE", tmp_path / "items_game.json")
-    monkeypatch.setattr(ig, "RAW_FILE", tmp_path / "items_game_raw.txt")
+    monkeypatch.setattr(ig, "RAW_FILE", tmp_path / "items_game.txt")
     monkeypatch.setattr(ig.requests, "get", lambda url, timeout: DummyResp())
     ig.ITEMS_GAME = None
     data = ig.ensure_items_game_cached()

--- a/utils/items_game_cache.py
+++ b/utils/items_game_cache.py
@@ -10,7 +10,7 @@ import vdf
 
 logger = logging.getLogger(__name__)
 
-RAW_FILE = Path("cache/items_game_raw.txt")
+RAW_FILE = Path("cache/items_game.txt")
 JSON_FILE = Path("cache/items_game.json")
 TTL = 48 * 60 * 60  # 48 hours
 

--- a/utils/local_data.py
+++ b/utils/local_data.py
@@ -11,7 +11,7 @@ EFFECT_NAMES: Dict[str, str] = {}
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 DEFAULT_SCHEMA_FILE = BASE_DIR / "cache" / "tf2_schema.json"
-DEFAULT_ITEMS_GAME_FILE = BASE_DIR / "data" / "items_game_cleaned.json"
+DEFAULT_ITEMS_GAME_FILE = BASE_DIR / "cache" / "items_game_cleaned.json"
 SCHEMA_FILE = Path(os.getenv("TF2_SCHEMA_FILE", DEFAULT_SCHEMA_FILE))
 ITEMS_GAME_FILE = Path(os.getenv("TF2_ITEMS_GAME_FILE", DEFAULT_ITEMS_GAME_FILE))
 


### PR DESCRIPTION
## Summary
- support `--refresh` option in `app.py`
- default cached items_game path to `cache/`
- rename raw items file to `items_game.txt`
- adjust script and gitignore for new cache location
- document refresh workflow in README
- test refresh flag behavior

## Testing
- `pre-commit run --files app.py utils/local_data.py utils/items_game_cache.py scripts/update_items_game.py README.md tests/test_items_game_cache.py tests/test_app_refresh.py .gitignore`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860a3a014948326819b726228008b41