### PR TITLE
Fix killstreaker effect & spell parsing

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -95,6 +95,38 @@ def test_enrich_inventory_skips_unknown_defindex():
     assert items[0]["name"] == "One"
 
 
+def test_enrich_inventory_killstreak_effect_from_attribute():
+    data = {
+        "items": [
+            {
+                "defindex": 111,
+                "quality": 6,
+                "attributes": [{"defindex": 2071, "float_value": 2003}],
+            }
+        ]
+    }
+    sf.SCHEMA = {"111": {"defindex": 111, "item_name": "Rocket", "image_url": "i"}}
+    sf.QUALITIES = {"6": "Unique"}
+    ld.EFFECT_NAMES = {"2003": "Cerebral Discharge"}
+    items = ip.enrich_inventory(data)
+    assert items[0]["killstreak_effect"] == "Cerebral Discharge"
+
+
+def test_enrich_inventory_spells_bitmask():
+    data = {
+        "items": [
+            {
+                "defindex": 111,
+                "attributes": [{"defindex": 730, "float_value": 5}],
+            }
+        ]
+    }
+    sf.SCHEMA = {"111": {"defindex": 111, "item_name": "Rocket", "image_url": "i"}}
+    sf.QUALITIES = {}
+    items = ip.enrich_inventory(data)
+    assert set(items[0]["spells"]) == {"Exorcism", "Footprints"}
+
+
 def test_get_inventories_adds_user_agent(monkeypatch):
     captured = {}
 

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -147,6 +147,14 @@ def _extract_paint(asset: Dict[str, Any]) -> Tuple[str | None, str | None]:
 def _extract_killstreak_effect(asset: Dict[str, Any]) -> str | None:
     """Return killstreak effect string if present."""
 
+    for attr in asset.get("attributes", []):
+        idx = attr.get("defindex")
+        if idx in (2071, 2013):
+            val = str(int(attr.get("float_value", 0)))
+            name = local_data.EFFECT_NAMES.get(val)
+            if name:
+                return name
+
     for desc in asset.get("descriptions", []):
         if not isinstance(desc, dict):
             continue
@@ -169,6 +177,14 @@ def _extract_spells(asset: Dict[str, Any]) -> Tuple[List[str], Dict[str, bool]]:
         "has_pumpkin_bombs": False,
         "has_voice_lines": False,
     }
+    SPELL_BITS = {
+        1: ("Exorcism", "has_exorcism"),
+        2: ("Paint Spell", "has_paint_spell"),
+        4: ("Footprints", "has_footprints"),
+        8: ("Pumpkin Bombs", "has_pumpkin_bombs"),
+        16: ("Voices From Below", "has_voice_lines"),
+    }
+
     for desc in asset.get("descriptions", []):
         if not isinstance(desc, dict):
             continue
@@ -187,6 +203,16 @@ def _extract_spells(asset: Dict[str, Any]) -> Tuple[List[str], Dict[str, bool]]:
             flags["has_pumpkin_bombs"] = True
         if "voices" in ltext or "rare spell" in ltext:
             flags["has_voice_lines"] = True
+
+    for attr in asset.get("attributes", []):
+        if attr.get("defindex") == 730:
+            bitmask = int(attr.get("float_value", 0))
+            for bit, (name, flag) in SPELL_BITS.items():
+                if bitmask & bit:
+                    if name not in lines:
+                        lines.append(name)
+                    flags[flag] = True
+            break
     return lines, flags
 
 


### PR DESCRIPTION
## Summary
- check attributes 2071/2013 for killstreaker effect ids
- read spell bitmask from attribute 730
- add regression tests for killstreak effect and spells

## Testing
- `pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861a63595688326bdfadf28cc1b00dd