### PR TITLE
Fix items_game fetch – only download raw file and clean locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ python app.py --refresh
 ```
 
 The files are stored under `cache/` and include `tf2schema.json`,
-`items_game.txt`, `items_game.json` and all Autobot API responses. Start
+`items_game.txt`, `items_game_cleaned.json` and all Autobot API responses. Start
 the server normally without `--refresh` after the update completes.
 
 ### Deploy

--- a/scripts/update_items_game.py
+++ b/scripts/update_items_game.py
@@ -15,19 +15,12 @@ def main() -> None:
     sys.path.insert(0, str(root))
 
     from utils import items_game_cache  # local import after path tweak
-    from utils import local_data
 
     logging.basicConfig(level=logging.INFO)
     data = items_game_cache.update_items_game()
-    cleaned = local_data.clean_items_game(data)
-    dest = (root / "cache/items_game.json").resolve()
-    dest.write_text(json.dumps(cleaned))
-    print(f"Fetched {len(data.get('items', {}))} items")
-    print(f"Wrote {len(cleaned)} cleaned items to {dest}")
-    if len(cleaned) < 10000:
-        print(
-            "Warning: cleaned items_game has fewer than 10k entries. Check parsing logic."
-        )
+    dest = (root / "cache/items_game_cleaned.json").resolve()
+    dest.write_text(json.dumps(data))
+    print(f"Fetched {len(data.get('items', {}))} cleaned items to {dest}")
 
 
 if __name__ == "__main__":

--- a/tests/test_autobot_schema_cache.py
+++ b/tests/test_autobot_schema_cache.py
@@ -9,6 +9,11 @@ def test_ensure_all_cached(tmp_path, monkeypatch):
     monkeypatch.setattr(ac, "CLASS_NAMES", [])
     monkeypatch.setattr(ac, "GRADE_FILES", {"v1": "item_grade_v1.json"})
     monkeypatch.setattr(ac, "BASE_ENDPOINTS", {"tf2schema.json": "/schema"})
+    monkeypatch.setattr(ac.items_game_cache, "update_items_game", lambda: None)
+    monkeypatch.setattr(
+        ac.items_game_cache, "JSON_FILE", tmp_path / "items_game_cleaned.json"
+    )
+    (tmp_path / "items_game_cleaned.json").write_text("{}")
 
     calls = []
 
@@ -32,6 +37,10 @@ def test_cache_hit(tmp_path, monkeypatch):
     monkeypatch.setattr(ac, "CLASS_NAMES", [])
     monkeypatch.setattr(ac, "GRADE_FILES", {})
     monkeypatch.setattr(ac, "BASE_ENDPOINTS", {})
+    monkeypatch.setattr(
+        ac.items_game_cache, "JSON_FILE", tmp_path / "items_game_cleaned.json"
+    )
+    (tmp_path / "items_game_cleaned.json").write_text("{}")
 
     (tmp_path / "defindexes.json").write_text(json.dumps({"x": 1}))
 
@@ -50,6 +59,10 @@ def test_class_aliases(tmp_path, monkeypatch):
     monkeypatch.setattr(ac, "GRADE_FILES", {})
     monkeypatch.setattr(ac, "BASE_ENDPOINTS", {})
     monkeypatch.setattr(ac, "CLASS_NAMES", ["Demo", "Engie"])
+    monkeypatch.setattr(ac.items_game_cache, "update_items_game", lambda: None)
+    monkeypatch.setattr(
+        ac.items_game_cache, "JSON_FILE", tmp_path / "items_game_cleaned.json"
+    )
 
     captured = []
 
@@ -73,6 +86,11 @@ def test_unknown_class_ignored(tmp_path, monkeypatch):
     monkeypatch.setattr(ac, "GRADE_FILES", {})
     monkeypatch.setattr(ac, "BASE_ENDPOINTS", {})
     monkeypatch.setattr(ac, "CLASS_NAMES", ["xyz"])
+
+    monkeypatch.setattr(ac.items_game_cache, "update_items_game", lambda: None)
+    monkeypatch.setattr(
+        ac.items_game_cache, "JSON_FILE", tmp_path / "items_game_cleaned.json"
+    )
 
     monkeypatch.setattr(ac, "_fetch_json", lambda url: {})
 

--- a/tests/test_items_game_cache.py
+++ b/tests/test_items_game_cache.py
@@ -4,7 +4,7 @@ import utils.items_game_cache as ig
 
 
 def test_items_game_cache_hit(tmp_path, monkeypatch):
-    json_file = tmp_path / "items_game.json"
+    json_file = tmp_path / "items_game_cleaned.json"
     sample = {"items": {"1": {"name": "One"}}}
     json_file.write_text(json.dumps(sample))
     monkeypatch.setattr(ig, "JSON_FILE", json_file)
@@ -14,19 +14,22 @@ def test_items_game_cache_hit(tmp_path, monkeypatch):
 
 
 class DummyResp:
-    def __init__(self, payload=None):
-        self.payload = payload or {"items": {"1": {"name": "One"}}}
+    def __init__(self, text=""):
+        self.text = text
 
     def raise_for_status(self):
         pass
 
-    def json(self):
-        return self.payload
-
 
 def test_items_game_cache_miss(tmp_path, monkeypatch):
-    monkeypatch.setattr(ig, "JSON_FILE", tmp_path / "items_game.json")
-    monkeypatch.setattr(ig.requests, "get", lambda url, timeout: DummyResp())
+    monkeypatch.setattr(ig, "JSON_FILE", tmp_path / "items_game_cleaned.json")
+    monkeypatch.setattr(ig, "RAW_FILE", tmp_path / "items_game.txt")
+
+    monkeypatch.setattr(ig.requests, "get", lambda url, timeout: DummyResp("raw"))
+    monkeypatch.setattr(
+        ig.local_data, "clean_items_game", lambda text: {"1": {"name": "One"}}
+    )
+
     ig.ITEMS_GAME = None
     data = ig.ensure_items_game_cached()
     assert data.get("items", {}).get("1", {}).get("name") == "One"

--- a/tests/test_local_data.py
+++ b/tests/test_local_data.py
@@ -6,7 +6,7 @@ from utils import local_data as ld
 
 def test_load_files_success(tmp_path, monkeypatch, capsys):
     schema_file = tmp_path / "tf2schema.json"
-    items_file = tmp_path / "items_game.json"
+    items_file = tmp_path / "items_game_cleaned.json"
     schema_file.write_text(json.dumps({"items": {"1": {"name": "One"}}}))
     items_file.write_text(json.dumps({"1": {"name": "A"}}))
     monkeypatch.setattr(ld, "SCHEMA_FILE", schema_file)

--- a/utils/autobot_schema_cache.py
+++ b/utils/autobot_schema_cache.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any, Dict
 
 import requests
+from . import items_game_cache
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +67,6 @@ GRADE_FILES = {
 
 BASE_ENDPOINTS = {
     "tf2schema.json": "/schema",
-    "items_game.json": "/raw/items_game/cleaned",
 }
 
 
@@ -121,6 +121,13 @@ def ensure_all_cached(refresh: bool = False) -> None:
     for fname, endpoint in BASE_ENDPOINTS.items():
         url = f"{BASE_URL}{endpoint}"
         _ensure_file(CACHE_DIR / fname, url, refresh)
+
+    if refresh:
+        items_game_cache.update_items_game()
+    elif not items_game_cache.JSON_FILE.exists():
+        raise RuntimeError(
+            f"Missing {items_game_cache.JSON_FILE}. Run with --refresh to download."
+        )
 
 
 def get_item_grade(defindex: int | str) -> Dict[str, Any]:

--- a/utils/local_data.py
+++ b/utils/local_data.py
@@ -11,8 +11,7 @@ EFFECT_NAMES: Dict[str, str] = {}
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 DEFAULT_SCHEMA_FILE = BASE_DIR / "cache" / "tf2schema.json"
-# Autobot provides an already reduced items_game.json
-DEFAULT_ITEMS_GAME_FILE = BASE_DIR / "cache" / "items_game.json"
+DEFAULT_ITEMS_GAME_FILE = BASE_DIR / "cache" / "items_game_cleaned.json"
 SCHEMA_FILE = Path(os.getenv("TF2_SCHEMA_FILE", DEFAULT_SCHEMA_FILE))
 ITEMS_GAME_FILE = Path(os.getenv("TF2_ITEMS_GAME_FILE", DEFAULT_ITEMS_GAME_FILE))
 
@@ -81,12 +80,12 @@ def load_files(*, auto_refetch: bool = False) -> Tuple[Dict[str, Any], Dict[str,
     with items_game_path.open() as f:
         ITEMS_GAME_CLEANED = json.load(f)
     if not isinstance(ITEMS_GAME_CLEANED, dict) or not ITEMS_GAME_CLEANED:
-        raise RuntimeError("items_game.json is empty or invalid")
+        raise RuntimeError("items_game_cleaned.json is empty or invalid")
     print(
         f"\N{CHECK MARK} Loaded items_game with {len(ITEMS_GAME_CLEANED)} entries from {items_game_path}"
     )
     if len(ITEMS_GAME_CLEANED) < 10000:
         print(
-            "\N{WARNING SIGN} items_game.json may be stale or incomplete. Consider a refresh."
+            "\N{WARNING SIGN} items_game_cleaned.json may be stale or incomplete. Consider a refresh."
         )
     return TF2_SCHEMA, ITEMS_GAME_CLEANED


### PR DESCRIPTION
## Summary
- fetch raw `items_game.txt` from schema.autobot.tf
- clean it locally and store as `items_game_cleaned.json`
- update schema refresh routine to use the cleaned cache
- adjust tests and docs for new filename

## Testing
- `pre-commit run --files utils/items_game_cache.py utils/local_data.py utils/autobot_schema_cache.py scripts/update_items_game.py tests/test_items_game_cache.py tests/test_local_data.py tests/test_autobot_schema_cache.py README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686140e4cfc48326847992bb01572cc0