### PR TITLE
Display enriched inventory details

### DIFF
--- a/static/retry.js
+++ b/static/retry.js
@@ -145,6 +145,7 @@ function attachItemModal() {
       }
 
       const generalEntries = [];
+      if (data.item_name) generalEntries.push(["Base Name", data.item_name]);
       if (data.quality) generalEntries.push(["Quality", data.quality]);
       if (data.level) generalEntries.push(["", "Level " + data.level]);
       if (data.origin) generalEntries.push(["", data.origin]);

--- a/templates/_user.html
+++ b/templates/_user.html
@@ -38,7 +38,7 @@
             {% else %}
               <div class="missing-icon"></div>
             {% endif %}
-            <div class="item-name">{{ item.name }}</div>
+            <div class="item-name" title="{{ item.item_name }}">{{ item.name }}</div>
           </div>
         {% endfor %}
       </div>


### PR DESCRIPTION
## Summary
- enhance item cards to show enriched schema names in a tooltip
- surface base item name in modal general section

## Testing
- `pre-commit run --files static/retry.js templates/_user.html`

------
https://chatgpt.com/codex/tasks/task_e_6861ec84f7348326bc5f7caf3a347aa9