### PR TITLE
Fix item modal details

### DIFF
--- a/static/retry.js
+++ b/static/retry.js
@@ -135,17 +135,18 @@ function attachItemModal() {
         wrap.style.display = '';
       }
 
-      setSection('general', [
-        ['Quality', data.quality],
-        ['Origin', data.origin],
-        ['Level', data.level],
-      ]);
+      const generalEntries = [];
+      if (data.quality) generalEntries.push(['Quality', data.quality]);
+      if (data.level) generalEntries.push(['', 'Level ' + data.level]);
+      if (data.origin) generalEntries.push(['', data.origin]);
+      setSection('general', generalEntries);
 
-      setSection('killstreak', [
-        ['Tier', data.killstreak_tier],
-        ['Sheen', data.sheen],
-        ['Effect', data.killstreak_effect],
-      ]);
+      const ksEntries = [];
+      if (data.killstreak_tier) ksEntries.push(['Tier', data.killstreak_tier]);
+      if (data.sheen) ksEntries.push(['Sheen', data.sheen]);
+      if (data.killstreak_effect)
+        ksEntries.push(['Effect', data.killstreak_effect]);
+      setSection('killstreak', ksEntries);
 
       if (sections.paint && sectionWrap.paint) {
         sections.paint.innerHTML = '';

--- a/templates/index.html
+++ b/templates/index.html
@@ -129,7 +129,7 @@
             <div id="modal-general"></div>
           </div>
           <div id="section-killstreak" class="modal-section">
-            <h4>Killstreak</h4>
+            <h4>Killstreak Info</h4>
             <div id="modal-killstreak"></div>
           </div>
           <div id="section-paint" class="modal-section">


### PR DESCRIPTION
## Summary
- tweak modal wording in `index.html`
- show level/origin and killstreak effect correctly in modal

## Testing
- `pre-commit run --files templates/index.html static/retry.js static/style.css`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861990c881483268f2bdfb8f0e5b00a