### PR TITLE
Add spell badges and click-away modal

### DIFF
--- a/static/retry.js
+++ b/static/retry.js
@@ -67,8 +67,16 @@ function attachItemModal() {
   const title = document.getElementById('modal-title');
   const img = document.getElementById('modal-img');
   const details = document.getElementById('modal-details');
-  const close = document.getElementById('modal-close');
-  if (close) close.addEventListener('click', () => modal.close());
+  const badgeBox = document.getElementById('modal-badges');
+
+  function closeModal() {
+    modal.style.opacity = '0';
+    setTimeout(() => modal.close(), 200);
+  }
+
+  modal.addEventListener('click', e => {
+    if (e.target === modal) closeModal();
+  });
 
   document.querySelectorAll('.item-card').forEach(card => {
     card.addEventListener('click', () => {
@@ -79,27 +87,76 @@ function attachItemModal() {
       if (img) img.src = data.image_url || '';
       if (details) {
         details.innerHTML = '';
-        const fields = [
+        const attrs = document.createElement('div');
+        if (data.killstreak_tier) {
+          const ks = document.createElement('div');
+          ks.textContent = data.killstreak_tier;
+          attrs.appendChild(ks);
+          if (data.sheen) {
+            const sh = document.createElement('div');
+            sh.textContent = '\u2022 Sheen: ' + data.sheen;
+            attrs.appendChild(sh);
+          }
+          if (data.killstreak_effect) {
+            const ke = document.createElement('div');
+            ke.textContent = '\u2022 Effect: ' + data.killstreak_effect;
+            attrs.appendChild(ke);
+          }
+        }
+
+        [
           ['Type', data.item_type_name],
           ['Level', data.level],
-          ['Origin', data.origin],
-          ['Killstreak', data.killstreak_tier],
-          ['Paint', data.paint_name],
-        ];
-        fields.forEach(([label, value]) => {
+          ['Origin', data.origin]
+        ].forEach(([label, value]) => {
           if (!value) return;
           const div = document.createElement('div');
-          if (label === 'Paint' && data.paint_hex) {
+          div.textContent = label + ': ' + value;
+          attrs.appendChild(div);
+        });
+
+        if (data.paint_name) {
+          const div = document.createElement('div');
+          if (data.paint_hex) {
             const sw = document.createElement('span');
             sw.style.display = 'inline-block';
             sw.style.width = '12px';
             sw.style.height = '12px';
             sw.style.marginRight = '4px';
+            sw.style.border = '1px solid #333';
+            sw.style.borderRadius = '50%';
             sw.style.background = data.paint_hex;
             div.appendChild(sw);
           }
-          div.appendChild(document.createTextNode(label + ': ' + value));
-          details.appendChild(div);
+          div.appendChild(document.createTextNode('Paint: ' + data.paint_name));
+          attrs.appendChild(div);
+        }
+
+        details.appendChild(attrs);
+
+        if (Array.isArray(data.spells) && data.spells.length) {
+          const head = document.createElement('h4');
+          head.textContent = 'Spells';
+          head.id = 'modal-spells';
+          details.appendChild(head);
+          data.spells.forEach(sp => {
+            const sdiv = document.createElement('div');
+            sdiv.textContent = sp;
+            details.appendChild(sdiv);
+          });
+        }
+      }
+      if (badgeBox) {
+        badgeBox.innerHTML = '';
+        (data.badges || []).forEach(b => {
+          const span = document.createElement('span');
+          span.textContent = b.icon;
+          span.title = b.title;
+          span.addEventListener('click', () => {
+            const sec = document.getElementById('modal-spells');
+            if (sec) sec.scrollIntoView({ behavior: 'smooth' });
+          });
+          badgeBox.appendChild(span);
         });
       }
       if (typeof modal.showModal === 'function') {
@@ -107,6 +164,7 @@ function attachItemModal() {
       } else {
         modal.style.display = 'block';
       }
+      modal.style.opacity = '1';
     });
   });
 }

--- a/templates/_user.html
+++ b/templates/_user.html
@@ -28,6 +28,11 @@
       <div class="inventory-container">
         {% for item in user.items %}
           <div class="item-card" style="border-color: {{ item.quality_color }};" data-item='{{ item|tojson|safe }}'>
+            <div class="item-badges">
+              {% for badge in item.badges or [] %}
+                <span title="{{ badge.title }}">{{ badge.icon }}</span>
+              {% endfor %}
+            </div>
             {% if item.image_url %}
               <img class="item-img" src="{{ item.image_url }}" alt="{{ item.name }}" width="64" height="64" onerror="this.style.display='none';">
             {% else %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -67,7 +67,10 @@
             border: 1px solid #555;
             border-radius: 8px;
             padding: 1rem;
+            opacity: 0;
+            transition: opacity 0.2s;
         }
+        #item-modal[open] { opacity: 1; }
         #item-modal::backdrop {
             background: rgba(0,0,0,0.6);
         }
@@ -76,14 +79,9 @@
             justify-content: space-between;
             align-items: center;
         }
-        #item-modal button {
-            background: transparent;
-            border: none;
-            color: #fff;
-            cursor: pointer;
-            font-size: 1.2rem;
-        }
         #modal-details div { margin-top: 2px; }
+        .item-badges { position: absolute; top: 2px; right: 2px; display: flex; gap: 2px; }
+        .item-badges span { font-size: 0.75rem; }
     </style>
 </head>
 <body>
@@ -111,8 +109,8 @@
 
     <dialog id="item-modal">
       <div class="modal-header">
-        <button id="modal-close" type="button">&times;</button>
         <h3 id="modal-title"></h3>
+        <div id="modal-badges" class="item-badges"></div>
       </div>
       <div class="modal-body">
         <img id="modal-img" src="" width="64" height="64" alt="">


### PR DESCRIPTION
## Summary
- show icons for spells on item cards
- modal badges link to spell details
- close the item modal by clicking outside
- display paint swatch and killstreak info together

## Testing
- `pre-commit run --files utils/inventory_processor.py templates/_user.html templates/index.html static/retry.js`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860aec0b0288326b43b85a2daf3c1b8