### PR TITLE
Fix item images by using schema URLs

### DIFF
--- a/templates/_user.html
+++ b/templates/_user.html
@@ -28,8 +28,8 @@
       <div class="inventory-container">
         {% for item in user.items %}
           <div class="item-card" style="border-color: {{ item.quality_color }};">
-            {% if item.final_url %}
-              <img class="item-img" src="{{ item.final_url }}" alt="{{ item.name }}" width="64" height="64" onerror="this.style.display='none';">
+            {% if item.image_url %}
+              <img class="item-img" src="{{ item.image_url }}" alt="{{ item.name }}" width="64" height="64" onerror="this.style.display='none';">
             {% else %}
               <div class="missing-icon"></div>
             {% endif %}

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -19,14 +19,18 @@ def no_items_game(monkeypatch):
 def test_enrich_inventory():
     data = {"items": [{"defindex": 111, "quality": 11}]}
     sf.SCHEMA = {
-        "111": {"defindex": 111, "item_name": "Rocket Launcher", "image_url": "img"}
+        "111": {
+            "defindex": 111,
+            "item_name": "Rocket Launcher",
+            "image_url": "https://steamcommunity-a.akamaihd.net/economy/image/img/360fx360f",
+        }
     }
     sf.QUALITIES = {"11": "Strange"}
     items = ip.enrich_inventory(data)
     assert items[0]["name"] == "Strange Rocket Launcher"
     assert items[0]["quality"] == "Strange"
     assert items[0]["quality_color"] == "#CF6A32"
-    assert items[0]["final_url"].startswith(
+    assert items[0]["image_url"].startswith(
         "https://steamcommunity-a.akamaihd.net/economy/image/"
     )
 
@@ -54,7 +58,11 @@ def test_enrich_inventory_unusual_effect():
 def test_process_inventory_handles_missing_icon():
     data = {"items": [{"defindex": 1}, {"defindex": 2}]}
     sf.SCHEMA = {
-        "1": {"defindex": 1, "item_name": "One", "image_url": "a"},
+        "1": {
+            "defindex": 1,
+            "item_name": "One",
+            "image_url": "https://steamcommunity-a.akamaihd.net/economy/image/a/360fx360f",
+        },
         "2": {"defindex": 2, "item_name": "Two", "image_url": ""},
     }
     sf.QUALITIES = {}
@@ -62,11 +70,11 @@ def test_process_inventory_handles_missing_icon():
     assert {i["name"] for i in items} == {"One", "Two"}
     for item in items:
         if item["name"] == "One":
-            assert item["final_url"].startswith(
+            assert item["image_url"].startswith(
                 "https://steamcommunity-a.akamaihd.net/economy/image/"
             )
         else:
-            assert item["final_url"] == ""
+            assert item["image_url"] == ""
 
 
 def test_enrich_inventory_preserves_absolute_url():
@@ -75,7 +83,7 @@ def test_enrich_inventory_preserves_absolute_url():
     sf.SCHEMA = {"5": {"defindex": 5, "item_name": "Abs", "image_url": url}}
     sf.QUALITIES = {"0": "Normal"}
     items = ip.enrich_inventory(data)
-    assert items[0]["final_url"] == url
+    assert items[0]["image_url"] == url
 
 
 def test_enrich_inventory_skips_unknown_defindex():
@@ -162,7 +170,7 @@ def test_user_template_safe(monkeypatch, status):
         avatar="",
         playtime=0.0,
         profile="#",
-        items=[{"final_url": ""}] if status == "parsed" else [],
+        items=[{"image_url": ""}] if status == "parsed" else [],
         status=status,
     )
 

--- a/tests/test_schema_fetcher.py
+++ b/tests/test_schema_fetcher.py
@@ -9,7 +9,11 @@ def test_schema_cache_hit(tmp_path, monkeypatch):
     cache = tmp_path / "tf2_schema.json"
     sample = {
         "items": {
-            str(i): {"defindex": i, "name": "Item", "image_url": "i"}
+            str(i): {
+                "defindex": i,
+                "name": "Item",
+                "image_url": "https://steamcommunity-a.akamaihd.net/economy/image/i/360fx360f",
+            }
             for i in range(5000)
         },
         "qualities": {"0": "Normal"},
@@ -62,8 +66,7 @@ def test_schema_cache_miss(tmp_path, monkeypatch):
         "2": {
             "defindex": 2,
             "name": "Other",
-            "image_url": "u",
-            "image_url_large": None,
+            "image_url": "https://steamcommunity-a.akamaihd.net/economy/image/u/360fx360f",
         }
     }
     assert cache.exists()

--- a/tests/test_user_template.py
+++ b/tests/test_user_template.py
@@ -19,7 +19,7 @@ def app(monkeypatch):
 @pytest.mark.parametrize(
     "context",
     [
-        {"user": {"items": [{"name": "Foo", "final_url": ""}]}},
+        {"user": {"items": [{"name": "Foo", "image_url": ""}]}},
         {"user": {"items": []}},
         {"user": {}},
     ],

--- a/utils/schema_fetcher.py
+++ b/utils/schema_fetcher.py
@@ -7,6 +7,8 @@ from typing import Any, Dict
 
 import requests
 
+CLOUD = "https://steamcommunity-a.akamaihd.net/economy/image/"
+
 logger = logging.getLogger(__name__)
 
 CACHE_FILE = Path("cache/tf2_schema.json")
@@ -43,11 +45,25 @@ def _fetch_schema(api_key: str) -> Dict[str, Any]:
             defindex = str(item.get("defindex"))
             if not defindex or "name" not in item:
                 continue
+
+            path = (
+                item.get("image_url_large")
+                or item.get("image_url")
+                or item.get("icon_url_large")
+                or item.get("icon_url")
+                or ""
+            )
+            if path.startswith("http"):
+                image_url = path
+            elif path:
+                image_url = f"{CLOUD}{path}/360fx360f"
+            else:
+                image_url = ""
+
             items[defindex] = {
                 "defindex": item.get("defindex"),
                 "name": item.get("name"),
-                "image_url": item.get("image_url"),
-                "image_url_large": item.get("image_url_large"),
+                "image_url": image_url,
             }
         if not data.get("next"):
             break


### PR DESCRIPTION
## Summary
- pull CDN image paths directly from the TF2 schema
- drop items_game fallback for icon URLs
- render inventory items with `item.image_url`
- update tests for the new image field

## Testing
- `pre-commit run --files utils/schema_fetcher.py utils/inventory_processor.py templates/_user.html tests/test_schema_fetcher.py tests/test_inventory_processor.py tests/test_user_template.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860a7ff1c6c8326aae385cfcce429e6