### PR TITLE
Add attribute badges and modal details

### DIFF
--- a/static/retry.js
+++ b/static/retry.js
@@ -134,6 +134,17 @@ function attachItemModal() {
 
         details.appendChild(attrs);
 
+        if (Array.isArray(data.strange_parts) && data.strange_parts.length) {
+          const head = document.createElement('h4');
+          head.textContent = 'Strange Parts';
+          details.appendChild(head);
+          data.strange_parts.forEach(part => {
+            const div = document.createElement('div');
+            div.textContent = part;
+            details.appendChild(div);
+          });
+        }
+
         if (Array.isArray(data.spells) && data.spells.length) {
           const head = document.createElement('h4');
           head.textContent = 'Spells';
@@ -141,15 +152,37 @@ function attachItemModal() {
           details.appendChild(head);
           data.spells.forEach(sp => {
             const sdiv = document.createElement('div');
-            sdiv.textContent = sp;
+            let icon = '';
+            const l = sp.toLowerCase();
+            if (l.includes('footsteps')) icon = '👣';
+            else if (l.includes('exorcism')) icon = '👻';
+            else if (l.includes('pumpkin')) icon = '🎃';
+            else if (l.includes('paint')) icon = '🎨';
+            if (icon) {
+              const span = document.createElement('span');
+              span.className = 'badge-icon';
+              span.textContent = icon;
+              span.style.marginRight = '4px';
+              sdiv.appendChild(span);
+            }
+            sdiv.appendChild(document.createTextNode(sp));
             details.appendChild(sdiv);
           });
         }
       }
       if (badgeBox) {
         badgeBox.innerHTML = '';
-        (data.badges || []).forEach(b => {
+        const extra = [];
+        if (data.paint_name) extra.push({ icon: '🎨', title: 'Painted' });
+        if (data.killstreak_tier)
+          extra.push({ icon: '⚔️', title: data.killstreak_tier });
+        if (data.killstreaker_effect)
+          extra.push({ icon: '💀', title: 'Killstreaker Effect' });
+        if (Array.isArray(data.strange_parts) && data.strange_parts.length)
+          extra.push({ icon: '📊', title: 'Strange Parts' });
+        [...(data.badges || []), ...extra].forEach(b => {
           const span = document.createElement('span');
+          span.className = 'badge-icon';
           span.textContent = b.icon;
           span.title = b.title;
           span.addEventListener('click', () => {

--- a/static/style.css
+++ b/static/style.css
@@ -151,6 +151,7 @@ button {
   border-radius: 8px;
   overflow: hidden;
   background-color: #1e1e1e;
+  position: relative;
 }
 
 .item-card:hover {
@@ -179,6 +180,21 @@ button {
 }
 
 .tf2-hours { margin-left: 6px; font-size: 0.9em; }
+
+.item-badges {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  display: flex;
+  gap: 2px;
+}
+
+.badge-icon {
+  font-size: 0.75rem;
+  background: rgba(0, 0, 0, 0.5);
+  border-radius: 3px;
+  padding: 0 2px;
+}
 
 .page-footer {
   margin-top: 2rem;

--- a/templates/_user.html
+++ b/templates/_user.html
@@ -30,8 +30,20 @@
           <div class="item-card" style="border-color: {{ item.quality_color }};" data-item='{{ item|tojson|safe }}'>
             <div class="item-badges">
               {% for badge in item.badges or [] %}
-                <span title="{{ badge.title }}">{{ badge.icon }}</span>
+                <span class="badge-icon" title="{{ badge.title }}">{{ badge.icon }}</span>
               {% endfor %}
+              {% if item.paint_name %}
+                <span class="badge-icon" title="Painted">🎨</span>
+              {% endif %}
+              {% if item.killstreak_tier %}
+                <span class="badge-icon" title="{{ item.killstreak_tier }}">⚔️</span>
+              {% endif %}
+              {% if item.killstreaker_effect %}
+                <span class="badge-icon" title="Killstreaker Effect">💀</span>
+              {% endif %}
+              {% if item.strange_parts %}
+                <span class="badge-icon" title="Strange Parts">📊</span>
+              {% endif %}
             </div>
             {% if item.image_url %}
               <img class="item-img" src="{{ item.image_url }}" alt="{{ item.name }}" width="64" height="64" onerror="this.style.display='none';">

--- a/templates/index.html
+++ b/templates/index.html
@@ -81,7 +81,12 @@
         }
         #modal-details div { margin-top: 2px; }
         .item-badges { position: absolute; top: 2px; right: 2px; display: flex; gap: 2px; }
-        .item-badges span { font-size: 0.75rem; }
+        .badge-icon {
+            font-size: 0.75rem;
+            background: rgba(0, 0, 0, 0.5);
+            border-radius: 3px;
+            padding: 0 2px;
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- add overlay badge icons for special attributes
- list strange parts and spells with icons in modal
- add CSS styles for new badges

## Testing
- `pre-commit run --files templates/_user.html templates/index.html static/retry.js static/style.css`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6861756064888326af0444cf0faf838a