### PR TITLE
Improve badge generation

### DIFF
--- a/templates/_user.html
+++ b/templates/_user.html
@@ -32,18 +32,6 @@
               {% for badge in item.badges or [] %}
                 <span class="badge-icon" title="{{ badge.title }}">{{ badge.icon }}</span>
               {% endfor %}
-              {% if item.paint_name %}
-                <span class="badge-icon" title="Painted">🎨</span>
-              {% endif %}
-              {% if item.killstreak_tier %}
-                <span class="badge-icon" title="{{ item.killstreak_tier }}">⚔️</span>
-              {% endif %}
-              {% if item.killstreaker_effect %}
-                <span class="badge-icon" title="Killstreaker Effect">💀</span>
-              {% endif %}
-              {% if item.strange_parts %}
-                <span class="badge-icon" title="Strange Parts">📊</span>
-              {% endif %}
             </div>
             {% if item.image_url %}
               <img class="item-img" src="{{ item.image_url }}" alt="{{ item.name }}" width="64" height="64" onerror="this.style.display='none';">


### PR DESCRIPTION
## Summary
- consolidate badge detection logic in `generate_badges`
- add `STRANGE_PART_MAP` and `_extract_strange_parts`
- expose `unusual_effect` and `strange_parts` on items
- rely on server-provided badges in the user template

## Testing
- `pre-commit run --files utils/inventory_processor.py templates/_user.html`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68619158911883268f24614d76ef1e56