### PR TITLE
Implement hybrid schema enrichment pipeline

### DIFF
--- a/scripts/smoke_parse.py
+++ b/scripts/smoke_parse.py
@@ -1,0 +1,22 @@
+import json
+from pathlib import Path
+import sys
+
+from utils import schema_manager, inventory_processor
+
+
+def main() -> None:
+    inv_file = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("inventory.json")
+    if not inv_file.exists():
+        print(f"Missing {inv_file}")
+        return
+    data = json.loads(inv_file.read_text())
+    schema_manager.load_hybrid_schema()
+    items = inventory_processor.enrich_inventory(data)
+    for item in items:
+        badges = "".join(item.get("badges", []))
+        print(f"{item['name']}: {badges}")
+
+
+if __name__ == "__main__":
+    main()

--- a/static/retry.js
+++ b/static/retry.js
@@ -84,7 +84,12 @@ function attachItemModal() {
           ['Level', data.level],
           ['Origin', data.origin],
           ['Killstreak', data.killstreak_tier],
+          ['Sheen', data.sheen],
+          ['Killstreaker', data.killstreaker],
+          ['Festivized', data.is_festivized ? 'Yes' : null],
           ['Paint', data.paint_name],
+          ['Strange Parts', (data.strange_parts || []).join(', ')],
+          ['Spells', (data.spells || []).join(', ')],
         ];
         fields.forEach(([label, value]) => {
           if (!value) return;

--- a/templates/_user.html
+++ b/templates/_user.html
@@ -33,6 +33,7 @@
             {% else %}
               <div class="missing-icon"></div>
             {% endif %}
+            <div class="badge-row">{% for b in item.badges or [] %}{{ b }}{% endfor %}</div>
             <div class="item-name">{{ item.name }}</div>
           </div>
         {% endfor %}

--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -1,0 +1,55 @@
+import json
+
+from utils import schema_manager, inventory_processor
+
+
+def test_full_enrichment(tmp_path, monkeypatch):
+    schema = {
+        "items": {
+            "199": {
+                "name": "The Revolver",
+                "item_type_name": "Pistol",
+                "image_url": "img.png",
+            }
+        },
+        "qualities": {"11": "Strange"},
+        "qualityNames": {"strange": "#CF6A32"},
+        "effects": {"2003": "Incinerator"},
+        "paint_kits": {},
+        "strange_parts": {"24": "Players Hit"},
+    }
+    cache = tmp_path / "hybrid_schema.json"
+    cache.write_text(json.dumps(schema))
+    monkeypatch.setattr(schema_manager, "HYBRID_FILE", cache)
+    monkeypatch.setattr(schema_manager, "CACHE_DIR", tmp_path)
+    monkeypatch.setattr(inventory_processor, "HYBRID_SCHEMA", None)
+
+    data = {
+        "items": [
+            {
+                "defindex": 199,
+                "quality": 11,
+                "custom_name": "My Trusty Sidearm",
+                "level": 42,
+                "origin": 5,
+                "attributes": [
+                    {"defindex": 2014, "value": 3},
+                    {"defindex": 2012, "value": 2},
+                    {"defindex": 2013, "value": 2003},
+                    {"defindex": 2053, "value": 1},
+                    {"defindex": 382, "value": 24},
+                ],
+            }
+        ]
+    }
+
+    items = inventory_processor.enrich_inventory(data)
+    assert items[0]["base_name"] == "The Revolver"
+    assert items[0]["name"] == "My Trusty Sidearm"
+    assert items[0]["killstreak_tier"] == "Professional"
+    assert items[0]["sheen"] == "Deadly Daffodil"
+    assert items[0]["killstreaker"] == "Incinerator"
+    assert items[0]["is_festivized"] is True
+    assert items[0]["strange_parts"] == ["Players Hit"]
+    for badge in ["\u2694\ufe0f", "\u2728", "\U0001f480", "\U0001f384", "\U0001f4ca"]:
+        assert badge in items[0]["badges"]

--- a/utils/schema_manager.py
+++ b/utils/schema_manager.py
@@ -1,0 +1,103 @@
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict
+
+import vdf
+
+logger = logging.getLogger(__name__)
+
+CACHE_DIR = Path("cache")
+HYBRID_FILE = CACHE_DIR / "hybrid_schema.json"
+
+
+def _load_json(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        return {}
+    with path.open() as f:
+        try:
+            return json.load(f)
+        except Exception as exc:  # pragma: no cover - corrupt file
+            logger.info("Failed to load %s: %s", path, exc)
+            return {}
+
+
+def build_hybrid_schema(cache_dir: Path = CACHE_DIR) -> Dict[str, Any]:
+    """Merge schema data and items_game into a single mapping."""
+
+    items_path = cache_dir / "schema_items.json"
+    overview_path = cache_dir / "schema_overview.json"
+    ig_path = cache_dir / "items_game.txt"
+
+    items_map: Dict[str, Any] = {}
+    data = _load_json(items_path)
+    for item in data.get("result", {}).get("items", data.get("items", [])):
+        idx = str(item.get("defindex"))
+        if not idx:
+            continue
+        entry: Dict[str, Any] = {
+            "defindex": item.get("defindex"),
+            "name": item.get("name"),
+        }
+        if item.get("item_type_name"):
+            entry["item_type_name"] = item["item_type_name"]
+        path = (
+            item.get("image_url_large")
+            or item.get("image_url")
+            or item.get("icon_url_large")
+            or item.get("icon_url")
+        )
+        if path:
+            entry["image_url"] = path
+        items_map[idx] = entry
+
+    overview = _load_json(overview_path).get("result", {})
+    qualities = {str(v): k for k, v in overview.get("qualities", {}).items()}
+    qualities_colored = overview.get("qualityNames", {})
+    effects = overview.get("attribute_controlled_attached_particles", {})
+
+    ig_data: Dict[str, Any] = {}
+    strange_parts: Dict[str, Any] = {}
+    if ig_path.exists():
+        ig_raw = vdf.loads(ig_path.read_text()).get("items_game", {})
+        ig_data = ig_raw
+        for idx, meta in ig_raw.get("items", {}).items():
+            if not isinstance(meta, dict):
+                continue
+            entry = items_map.setdefault(str(idx), {})
+            for key, value in meta.items():
+                entry.setdefault(key, value)
+        strange_parts = {
+            str(idx): info.get("name")
+            for idx, info in ig_raw.get("items", {}).items()
+            if isinstance(info, dict) and info.get("item_class") == "strange_part"
+        }
+
+    hybrid = {
+        "items": items_map,
+        "attributes": ig_data.get("attributes", {}),
+        "qualities": qualities,
+        "qualities_colored": qualities_colored,
+        "effects": effects,
+        "paint_kits": ig_data.get("paint_kits", {}),
+        "strange_parts": strange_parts,
+    }
+
+    cache_file = cache_dir / "hybrid_schema.json"
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    cache_file.write_text(json.dumps(hybrid))
+    logger.info("Saved hybrid schema to %s", cache_file)
+    return hybrid
+
+
+def load_hybrid_schema(force_rebuild: bool = False) -> Dict[str, Any]:
+    """Load cached hybrid schema, rebuilding if missing or forced."""
+
+    path = HYBRID_FILE
+    if path.exists() and not force_rebuild:
+        with path.open() as f:
+            data = json.load(f)
+        if isinstance(data.get("items"), dict):
+            return data
+
+    return build_hybrid_schema(path.parent)


### PR DESCRIPTION
## Summary
- add `schema_manager` for merging schema files
- extend `inventory_processor` with enrichment badges and hybrid lookup
- display badges in `_user.html` and expose extra details in `retry.js`
- add smoke parsing utility
- cover enrichment logic with new tests

## Testing
- `pre-commit run --files static/retry.js templates/_user.html utils/inventory_processor.py utils/schema_manager.py tests/test_enrichment.py scripts/smoke_parse.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68626e6805688326bf1a7069053ce63a