### PR TITLE
Switch to Autobot schema files

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ Run the application with the `--refresh` flag to download the latest TF2 schema,
 python app.py --refresh
 ```
 
-The files are stored under `cache/` and include `tf2schema.json`,
-`items_game.txt`, `items_game_cleaned.json` and all Autobot API responses. Start
+The files are stored under `cache/` and include the `schema/` and `items_game/`
+JSON files downloaded from Autobot along with `items_game.txt`. Start
 the server normally without `--refresh` after the update completes.
 
 ### Deploy

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -1,5 +1,4 @@
 from utils import inventory_processor as ip
-from utils import schema_fetcher as sf
 from utils import steam_api_client as sac
 from utils import items_game_cache as ig
 from utils import local_data as ld
@@ -18,14 +17,13 @@ def no_items_game(monkeypatch):
 
 def test_enrich_inventory():
     data = {"items": [{"defindex": 111, "quality": 11}]}
-    sf.SCHEMA = {
+    ld.TF2_SCHEMA = {
         "111": {
             "defindex": 111,
             "item_name": "Rocket Launcher",
             "image_url": "https://steamcommunity-a.akamaihd.net/economy/image/img/360fx360f",
         }
     }
-    sf.QUALITIES = {"11": "Strange"}
     items = ip.enrich_inventory(data)
     assert items[0]["name"] == "Strange Rocket Launcher"
     assert items[0]["quality"] == "Strange"
@@ -45,10 +43,9 @@ def test_enrich_inventory_unusual_effect():
             }
         ]
     }
-    sf.SCHEMA = {
+    ld.TF2_SCHEMA = {
         "222": {"defindex": 222, "item_name": "Team Captain", "image_url": "img"}
     }
-    sf.QUALITIES = {"5": "Unusual"}
     ld.EFFECT_NAMES = {"13": "Burning Flames"}
     items = ip.enrich_inventory(data)
     assert items[0]["name"] == "Burning Flames Team Captain"
@@ -57,7 +54,7 @@ def test_enrich_inventory_unusual_effect():
 
 def test_process_inventory_handles_missing_icon():
     data = {"items": [{"defindex": 1}, {"defindex": 2}]}
-    sf.SCHEMA = {
+    ld.TF2_SCHEMA = {
         "1": {
             "defindex": 1,
             "item_name": "One",
@@ -65,7 +62,6 @@ def test_process_inventory_handles_missing_icon():
         },
         "2": {"defindex": 2, "item_name": "Two", "image_url": ""},
     }
-    sf.QUALITIES = {}
     items = ip.process_inventory(data)
     assert {i["name"] for i in items} == {"One", "Two"}
     for item in items:
@@ -80,16 +76,14 @@ def test_process_inventory_handles_missing_icon():
 def test_enrich_inventory_preserves_absolute_url():
     data = {"items": [{"defindex": 5, "quality": 0}]}
     url = "http://example.com/icon.png"
-    sf.SCHEMA = {"5": {"defindex": 5, "item_name": "Abs", "image_url": url}}
-    sf.QUALITIES = {"0": "Normal"}
+    ld.TF2_SCHEMA = {"5": {"defindex": 5, "item_name": "Abs", "image_url": url}}
     items = ip.enrich_inventory(data)
     assert items[0]["image_url"] == url
 
 
 def test_enrich_inventory_skips_unknown_defindex():
     data = {"items": [{"defindex": 1}, {"defindex": 2}]}
-    sf.SCHEMA = {"1": {"defindex": 1, "item_name": "One", "image_url": "a"}}
-    sf.QUALITIES = {}
+    ld.TF2_SCHEMA = {"1": {"defindex": 1, "item_name": "One", "image_url": "a"}}
     items = ip.enrich_inventory(data)
     assert len(items) == 1
     assert items[0]["name"] == "One"

--- a/tests/test_item_name_preference.py
+++ b/tests/test_item_name_preference.py
@@ -1,10 +1,9 @@
 from utils import inventory_processor as ip
-from utils import schema_fetcher as sf
 from utils import local_data as ld
 
 
 def test_enrich_inventory_prefers_items_game(monkeypatch):
-    sf.SCHEMA = {"111": {"defindex": 111, "item_name": "Wrong", "image_url": "i"}}
+    ld.TF2_SCHEMA = {"111": {"defindex": 111, "item_name": "Wrong", "image_url": "i"}}
     ld.ITEMS_GAME_CLEANED = {"111": {"name": "Correct"}}
     data = {"items": [{"defindex": 111, "quality": 6}]}
     items = ip.enrich_inventory(data)

--- a/tests/test_local_data.py
+++ b/tests/test_local_data.py
@@ -5,12 +5,15 @@ from utils import local_data as ld
 
 
 def test_load_files_success(tmp_path, monkeypatch, capsys):
-    schema_file = tmp_path / "tf2schema.json"
-    items_file = tmp_path / "items_game_cleaned.json"
-    schema_file.write_text(json.dumps({"items": {"1": {"name": "One"}}}))
-    items_file.write_text(json.dumps({"1": {"name": "A"}}))
-    monkeypatch.setattr(ld, "SCHEMA_FILE", schema_file)
+    schema_file = tmp_path / "items.json"
+    items_file = tmp_path / "ig_items.json"
+    effects_file = tmp_path / "effects.json"
+    schema_file.write_text(json.dumps({"1": {"name": "One"}}))
+    items_file.write_text(json.dumps({"items": {"1": {"name": "A"}}}))
+    effects_file.write_text(json.dumps({}))
+    monkeypatch.setattr(ld, "SCHEMA_ITEMS_FILE", schema_file)
     monkeypatch.setattr(ld, "ITEMS_GAME_FILE", items_file)
+    monkeypatch.setattr(ld, "EFFECTS_FILE", effects_file)
     ld.TF2_SCHEMA = {}
     ld.ITEMS_GAME_CLEANED = {}
     ld.EFFECT_NAMES = {}
@@ -18,12 +21,13 @@ def test_load_files_success(tmp_path, monkeypatch, capsys):
     out = capsys.readouterr().out
     assert ld.TF2_SCHEMA["1"]["name"] == "One"
     assert f"Loaded 1 items from {schema_file}" in out
-    assert "tf2schema.json may be stale" in out
+    assert "schema/items.json may be stale" in out
 
 
 def test_load_files_missing(tmp_path, monkeypatch):
-    monkeypatch.setattr(ld, "SCHEMA_FILE", tmp_path / "missing.json")
+    monkeypatch.setattr(ld, "SCHEMA_ITEMS_FILE", tmp_path / "missing.json")
     monkeypatch.setattr(ld, "ITEMS_GAME_FILE", tmp_path / "missing2.json")
+    monkeypatch.setattr(ld, "EFFECTS_FILE", tmp_path / "missing3.json")
     with pytest.raises(RuntimeError):
         ld.load_files()
 

--- a/tests/test_utils_extras.py
+++ b/tests/test_utils_extras.py
@@ -1,6 +1,5 @@
 from utils import steam_api_client as sac
 from utils import inventory_processor as ip
-from utils import schema_fetcher as sf
 from utils import items_game_cache as ig
 import pytest
 
@@ -21,10 +20,11 @@ def no_items_game(monkeypatch):
 
 def test_process_inventory_sorting():
     data = {"items": [{"defindex": 2}, {"defindex": 1}]}
-    sf.SCHEMA = {
+    from utils import local_data as ld
+
+    ld.TF2_SCHEMA = {
         "1": {"defindex": 1, "item_name": "A", "image_url": "b"},
         "2": {"defindex": 2, "item_name": "B", "image_url": "a"},
     }
-    sf.QUALITIES = {}
     items = ip.process_inventory(data)
     assert [item["name"] for item in items] == ["A", "B"]

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -6,7 +6,7 @@ from html import unescape
 import json
 from pathlib import Path
 
-from . import steam_api_client, schema_fetcher, items_game_cache, local_data
+from . import steam_api_client, items_game_cache, local_data
 
 logger = logging.getLogger(__name__)
 
@@ -225,7 +225,7 @@ def enrich_inventory(data: Dict[str, Any]) -> List[Dict[str, Any]]:
         return []
 
     items: List[Dict[str, Any]] = []
-    schema_map = local_data.TF2_SCHEMA or schema_fetcher.SCHEMA or {}
+    schema_map = local_data.TF2_SCHEMA
     cleaned_map = local_data.ITEMS_GAME_CLEANED or items_game_cache.ITEM_BY_DEFINDEX
 
     for asset in items_raw:


### PR DESCRIPTION
## Summary
- use `cache/schema/items.json` and related Autobot files instead of the old `tf2schema.json`
- drop fallback to `schema_fetcher` within the inventory processor
- update tests for new file names and schema globals
- document new cache layout in README

## Testing
- `pre-commit run --files utils/local_data.py utils/inventory_processor.py tests/test_inventory_processor.py tests/test_item_name_preference.py tests/test_local_data.py tests/test_utils_extras.py README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686150a41704832680d65885b7525a02