### PR TITLE
Fix items_game fetching from Autobot

### DIFF
--- a/utils/autobot_schema_cache.py
+++ b/utils/autobot_schema_cache.py
@@ -16,7 +16,6 @@ PROPERTIES_DIR = CACHE_DIR / "properties"
 GRADES_DIR = CACHE_DIR / "grades"
 
 SCHEMA_KEYS = [
-    "items_game_url",
     "qualities",
     "qualityNames",
     "originNames",
@@ -33,10 +32,12 @@ SCHEMA_KEYS = [
 ITEMS_GAME_KEYS = [
     "items",
     "attributes",
-    "item_sets",
-    "recipes",
-    "attribute_controlled_attached_particles",
-    "community_market_item_remaps",
+    "game_info",
+    "rarities",
+    "paintkits",
+    "paints",
+    "strange_parts",
+    "prefabs",
 ]
 
 PROPERTIES_KEYS = [


### PR DESCRIPTION
## Summary
- stop requesting the missing `/schema/items_game_url`
- fetch items_game metadata via specific subkeys

## Testing
- `pre-commit run --files utils/autobot_schema_cache.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861523075e48326a6263bf4acf8dc6c