### PR TITLE
Revise schema caching and refresh workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Run the application with the `--refresh` flag to download the latest TF2 schema,
 python app.py --refresh
 ```
 
-The files are stored under `cache/` and include `tf2_schema.json`,
+The files are stored under `cache/` and include `tf2schema.json`,
 `items_game.txt`, `items_game.json` and all Autobot API responses. Start
 the server normally without `--refresh` after the update completes.
 

--- a/app.py
+++ b/app.py
@@ -23,13 +23,10 @@ if not os.getenv("STEAM_API_KEY"):
     )
 
 if "--refresh" in sys.argv[1:]:
-    from utils import autobot_schema_cache
-    from utils import local_data
-
     print(
-        "\N{anticlockwise open circle arrow} Refresh requested: refetching TF2 schema and items_game..."
+        "\N{ANTICLOCKWISE OPEN CIRCLE ARROW} Refresh requested: redownloading TF2 schema and items_game..."
     )
-    autobot_schema_cache.ensure_all_cached(refresh=True)
+    ensure_all_cached(refresh=True)
     local_data.load_files()
     print("\N{CHECK MARK} Autobot schema refreshed")
     print(

--- a/tests/test_autobot_schema_cache.py
+++ b/tests/test_autobot_schema_cache.py
@@ -6,9 +6,9 @@ import utils.autobot_schema_cache as ac
 def test_ensure_all_cached(tmp_path, monkeypatch):
     monkeypatch.setattr(ac, "CACHE_DIR", tmp_path)
     monkeypatch.setattr(ac, "PROPERTIES", {"defindexes": "defindexes.json"})
-    monkeypatch.setattr(ac, "CLASS_CHARS", [])
+    monkeypatch.setattr(ac, "CLASS_NAMES", [])
     monkeypatch.setattr(ac, "GRADE_FILES", {"v1": "item_grade_v1.json"})
-    monkeypatch.setattr(ac, "BASE_ENDPOINTS", {"tf2_schema.json": "/schema/download"})
+    monkeypatch.setattr(ac, "BASE_ENDPOINTS", {"tf2schema.json": "/schema"})
 
     calls = []
 
@@ -18,18 +18,18 @@ def test_ensure_all_cached(tmp_path, monkeypatch):
 
     monkeypatch.setattr(ac, "_fetch_json", fake_fetch)
 
-    ac.ensure_all_cached()
+    ac.ensure_all_cached(refresh=True)
 
     assert (tmp_path / "defindexes.json").exists()
     assert (tmp_path / "item_grade_v1.json").exists()
-    assert (tmp_path / "tf2_schema.json").exists()
+    assert (tmp_path / "tf2schema.json").exists()
     assert calls
 
 
 def test_cache_hit(tmp_path, monkeypatch):
     monkeypatch.setattr(ac, "CACHE_DIR", tmp_path)
     monkeypatch.setattr(ac, "PROPERTIES", {"defindexes": "defindexes.json"})
-    monkeypatch.setattr(ac, "CLASS_CHARS", [])
+    monkeypatch.setattr(ac, "CLASS_NAMES", [])
     monkeypatch.setattr(ac, "GRADE_FILES", {})
     monkeypatch.setattr(ac, "BASE_ENDPOINTS", {})
 

--- a/tests/test_items_game_cache.py
+++ b/tests/test_items_game_cache.py
@@ -8,26 +8,24 @@ def test_items_game_cache_hit(tmp_path, monkeypatch):
     sample = {"items": {"1": {"name": "One"}}}
     json_file.write_text(json.dumps(sample))
     monkeypatch.setattr(ig, "JSON_FILE", json_file)
-    monkeypatch.setattr(ig, "RAW_FILE", tmp_path / "items_game.txt")
     ig.ITEMS_GAME = None
     data = ig.ensure_items_game_cached()
     assert data == sample
 
 
 class DummyResp:
-    def __init__(
-        self,
-        text='"items_game"\n{\n "items"\n {\n  "1"\n  {\n   "name" "One"\n  }\n }\n}\n',
-    ):
-        self.text = text
+    def __init__(self, payload=None):
+        self.payload = payload or {"items": {"1": {"name": "One"}}}
 
     def raise_for_status(self):
         pass
 
+    def json(self):
+        return self.payload
+
 
 def test_items_game_cache_miss(tmp_path, monkeypatch):
     monkeypatch.setattr(ig, "JSON_FILE", tmp_path / "items_game.json")
-    monkeypatch.setattr(ig, "RAW_FILE", tmp_path / "items_game.txt")
     monkeypatch.setattr(ig.requests, "get", lambda url, timeout: DummyResp())
     ig.ITEMS_GAME = None
     data = ig.ensure_items_game_cached()

--- a/tests/test_local_data.py
+++ b/tests/test_local_data.py
@@ -5,7 +5,7 @@ from utils import local_data as ld
 
 
 def test_load_files_success(tmp_path, monkeypatch, capsys):
-    schema_file = tmp_path / "tf2_schema.json"
+    schema_file = tmp_path / "tf2schema.json"
     items_file = tmp_path / "items_game.json"
     schema_file.write_text(json.dumps({"items": {"1": {"name": "One"}}}))
     items_file.write_text(json.dumps({"1": {"name": "A"}}))
@@ -18,7 +18,7 @@ def test_load_files_success(tmp_path, monkeypatch, capsys):
     out = capsys.readouterr().out
     assert ld.TF2_SCHEMA["1"]["name"] == "One"
     assert f"Loaded 1 items from {schema_file}" in out
-    assert "tf2_schema.json may be stale" in out
+    assert "tf2schema.json may be stale" in out
 
 
 def test_load_files_missing(tmp_path, monkeypatch):

--- a/tests/test_schema_fetcher.py
+++ b/tests/test_schema_fetcher.py
@@ -6,7 +6,7 @@ import utils.schema_fetcher as sf
 
 
 def test_schema_cache_hit(tmp_path, monkeypatch):
-    cache = tmp_path / "tf2_schema.json"
+    cache = tmp_path / "tf2schema.json"
     sample = {
         "items": {
             str(i): {
@@ -26,7 +26,7 @@ def test_schema_cache_hit(tmp_path, monkeypatch):
 
 
 def test_schema_cache_miss(tmp_path, monkeypatch):
-    cache = tmp_path / "tf2_schema.json"
+    cache = tmp_path / "tf2schema.json"
     monkeypatch.setattr(sf, "CACHE_FILE", cache)
 
     class DummyResp:
@@ -59,4 +59,4 @@ def test_schema_cache_miss(tmp_path, monkeypatch):
     schema = sf.ensure_schema_cached(api_key="k")
     assert schema == payload["items"]
     assert cache.exists()
-    assert any("schema/download" in u for u in captured)
+    assert any("/schema" in u for u in captured)

--- a/utils/local_data.py
+++ b/utils/local_data.py
@@ -10,7 +10,7 @@ ITEMS_GAME_CLEANED: Dict[str, Any] = {}
 EFFECT_NAMES: Dict[str, str] = {}
 
 BASE_DIR = Path(__file__).resolve().parent.parent
-DEFAULT_SCHEMA_FILE = BASE_DIR / "cache" / "tf2_schema.json"
+DEFAULT_SCHEMA_FILE = BASE_DIR / "cache" / "tf2schema.json"
 # Autobot provides an already reduced items_game.json
 DEFAULT_ITEMS_GAME_FILE = BASE_DIR / "cache" / "items_game.json"
 SCHEMA_FILE = Path(os.getenv("TF2_SCHEMA_FILE", DEFAULT_SCHEMA_FILE))
@@ -49,7 +49,7 @@ def load_files(*, auto_refetch: bool = False) -> Tuple[Dict[str, Any], Dict[str,
 
     items = data.get("items") or data
     if not isinstance(items, dict) or not items:
-        raise RuntimeError("tf2_schema.json is empty or invalid")
+        raise RuntimeError("tf2schema.json is empty or invalid")
 
     if len(items) < 5000 and auto_refetch:
         try:
@@ -71,7 +71,7 @@ def load_files(*, auto_refetch: bool = False) -> Tuple[Dict[str, Any], Dict[str,
     print(f"\N{CHECK MARK} Loaded {len(TF2_SCHEMA)} items from {schema_path}")
     if len(TF2_SCHEMA) < 5000:
         print(
-            "\N{WARNING SIGN} tf2_schema.json may be stale or incomplete. "
+            "\N{WARNING SIGN} tf2schema.json may be stale or incomplete. "
             "Consider forcing a refetch."
         )
 

--- a/utils/schema_fetcher.py
+++ b/utils/schema_fetcher.py
@@ -12,7 +12,7 @@ BASE_URL = "https://schema.autobot.tf"
 
 logger = logging.getLogger(__name__)
 
-CACHE_FILE = Path("cache/tf2_schema.json")
+CACHE_FILE = Path("cache/tf2schema.json")
 TTL = 48 * 60 * 60  # 48 hours
 
 
@@ -23,7 +23,7 @@ QUALITIES: Dict[str | int, str] = {}
 def _fetch_schema(_: str | None = None) -> Dict[str, Any]:
     """Download the complete schema JSON from schema.autobot.tf."""
 
-    url = f"{BASE_URL}/schema/download"
+    url = f"{BASE_URL}/schema"
     r = requests.get(url, timeout=20)
     r.raise_for_status()
     return r.json()


### PR DESCRIPTION
## Summary
- refresh schema cache from schema.autobot.tf under new filenames
- validate cache files exist before starting the app
- fetch cleaned items_game data directly
- update tests for new cache paths

## Testing
- `black .`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686138985470832699f8a516337102cf