### PR TITLE
Load env vars from .env for fetch_data

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 STEAM_API_KEY=your_steam_key_here
+TEST_STEAM_ID=your_steamid64

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ export FLASK_DEBUG=1
 python app.py
 ```
 
-To run the tests with cached data:
+
+To run the tests with cached data, set `STEAM_API_KEY` and
+`TEST_STEAM_ID` in your `.env` file then run:
 
 ```bash
-export STEAM_API_KEY=XXX
-export TEST_STEAM_ID=76561197972495328
 python scripts/fetch_data.py
 pytest -q
 ```
@@ -131,8 +131,8 @@ the update completes.
 ### Fetching example data
 
 Use the helper script below to download raw schema files and a sample
-inventory for testing. `STEAM_API_KEY` and `TEST_STEAM_ID` must be set in your
-environment:
+inventory for testing. Set `STEAM_API_KEY` and `TEST_STEAM_ID` in your
+`.env` file first:
 
 ```bash
 python scripts/fetch_data.py

--- a/scripts/fetch_data.py
+++ b/scripts/fetch_data.py
@@ -3,7 +3,10 @@ import os
 from pathlib import Path
 from typing import Any
 
+from dotenv import load_dotenv
 import requests
+
+load_dotenv(Path(__file__).resolve().parents[1] / ".env")
 
 SCHEMA_ITEMS_URL = (
     "https://api.steampowered.com/IEconItems_440/GetSchemaItems/v1/"


### PR DESCRIPTION
## Summary
- load environment variables from `.env` in `fetch_data.py`
- document using `.env` for tests and sample data
- extend `.env.example` with `TEST_STEAM_ID`

## Testing
- `pre-commit run --files scripts/fetch_data.py README.md .env.example`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68625ae158a883269f3d0c502779f963