### PR TITLE
codex/enrich-all-item-features

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ Only the SteamID3 token is used:
 
 The application converts the ID to SteamID64 and fetches the inventory.
 
+### Enriched Item Data
+
+Each item returned from the API is decorated with extra fields such as
+`killstreak_tier`, `sheen`, `killstreaker`, applied paints, spells and strange
+parts. Boolean flags like `is_festivized` and a list of `badges` make it easy to
+display everything in the UI. Refer to `utils/inventory_processor.py` for the
+full structure.
+
 ## Dependency Management
 
 Dependencies are pinned in `requirements.txt` and locked with

--- a/static/retry.js
+++ b/static/retry.js
@@ -139,13 +139,14 @@ function attachItemModal() {
       if (data.quality) generalEntries.push(['Quality', data.quality]);
       if (data.level) generalEntries.push(['', 'Level ' + data.level]);
       if (data.origin) generalEntries.push(['', data.origin]);
+      if (data.unusual_effect) generalEntries.push(['Effect', data.unusual_effect]);
+      if (data.is_festivized) generalEntries.push(['Festivized', 'Yes']);
       setSection('general', generalEntries);
 
       const ksEntries = [];
       if (data.killstreak_tier) ksEntries.push(['Tier', data.killstreak_tier]);
       if (data.sheen) ksEntries.push(['Sheen', data.sheen]);
-      if (data.killstreak_effect)
-        ksEntries.push(['Effect', data.killstreak_effect]);
+      if (data.killstreaker) ksEntries.push(['Killstreaker', data.killstreaker]);
       setSection('killstreak', ksEntries);
 
       if (sections.paint && sectionWrap.paint) {

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -109,7 +109,7 @@ def test_enrich_inventory_killstreak_effect_from_attribute():
     sf.QUALITIES = {"6": "Unique"}
     ld.EFFECT_NAMES = {"2003": "Cerebral Discharge"}
     items = ip.enrich_inventory(data)
-    assert items[0]["killstreak_effect"] == "Cerebral Discharge"
+    assert items[0]["killstreaker"] == "Cerebral Discharge"
 
 
 def test_enrich_inventory_spells_bitmask():
@@ -124,7 +124,33 @@ def test_enrich_inventory_spells_bitmask():
     sf.SCHEMA = {"111": {"defindex": 111, "item_name": "Rocket", "image_url": "i"}}
     sf.QUALITIES = {}
     items = ip.enrich_inventory(data)
-    assert set(items[0]["spells"]) == {"Exorcism", "Footprints"}
+    assert set(items[0]["spells"]) == {"Fire Footprints", "Pumpkin Bombs"}
+
+
+def test_attribute_handlers_combined():
+    data = {
+        "items": [
+            {
+                "defindex": 999,
+                "quality": 6,
+                "attributes": [
+                    {"defindex": 730, "float_value": 17},
+                    {"defindex": 2071, "float_value": 2003},
+                    {"defindex": 380, "float_value": 0},
+                ],
+            }
+        ]
+    }
+    sf.SCHEMA = {"999": {"defindex": 999, "item_name": "Thing", "image_url": ""}}
+    sf.QUALITIES = {"6": "Unique"}
+    ld.EFFECT_NAMES = {"2003": "Cerebral Discharge"}
+    items = ip.enrich_inventory(data)
+    item = items[0]
+    assert item["killstreaker"] == "Cerebral Discharge"
+    assert set(item["spells"]) == {"Fire Footprints", "Paint Spell"}
+    assert item["spell_flags"]["footprints"]
+    assert item["spell_flags"]["paint_spell"]
+    assert "Heavies Killed" in item["strange_parts"]
 
 
 def test_get_inventories_adds_user_agent(monkeypatch):

--- a/utils/local_data.py
+++ b/utils/local_data.py
@@ -9,6 +9,55 @@ TF2_SCHEMA: Dict[str, Any] = {}
 ITEMS_GAME_CLEANED: Dict[str, Any] = {}
 EFFECT_NAMES: Dict[str, str] = {}
 
+# Common lookup tables for item enrichment
+PAINT_MAP: Dict[int, Tuple[str, str]] = {
+    3100495: ("A Color Similar to Slate", "#2F4F4F"),
+    8208497: ("A Deep Commitment to Purple", "#7D4071"),
+    8208498: ("A Distinctive Lack of Hue", "#141414"),
+    1315860: ("An Extraordinary Abundance of Tinge", "#CF7336"),
+    2960676: ("Color No. 216-190-216", "#D8BED8"),
+    8289918: ("Dark Salmon Injustice", "#8847FF"),
+    15132390: ("Drably Olive", "#808000"),
+    8421376: ("Indubitably Green", "#729E42"),
+    13595446: ("Mann Co. Orange", "#CF7336"),
+    12377523: ("Muskelmannbraun", "#A57545"),
+    5322826: ("Noble Hatter's Violet", "#51384A"),
+    15787660: ("Pink as Hell", "#FF69B4"),
+    15185211: ("A Mann's Mint", "#BCDDB3"),
+}
+
+KILLSTREAK_TIERS = {
+    1: "Killstreak",
+    2: "Specialized Killstreak",
+    3: "Professional Killstreak",
+}
+
+SHEEN_NAMES = {
+    1: "Team Shine",
+    2: "Deadly Daffodil",
+    3: "Mandarin",
+    4: "Mean Green",
+    5: "Villainous Violet",
+    6: "Hot Rod",
+}
+
+SPELL_BITFLAGS = {
+    1: ("Fire Footprints", "footprints"),
+    2: ("Voices From Below", "voices"),
+    4: ("Pumpkin Bombs", "pumpkin"),
+    8: ("Exorcism", "exorcism"),
+    16: ("Paint Spell", "paint_spell"),
+}
+
+STRANGE_PARTS = {
+    380: "Heavies Killed",
+    381: "Buildings Destroyed",
+    382: "Domination Kills",
+    383: "Kills While Ubercharged",
+    384: "Kills While Explosive Jumping",
+    385: "Kills During Victory Time",
+}
+
 BASE_DIR = Path(__file__).resolve().parent.parent
 DEFAULT_SCHEMA_FILE = BASE_DIR / "cache" / "tf2_schema.json"
 DEFAULT_ITEMS_GAME_FILE = BASE_DIR / "cache" / "items_game_cleaned.json"


### PR DESCRIPTION
## Summary
- decode all Steam item attributes with a unified handler table
- expose color, sheen, spell and effect maps in `local_data`
- surface festivity flags, killstreaker effects and spells in the UI
- extend tests for new enrichment fields
- document enriched item fields in the README

## Testing
- `pre-commit run --files utils/inventory_processor.py utils/local_data.py static/retry.js README.md tests/test_inventory_processor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861c556a370832683c0187a0ed309bb