### PR TITLE
Add Autobot schema caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,16 +108,16 @@ pre-commit install
 
 ### Updating item cache
 
-Run the application with the `--refresh` flag to download the latest TF2 schema
-and `items_game.txt`:
+Run the application with the `--refresh` flag to download the latest TF2 schema,
+`items_game.txt` and all Autobot schema properties:
 
 ```bash
 python app.py --refresh
 ```
 
-The files are stored under `cache/` as `tf2_schema.json`, `items_game.txt` and
-`items_game_cleaned.json`. Start the server normally without `--refresh` after
-the update completes.
+The files are stored under `cache/` and include `tf2_schema.json`,
+`items_game.txt`, `items_game_cleaned.json` and all Autobot API responses. Start
+the server normally without `--refresh` after the update completes.
 
 ### Deploy
 

--- a/app.py
+++ b/app.py
@@ -16,6 +16,7 @@ from utils.inventory_processor import enrich_inventory
 from utils import steam_api_client as sac
 from utils import items_game_cache
 from utils import local_data
+from utils.autobot_schema_cache import ensure_all_cached
 
 load_dotenv()
 if not os.getenv("STEAM_API_KEY"):
@@ -25,6 +26,7 @@ if not os.getenv("STEAM_API_KEY"):
 
 if "--refresh" in sys.argv[1:]:
     from utils import schema_fetcher, items_game_cache, local_data
+    from utils import autobot_schema_cache
 
     print(
         "\N{anticlockwise open circle arrow} Refresh requested: refetching TF2 schema and items_game..."
@@ -39,6 +41,7 @@ if "--refresh" in sys.argv[1:]:
     cleaned = local_data.clean_items_game(items_game)
     Path("cache/items_game_cleaned.json").write_text(json.dumps(cleaned))
     print(f"Saved {len(cleaned)} cleaned item definitions")
+    autobot_schema_cache.ensure_all_cached(refresh=True)
     print(
         "\N{CHECK MARK} Refresh complete. Restart app normally without --refresh to start server."
     )
@@ -53,6 +56,7 @@ MAX_MERGE_MS = 0
 
 SCHEMA = ensure_schema_cached()
 print(f"Loaded {len(SCHEMA)} schema items")
+ensure_all_cached()
 local_data.load_files()
 
 # --- Utility functions ------------------------------------------------------

--- a/tests/test_app_import.py
+++ b/tests/test_app_import.py
@@ -10,6 +10,9 @@ def test_app_uses_mock_schema(monkeypatch):
 
     monkeypatch.setattr("utils.schema_fetcher.ensure_schema_cached", fake_ensure)
     monkeypatch.setattr(
+        "utils.autobot_schema_cache.ensure_all_cached", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
         "utils.items_game_cache.ensure_future",
         lambda *a, **k: asyncio.get_event_loop().create_future(),
     )

--- a/tests/test_app_refresh.py
+++ b/tests/test_app_refresh.py
@@ -20,6 +20,9 @@ def test_refresh_flag_triggers_update(monkeypatch):
         "utils.items_game_cache.update_items_game",
         lambda: called.__setitem__("items", True) or {},
     )
+    monkeypatch.setattr(
+        "utils.autobot_schema_cache.ensure_all_cached", lambda *a, **k: None
+    )
     monkeypatch.setattr("utils.local_data.clean_items_game", lambda d: {})
     monkeypatch.setattr(sys, "argv", ["app.py", "--refresh"])
     sys.modules.pop("app", None)

--- a/tests/test_autobot_schema_cache.py
+++ b/tests/test_autobot_schema_cache.py
@@ -1,0 +1,44 @@
+import json
+
+import utils.autobot_schema_cache as ac
+
+
+def test_ensure_all_cached(tmp_path, monkeypatch):
+    monkeypatch.setattr(ac, "CACHE_DIR", tmp_path)
+    monkeypatch.setattr(ac, "PROPERTIES", {"defindexes": "defindexes.json"})
+    monkeypatch.setattr(ac, "CLASS_CHARS", [])
+    monkeypatch.setattr(ac, "GRADE_FILES", {"v1": "item_grade_v1.json"})
+    monkeypatch.setattr(ac, "BASE_ENDPOINTS", {"tf2_schema.json": "/schema/download"})
+
+    calls = []
+
+    def fake_fetch(url):
+        calls.append(url)
+        return {"ok": True}
+
+    monkeypatch.setattr(ac, "_fetch_json", fake_fetch)
+
+    ac.ensure_all_cached()
+
+    assert (tmp_path / "defindexes.json").exists()
+    assert (tmp_path / "item_grade_v1.json").exists()
+    assert (tmp_path / "tf2_schema.json").exists()
+    assert calls
+
+
+def test_cache_hit(tmp_path, monkeypatch):
+    monkeypatch.setattr(ac, "CACHE_DIR", tmp_path)
+    monkeypatch.setattr(ac, "PROPERTIES", {"defindexes": "defindexes.json"})
+    monkeypatch.setattr(ac, "CLASS_CHARS", [])
+    monkeypatch.setattr(ac, "GRADE_FILES", {})
+    monkeypatch.setattr(ac, "BASE_ENDPOINTS", {})
+
+    (tmp_path / "defindexes.json").write_text(json.dumps({"x": 1}))
+
+    monkeypatch.setattr(
+        ac,
+        "_fetch_json",
+        lambda url: (_ for _ in ()).throw(AssertionError("should not fetch")),
+    )
+
+    ac.ensure_all_cached()

--- a/tests/test_env_loading.py
+++ b/tests/test_env_loading.py
@@ -7,6 +7,9 @@ import pytest
 def test_missing_env_vars_raises(monkeypatch):
     monkeypatch.delenv("STEAM_API_KEY", raising=False)
     monkeypatch.setattr("utils.schema_fetcher.ensure_schema_cached", lambda: {})
+    monkeypatch.setattr(
+        "utils.autobot_schema_cache.ensure_all_cached", lambda *a, **k: None
+    )
     monkeypatch.setattr("utils.local_data.load_files", lambda: ({}, {}))
     sys.modules.pop("app", None)
     with pytest.raises(RuntimeError):
@@ -16,6 +19,9 @@ def test_missing_env_vars_raises(monkeypatch):
 def test_env_present_allows_import(monkeypatch):
     monkeypatch.setenv("STEAM_API_KEY", "x")
     monkeypatch.setattr("utils.schema_fetcher.ensure_schema_cached", lambda: {})
+    monkeypatch.setattr(
+        "utils.autobot_schema_cache.ensure_all_cached", lambda *a, **k: None
+    )
     monkeypatch.setattr("utils.local_data.load_files", lambda: ({}, {}))
     sys.modules.pop("app", None)
     importlib.import_module("app")

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -156,6 +156,9 @@ def test_fetch_inventory_statuses(monkeypatch, payload, expected):
 def test_user_template_safe(monkeypatch, status):
     monkeypatch.setenv("STEAM_API_KEY", "x")
     monkeypatch.setattr("utils.schema_fetcher.ensure_schema_cached", lambda: {})
+    monkeypatch.setattr(
+        "utils.autobot_schema_cache.ensure_all_cached", lambda *a, **k: None
+    )
     monkeypatch.setattr("utils.local_data.load_files", lambda: ({}, {}))
     import importlib
 

--- a/tests/test_user_template.py
+++ b/tests/test_user_template.py
@@ -10,6 +10,9 @@ HTML = '{% include "_user.html" %}'
 def app(monkeypatch):
     monkeypatch.setenv("STEAM_API_KEY", "x")
     monkeypatch.setattr("utils.schema_fetcher.ensure_schema_cached", lambda: {})
+    monkeypatch.setattr(
+        "utils.autobot_schema_cache.ensure_all_cached", lambda *a, **k: None
+    )
     monkeypatch.setattr("utils.local_data.load_files", lambda: ({}, {}))
     mod = importlib.import_module("app")
     importlib.reload(mod)

--- a/utils/autobot_schema_cache.py
+++ b/utils/autobot_schema_cache.py
@@ -1,0 +1,83 @@
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://schema.autobot.tf"
+CACHE_DIR = Path("cache")
+
+PROPERTIES = {
+    "defindexes": "defindexes.json",
+    "qualities": "qualities.json",
+    "killstreaks": "killstreaks.json",
+    "effects": "effects.json",
+    "paintkits": "paintkits.json",
+    "wears": "wears.json",
+    "crateseries": "crateseries.json",
+    "paints": "paints.json",
+    "strangeParts": "strange_parts.json",
+    "craftWeapons": "craft_weapons.json",
+    "uncraftWeapons": "uncraft_weapons.json",
+}
+
+CLASS_CHARS = ["s", "p", "m", "d", "e", "h", "t", "l", "g"]
+
+GRADE_FILES = {
+    "v1": "item_grade_v1.json",
+    "v2": "item_grade_v2.json",
+}
+
+BASE_ENDPOINTS = {
+    "tf2_schema.json": "/schema/download",
+    "items_game.json": "/raw/items_game/current",
+}
+
+
+def _fetch_json(url: str) -> Dict[str, Any]:
+    r = requests.get(url, timeout=20)
+    r.raise_for_status()
+    return r.json()
+
+
+def _ensure_file(path: Path, url: str, refresh: bool) -> None:
+    if refresh or not path.exists():
+        data = _fetch_json(url)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(data))
+        logger.info("cached %s", path)
+
+
+def ensure_all_cached(refresh: bool = False) -> None:
+    """Ensure all schema files from Autobot are cached."""
+
+    for name, fname in PROPERTIES.items():
+        url = f"{BASE_URL}/properties/{name}"
+        _ensure_file(CACHE_DIR / fname, url, refresh)
+
+    for char in CLASS_CHARS:
+        url = f"{BASE_URL}/properties/craftWeaponsByClass/{char}"
+        dest = CACHE_DIR / "craft_by_class" / f"{char}.json"
+        _ensure_file(dest, url, refresh)
+
+    for ver, fname in GRADE_FILES.items():
+        url = f"{BASE_URL}/getItemGrade/{ver}"
+        _ensure_file(CACHE_DIR / fname, url, refresh)
+
+    for fname, endpoint in BASE_ENDPOINTS.items():
+        url = f"{BASE_URL}{endpoint}"
+        _ensure_file(CACHE_DIR / fname, url, refresh)
+
+
+def get_item_grade(defindex: int | str) -> Dict[str, Any]:
+    """Return item grade data for a defindex, fetching if needed."""
+
+    path = CACHE_DIR / "item_grade_by_defindex" / f"{defindex}.json"
+    if not path.exists():
+        url = f"{BASE_URL}/getItemGrade/fromDefindex/{defindex}"
+        _ensure_file(path, url, refresh=False)
+    with path.open() as f:
+        return json.load(f)


### PR DESCRIPTION
## Summary
- cache schema.autobot.tf endpoints in `ensure_all_cached`
- refresh Autobot caches with `--refresh`
- avoid network calls in tests via monkeypatching
- document Autobot caching in README

## Testing
- `pre-commit run --files app.py utils/autobot_schema_cache.py README.md tests/test_app_import.py tests/test_app_refresh.py tests/test_autobot_schema_cache.py tests/test_env_loading.py tests/test_user_template.py tests/test_inventory_processor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860bd36f0808326b56a0cf1e59d1c79