### PR TITLE
Add fetch_data script and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,16 @@ The files are stored under `cache/` as `tf2_schema.json`, `items_game.txt` and
 `items_game_cleaned.json`. Start the server normally without `--refresh` after
 the update completes.
 
+### Fetching example data
+
+Use the helper script below to download raw schema files and a sample
+inventory for testing. `STEAM_API_KEY` and `TEST_STEAM_ID` must be set in your
+environment:
+
+```bash
+python scripts/fetch_data.py
+```
+
 ### Deploy
 
 The app can be deployed to any platform that supports Python 3.12. For Docker:

--- a/scripts/fetch_data.py
+++ b/scripts/fetch_data.py
@@ -1,0 +1,84 @@
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import requests
+
+SCHEMA_ITEMS_URL = (
+    "https://api.steampowered.com/IEconItems_440/GetSchemaItems/v1/"
+    "?key={key}&format=json"
+)
+SCHEMA_OVERVIEW_URL = (
+    "https://api.steampowered.com/IEconItems_440/GetSchemaOverview/v1/"
+    "?key={key}&format=json"
+)
+ITEMS_GAME_URL = (
+    "https://raw.githubusercontent.com/SteamDatabase/SteamTracking/master/"
+    "TeamFortress2/tf/scripts/items/items_game.txt"
+)
+INVENTORY_URL = (
+    "https://steamcommunity.com/inventory/{steamid}/440/2?l=english&count=5000"
+)
+
+CACHE_DIR = Path("cache")
+
+
+def _download(url: str) -> Any:
+    resp = requests.get(url, timeout=30)
+    resp.raise_for_status()
+    if url.endswith(".txt"):
+        return resp.text
+    return resp.json()
+
+
+def fetch_schema_items(api_key: str, dest: Path | None = None) -> Path:
+    if dest is None:
+        dest = CACHE_DIR / "schema_items.json"
+    data = _download(SCHEMA_ITEMS_URL.format(key=api_key))
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(json.dumps(data))
+    return dest
+
+
+def fetch_schema_overview(api_key: str, dest: Path | None = None) -> Path:
+    if dest is None:
+        dest = CACHE_DIR / "schema_overview.json"
+    data = _download(SCHEMA_OVERVIEW_URL.format(key=api_key))
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(json.dumps(data))
+    return dest
+
+
+def fetch_items_game(dest: Path | None = None) -> Path:
+    if dest is None:
+        dest = CACHE_DIR / "items_game.txt"
+    text = _download(ITEMS_GAME_URL)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(text)
+    return dest
+
+
+def fetch_inventory(steamid: str, dest: Path | None = None) -> Path:
+    if dest is None:
+        dest = CACHE_DIR / f"inventory_{steamid}.json"
+    data = _download(INVENTORY_URL.format(steamid=steamid))
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(json.dumps(data))
+    return dest
+
+
+def fetch_all(api_key: str | None = None, steamid: str | None = None) -> None:
+    api_key = api_key or os.getenv("STEAM_API_KEY")
+    steamid = steamid or os.getenv("TEST_STEAM_ID")
+    if not api_key or not steamid:
+        raise ValueError("STEAM_API_KEY and TEST_STEAM_ID are required")
+
+    fetch_schema_items(api_key)
+    fetch_schema_overview(api_key)
+    fetch_items_game()
+    fetch_inventory(steamid)
+
+
+if __name__ == "__main__":
+    fetch_all()

--- a/tests/test_fetch_data.py
+++ b/tests/test_fetch_data.py
@@ -1,0 +1,51 @@
+import json
+
+import pytest
+
+import scripts.fetch_data as fd
+
+
+class DummyResp:
+    def __init__(self, payload):
+        self.payload = payload
+        self.status_code = 200
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        if isinstance(self.payload, dict):
+            return self.payload
+        raise ValueError
+
+    @property
+    def text(self):
+        if isinstance(self.payload, str):
+            return self.payload
+        return json.dumps(self.payload)
+
+
+def fake_get(url, timeout=30):
+    if "GetSchemaItems" in url:
+        return DummyResp({"result": {"items": []}})
+    if "GetSchemaOverview" in url:
+        return DummyResp({"result": {"qualities": {"0": "Normal"}}})
+    if "items_game.txt" in url:
+        return DummyResp("items_game\n{")
+    if "inventory" in url:
+        return DummyResp({"success": True})
+    raise AssertionError(f"Unexpected url {url}")
+
+
+@pytest.fixture(autouse=True)
+def patch_requests(monkeypatch):
+    monkeypatch.setattr(fd, "requests", type("R", (), {"get": fake_get}))
+
+
+def test_fetch_all(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    fd.fetch_all(api_key="k", steamid="1")
+    assert (tmp_path / "cache/schema_items.json").exists()
+    assert (tmp_path / "cache/schema_overview.json").exists()
+    assert (tmp_path / "cache/items_game.txt").exists()
+    assert (tmp_path / "cache/inventory_1.json").exists()


### PR DESCRIPTION
## Summary
- add scripts/fetch_data.py for downloading raw TF2 data
- document how to fetch example data in README
- cover new script with offline unit test

## Testing
- `ruff check scripts/fetch_data.py tests/test_fetch_data.py`
- `black scripts/fetch_data.py tests/test_fetch_data.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68625019f16c8326a2ab54d54e9a5b31