### PR TITLE
Implement item enrichment features

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,3 +134,39 @@ docker run -p 5000:5000 tf2-scanner
 python app.py          # now reachable at http://<LAN_IP>:5000
 docker run -p 5000:5000 tf2-inv
 ```
+
+## 🎖 Enriched Item Fields
+
+| Key                 | Example                        | Description           |
+| ------------------- | ------------------------------ | --------------------- |
+| defindex            | `222`                          | Item definition index |
+| name                | `Professional Rocket Launcher` | Display name          |
+| quality             | `Unique`                       | Item quality string   |
+| quality_color       | `#FFD700`                      | Hex color for quality |
+| image_url           | `https://...`                  | Item icon URL         |
+| item_type_name      | `Rocket Launcher`              | Type from schema      |
+| item_name           | `Rocket Launcher`              | Raw schema name       |
+| craft_class         | `weapon`                       | Craft class           |
+| craft_material_type | `weapon`                       | Craft material        |
+| item_set            | _varies_                       | Item set name         |
+| capabilities        | _dict_                         | Capability flags      |
+| tags                | _list_                         | Schema tags           |
+| equip_regions       | _list_                         | Equip region list     |
+| item_class          | `tf_weapon_rocketlauncher`     | Class string          |
+| slot_type           | `primary`                      | Equip slot            |
+| level               | `1`                            | Item level            |
+| origin              | `Timed Drop`                   | Item origin           |
+| killstreak_tier     | `Professional`                 | Killstreak tier       |
+| sheen               | `Team Shine`                   | Killstreak sheen      |
+| killstreaker        | `Fire Horns`                   | Killstreaker effect   |
+| paint_name          | `A Deep Commitment to Purple`  | Applied paint         |
+| paint_hex           | `#7D4071`                      | Paint color           |
+| spells              | `["Exorcism"]`                 | Halloween spells      |
+| strange_parts       | `["Buildings Destroyed"]`      | Attached parts        |
+| unusual_effect      | `Burning Flames`               | Unusual effect        |
+| is_festivized       | `true`                         | Has festive lights    |
+| custom_name         | `"My Launcher"`                | Player-set name       |
+| badges              | `[{'icon': '🎨'}]`             | Badge metadata        |
+| misc_attrs          | _list_                         | Unhandled attributes  |
+
+**Emoji legend:** 🎨 paint, ⚔️ killstreak tier, 💀 killstreaker, ✨ sheen, 👣 footprints, 👻 exorcism, 🎃 pumpkin bombs, 🗣 voices from below, 📊 strange parts, 🎄 festive, 🔥 unusual effect.

--- a/scripts/smoke_parse.py
+++ b/scripts/smoke_parse.py
@@ -1,0 +1,15 @@
+import json
+from utils.inventory_processor import enrich_inventory
+
+for path in [
+    "tests/fixtures/pro_item.json",
+    "tests/fixtures/simple_item.json",
+    "tests/fixtures/unusual_item.json",
+]:
+    with open(path) as f:
+        data = {"items": [json.load(f)]}
+        items = enrich_inventory(data)
+        badges = sum(len(i.get("badges", [])) for i in items)
+        print(f"{path}: {len(items)} items, {badges} badges")
+
+print("OK")

--- a/static/retry.js
+++ b/static/retry.js
@@ -1,23 +1,23 @@
 function appendCard(html) {
-  const wrapper = document.createElement('div');
+  const wrapper = document.createElement("div");
   wrapper.innerHTML = html;
   const card = wrapper.firstElementChild;
   if (card) {
-    document.getElementById('user-container').appendChild(card);
+    document.getElementById("user-container").appendChild(card);
   }
 }
 
 function refreshCard(id) {
-  const pill = document.querySelector('#user-' + id + ' .status-pill');
+  const pill = document.querySelector("#user-" + id + " .status-pill");
   if (pill) {
     pill.innerHTML = '<i class="fa-solid fa-arrows-rotate fa-spin"></i>';
   }
-  return fetch('/retry/' + id, { method: 'POST' })
-    .then(r => r.text())
-    .then(html => {
-      const existing = document.getElementById('user-' + id);
+  return fetch("/retry/" + id, { method: "POST" })
+    .then((r) => r.text())
+    .then((html) => {
+      const existing = document.getElementById("user-" + id);
       if (existing) {
-        const wrapper = document.createElement('div');
+        const wrapper = document.createElement("div");
         wrapper.innerHTML = html;
         existing.replaceWith(wrapper.firstElementChild);
       } else {
@@ -28,25 +28,25 @@ function refreshCard(id) {
 }
 
 function attachHandlers() {
-  document.querySelectorAll('.retry-pill').forEach(el => {
-    el.addEventListener('click', () => refreshCard(el.dataset.steamid));
+  document.querySelectorAll(".retry-pill").forEach((el) => {
+    el.addEventListener("click", () => refreshCard(el.dataset.steamid));
   });
-  const btn = document.getElementById('retry-all');
+  const btn = document.getElementById("retry-all");
   if (btn) {
-    btn.disabled = document.querySelectorAll('.retry-pill').length === 0;
+    btn.disabled = document.querySelectorAll(".retry-pill").length === 0;
   }
 
   attachItemModal();
 }
 
 function refreshAll() {
-  const btn = document.getElementById('retry-all');
+  const btn = document.getElementById("retry-all");
   if (!btn) return;
   btn.disabled = true;
   const original = btn.textContent;
-  btn.textContent = 'Refreshing…';
-  const promises = Array.from(document.querySelectorAll('.retry-pill')).map(el =>
-    refreshCard(el.dataset.steamid)
+  btn.textContent = "Refreshing…";
+  const promises = Array.from(document.querySelectorAll(".retry-pill")).map(
+    (el) => refreshCard(el.dataset.steamid),
   );
   Promise.all(promises).finally(() => {
     btn.disabled = false;
@@ -56,48 +56,48 @@ function refreshAll() {
 }
 
 function loadUsers(ids) {
-  ids.forEach(id => {
+  ids.forEach((id) => {
     refreshCard(id);
   });
 }
 
 function attachItemModal() {
-  const modal = document.getElementById('item-modal');
+  const modal = document.getElementById("item-modal");
   if (!modal) return;
-  const title = document.getElementById('modal-title');
-  const img = document.getElementById('modal-img');
-  const missing = document.getElementById('modal-missing');
-  const details = document.getElementById('modal-details');
-  const badgeBox = document.getElementById('modal-badges');
-  const copyLink = document.getElementById('copy-json');
+  const title = document.getElementById("modal-title");
+  const img = document.getElementById("modal-img");
+  const missing = document.getElementById("modal-missing");
+  const details = document.getElementById("modal-details");
+  const badgeBox = document.getElementById("modal-badges");
+  const copyLink = document.getElementById("copy-json");
 
   const sections = {
-    general: document.getElementById('modal-general'),
-    killstreak: document.getElementById('modal-killstreak'),
-    paint: document.getElementById('modal-paint'),
-    spells: document.getElementById('modal-spells'),
-    parts: document.getElementById('modal-parts'),
+    general: document.getElementById("modal-general"),
+    killstreak: document.getElementById("modal-killstreak"),
+    paint: document.getElementById("modal-paint"),
+    spells: document.getElementById("modal-spells"),
+    parts: document.getElementById("modal-parts"),
   };
   const sectionWrap = {
-    general: document.getElementById('section-general'),
-    killstreak: document.getElementById('section-killstreak'),
-    paint: document.getElementById('section-paint'),
-    spells: document.getElementById('section-spells'),
-    parts: document.getElementById('section-parts'),
+    general: document.getElementById("section-general"),
+    killstreak: document.getElementById("section-killstreak"),
+    paint: document.getElementById("section-paint"),
+    spells: document.getElementById("section-spells"),
+    parts: document.getElementById("section-parts"),
   };
 
   function closeModal() {
-    modal.style.opacity = '0';
-    modal.style.transform = 'scale(0.95)';
+    modal.style.opacity = "0";
+    modal.style.transform = "scale(0.95)";
     setTimeout(() => modal.close(), 200);
   }
 
-  modal.addEventListener('click', e => {
+  modal.addEventListener("click", (e) => {
     if (e.target === modal) closeModal();
   });
 
-  document.querySelectorAll('.item-card').forEach(card => {
-    card.addEventListener('click', () => {
+  document.querySelectorAll(".item-card").forEach((card) => {
+    card.addEventListener("click", () => {
       let data = card.dataset.item;
       if (!data) return;
       try {
@@ -105,15 +105,24 @@ function attachItemModal() {
       } catch {
         return;
       }
-      if (title) title.textContent = data.name || '';
+      const safe = [
+        "killstreaker",
+        "unusual_effect",
+        "is_festivized",
+        "spells",
+      ];
+      safe.forEach((k) => {
+        if (data[k] === undefined) data[k] = null;
+      });
+      if (title) title.textContent = data.name || "";
       if (img) {
         if (data.image_url) {
-          img.style.display = 'block';
+          img.style.display = "block";
           img.src = data.image_url;
-          if (missing) missing.style.display = 'none';
+          if (missing) missing.style.display = "none";
         } else {
-          img.style.display = 'none';
-          if (missing) missing.style.display = 'flex';
+          img.style.display = "none";
+          if (missing) missing.style.display = "flex";
         }
       }
 
@@ -121,118 +130,124 @@ function attachItemModal() {
         const box = sections[key];
         const wrap = sectionWrap[key];
         if (!box || !wrap) return;
-        box.innerHTML = '';
-        const rows = entries.filter(e => e[1]);
+        box.innerHTML = "";
+        const rows = entries.filter((e) => e[1]);
         if (!rows.length) {
-          wrap.style.display = 'none';
+          wrap.style.display = "none";
           return;
         }
         rows.forEach(([label, val]) => {
-          const div = document.createElement('div');
-          div.textContent = label ? label + ': ' + val : val;
+          const div = document.createElement("div");
+          div.textContent = label ? label + ": " + val : val;
           box.appendChild(div);
         });
-        wrap.style.display = '';
+        wrap.style.display = "";
       }
 
       const generalEntries = [];
-      if (data.quality) generalEntries.push(['Quality', data.quality]);
-      if (data.level) generalEntries.push(['', 'Level ' + data.level]);
-      if (data.origin) generalEntries.push(['', data.origin]);
-      setSection('general', generalEntries);
+      if (data.quality) generalEntries.push(["Quality", data.quality]);
+      if (data.level) generalEntries.push(["", "Level " + data.level]);
+      if (data.origin) generalEntries.push(["", data.origin]);
+      if (data.unusual_effect)
+        generalEntries.push(["Unusual", data.unusual_effect]);
+      if (data.is_festivized !== null)
+        generalEntries.push(["Festivized", data.is_festivized ? "✓" : "✗"]);
+      setSection("general", generalEntries);
 
       const ksEntries = [];
-      if (data.killstreak_tier) ksEntries.push(['Tier', data.killstreak_tier]);
-      if (data.sheen) ksEntries.push(['Sheen', data.sheen]);
-      if (data.killstreak_effect)
-        ksEntries.push(['Effect', data.killstreak_effect]);
-      setSection('killstreak', ksEntries);
+      if (data.killstreak_tier) ksEntries.push(["Tier", data.killstreak_tier]);
+      if (data.sheen) ksEntries.push(["Sheen", data.sheen]);
+      if (data.killstreaker)
+        ksEntries.push(["Killstreaker", data.killstreaker]);
+      setSection("killstreak", ksEntries);
 
       if (sections.paint && sectionWrap.paint) {
-        sections.paint.innerHTML = '';
+        sections.paint.innerHTML = "";
         if (data.paint_name) {
-          const div = document.createElement('div');
+          const div = document.createElement("div");
           if (data.paint_hex) {
-            const sw = document.createElement('span');
-            sw.className = 'paint-swatch';
+            const sw = document.createElement("span");
+            sw.className = "paint-swatch";
             sw.style.background = data.paint_hex;
             div.appendChild(sw);
           }
           div.appendChild(document.createTextNode(data.paint_name));
           sections.paint.appendChild(div);
-          sectionWrap.paint.style.display = '';
+          sectionWrap.paint.style.display = "";
         } else {
-          sectionWrap.paint.style.display = 'none';
+          sectionWrap.paint.style.display = "none";
         }
       }
 
       if (sections.spells && sectionWrap.spells) {
-        sections.spells.innerHTML = '';
+        sections.spells.innerHTML = "";
         if (Array.isArray(data.spells) && data.spells.length) {
-          data.spells.forEach(sp => {
-            const li = document.createElement('li');
+          data.spells.forEach((sp) => {
+            const li = document.createElement("li");
             li.textContent = sp;
             sections.spells.appendChild(li);
           });
-          sectionWrap.spells.style.display = '';
+          sectionWrap.spells.style.display = "";
         } else {
-          sectionWrap.spells.style.display = 'none';
+          sectionWrap.spells.style.display = "none";
         }
       }
 
       if (sections.parts && sectionWrap.parts) {
-        sections.parts.innerHTML = '';
+        sections.parts.innerHTML = "";
         if (Array.isArray(data.strange_parts) && data.strange_parts.length) {
-          data.strange_parts.forEach(pt => {
-            const li = document.createElement('li');
+          data.strange_parts.forEach((pt) => {
+            const li = document.createElement("li");
             li.textContent = pt;
             sections.parts.appendChild(li);
           });
-          sectionWrap.parts.style.display = '';
+          sectionWrap.parts.style.display = "";
         } else {
-          sectionWrap.parts.style.display = 'none';
+          sectionWrap.parts.style.display = "none";
         }
       }
 
       if (copyLink) {
         if (window.debugMode) {
-          copyLink.style.display = 'inline';
-          copyLink.onclick = e => {
+          copyLink.style.display = "inline";
+          copyLink.onclick = (e) => {
             e.preventDefault();
             navigator.clipboard.writeText(JSON.stringify(data, null, 2));
-            copyLink.textContent = 'copied!';
-            setTimeout(() => (copyLink.textContent = 'copy raw JSON'), 1000);
+            copyLink.textContent = "copied!";
+            setTimeout(() => (copyLink.textContent = "copy raw JSON"), 1000);
           };
         } else {
-          copyLink.style.display = 'none';
+          copyLink.style.display = "none";
         }
       }
 
       if (badgeBox) {
-        badgeBox.innerHTML = '';
-        (data.badges || []).forEach(b => {
-          const span = document.createElement('span');
-          span.className = 'badge-icon';
+        badgeBox.innerHTML = "";
+        (data.badges || []).forEach((b) => {
+          const span = document.createElement("span");
+          span.className = "badge-icon";
           span.textContent = b.icon;
           span.title = b.title;
-          let target = '';
-          if (b.icon === '🎨') {
-            target = b.title.startsWith('Painted') ? 'section-paint' : 'section-spells';
-          } else if (b.icon === '⚔️' || b.icon === '💀') {
-            target = 'section-killstreak';
-          } else if (b.icon === '📊') {
-            target = 'section-parts';
-          } else if (['👻', '👣', '🎃', '✨'].includes(b.icon)) {
-            target = 'section-spells';
+          let target = "";
+          if (b.icon === "🎨") {
+            target = b.title.startsWith("Painted")
+              ? "section-paint"
+              : "section-spells";
+          } else if (b.icon === "⚔️" || b.icon === "💀") {
+            target = "section-killstreak";
+          } else if (b.icon === "📊") {
+            target = "section-parts";
+          } else if (["👻", "👣", "🎃", "✨"].includes(b.icon)) {
+            target = "section-spells";
           }
           if (target) {
-            span.style.cursor = 'pointer';
-            span.addEventListener('click', () => {
+            span.style.cursor = "pointer";
+            span.addEventListener("click", () => {
               const sec = document.getElementById(target);
               if (sec) {
-                sec.scrollIntoView({ behavior: 'smooth' });
-                sec.classList.add('flash');
-                setTimeout(() => sec.classList.remove('flash'), 600);
+                sec.scrollIntoView({ behavior: "smooth" });
+                sec.classList.add("flash");
+                setTimeout(() => sec.classList.remove("flash"), 600);
               }
             });
           }
@@ -240,22 +255,22 @@ function attachItemModal() {
         });
       }
 
-      if (typeof modal.showModal === 'function') {
+      if (typeof modal.showModal === "function") {
         modal.showModal();
       } else {
-        modal.style.display = 'block';
+        modal.style.display = "block";
       }
-      modal.style.opacity = '1';
-      modal.style.transform = 'scale(1)';
+      modal.style.opacity = "1";
+      modal.style.transform = "scale(1)";
     });
   });
 }
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener("DOMContentLoaded", () => {
   attachHandlers();
-  const btn = document.getElementById('retry-all');
+  const btn = document.getElementById("retry-all");
   if (btn) {
-    btn.addEventListener('click', refreshAll);
+    btn.addEventListener("click", refreshAll);
   }
   if (window.initialIds && window.initialIds.length) {
     loadUsers(window.initialIds);

--- a/tests/fixtures/pro_item.json
+++ b/tests/fixtures/pro_item.json
@@ -1,0 +1,13 @@
+{
+  "defindex": 222,
+  "quality": 6,
+  "attributes": [
+    {"defindex": 730, "float_value": 12},
+    {"defindex": 2025, "float_value": 3},
+    {"defindex": 2013, "float_value": 701},
+    {"defindex": 2071, "float_value": 2002},
+    {"defindex": 380, "float_value": 1},
+    {"defindex": 2041, "float_value": 1},
+    {"defindex": 214, "float_value": 13}
+  ]
+}

--- a/tests/fixtures/simple_item.json
+++ b/tests/fixtures/simple_item.json
@@ -1,0 +1,4 @@
+{
+  "defindex": 111,
+  "quality": 6
+}

--- a/tests/fixtures/unusual_item.json
+++ b/tests/fixtures/unusual_item.json
@@ -1,0 +1,5 @@
+{
+  "defindex": 222,
+  "quality": 5,
+  "descriptions": [{"value": "Unusual Effect: Burning Flames"}]
+}


### PR DESCRIPTION
## Summary
- add static lookup tables in local_data
- refactor inventory processor with attribute handlers
- update modal logic for new item fields
- add fixture and test for enriched attributes
- document enriched item fields
- add smoke_parse utility

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6861e366d2c883269d637cc50463bc95