### PR TITLE
Update item rendering and spell handling

### DIFF
--- a/static/retry.js
+++ b/static/retry.js
@@ -79,6 +79,22 @@ function attachItemModal() {
       if (img) img.src = data.image_url || '';
       if (details) {
         details.innerHTML = '';
+        if (data.custom_name) {
+          const div = document.createElement('div');
+          div.innerHTML = '<b>Custom Name:</b> ' + data.custom_name;
+          details.appendChild(div);
+        }
+        if (data.custom_desc) {
+          const div = document.createElement('div');
+          div.style.whiteSpace = 'pre-line';
+          div.textContent = data.custom_desc;
+          details.appendChild(div);
+        }
+        if (data.spells && data.spells.length) {
+          const div = document.createElement('div');
+          div.innerHTML = '<b>Spells:</b> ' + data.spells.join(', ');
+          details.appendChild(div);
+        }
         const fields = [
           ['Type', data.item_type_name],
           ['Level', data.level],
@@ -89,7 +105,6 @@ function attachItemModal() {
           ['Festivized', data.is_festivized ? 'Yes' : null],
           ['Paint', data.paint_name],
           ['Strange Parts', (data.strange_parts || []).join(', ')],
-          ['Spells', (data.spells || []).join(', ')],
         ];
         fields.forEach(([label, value]) => {
           if (!value) return;

--- a/static/style.css
+++ b/static/style.css
@@ -178,6 +178,13 @@ button {
   color: #fff;
 }
 
+.item-title {
+  font-size: 12px;
+  text-align: center;
+  word-break: break-word;
+  color: #fff;
+}
+
 .tf2-hours { margin-left: 6px; font-size: 0.9em; }
 
 .page-footer {

--- a/templates/_user.html
+++ b/templates/_user.html
@@ -34,7 +34,7 @@
               <div class="missing-icon"></div>
             {% endif %}
             <div class="badge-row">{% for b in item.badges or [] %}{{ b }}{% endfor %}</div>
-            <div class="item-name">{{ item.name }}</div>
+            <div class="item-title">{{ item.name }}</div>
           </div>
         {% endfor %}
       </div>

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -22,7 +22,7 @@ def test_enrich_inventory():
         "111": {
             "defindex": 111,
             "item_name": "Rocket Launcher",
-            "image_url": "https://steamcommunity-a.akamaihd.net/economy/image/img/360fx360f",
+            "image": "https://steamcommunity-a.akamaihd.net/economy/image/img/360fx360f",
         }
     }
     sf.QUALITIES = {"11": "Strange"}
@@ -45,9 +45,7 @@ def test_enrich_inventory_unusual_effect():
             }
         ]
     }
-    sf.SCHEMA = {
-        "222": {"defindex": 222, "item_name": "Team Captain", "image_url": "img"}
-    }
+    sf.SCHEMA = {"222": {"defindex": 222, "item_name": "Team Captain", "image": "img"}}
     sf.QUALITIES = {"5": "Unusual"}
     ld.EFFECT_NAMES = {"13": "Burning Flames"}
     items = ip.enrich_inventory(data)
@@ -61,9 +59,9 @@ def test_process_inventory_handles_missing_icon():
         "1": {
             "defindex": 1,
             "item_name": "One",
-            "image_url": "https://steamcommunity-a.akamaihd.net/economy/image/a/360fx360f",
+            "image": "https://steamcommunity-a.akamaihd.net/economy/image/a/360fx360f",
         },
-        "2": {"defindex": 2, "item_name": "Two", "image_url": ""},
+        "2": {"defindex": 2, "item_name": "Two", "image": ""},
     }
     sf.QUALITIES = {}
     items = ip.process_inventory(data)
@@ -74,13 +72,13 @@ def test_process_inventory_handles_missing_icon():
                 "https://steamcommunity-a.akamaihd.net/economy/image/"
             )
         else:
-            assert item["image_url"] == ""
+            assert item["image_url"] == "/static/placeholder.png"
 
 
 def test_enrich_inventory_preserves_absolute_url():
     data = {"items": [{"defindex": 5, "quality": 0}]}
     url = "http://example.com/icon.png"
-    sf.SCHEMA = {"5": {"defindex": 5, "item_name": "Abs", "image_url": url}}
+    sf.SCHEMA = {"5": {"defindex": 5, "item_name": "Abs", "image": url}}
     sf.QUALITIES = {"0": "Normal"}
     items = ip.enrich_inventory(data)
     assert items[0]["image_url"] == url
@@ -88,7 +86,7 @@ def test_enrich_inventory_preserves_absolute_url():
 
 def test_enrich_inventory_skips_unknown_defindex():
     data = {"items": [{"defindex": 1}, {"defindex": 2}]}
-    sf.SCHEMA = {"1": {"defindex": 1, "item_name": "One", "image_url": "a"}}
+    sf.SCHEMA = {"1": {"defindex": 1, "item_name": "One", "image": "a"}}
     sf.QUALITIES = {}
     items = ip.enrich_inventory(data)
     assert len(items) == 1

--- a/utils/schema_manager.py
+++ b/utils/schema_manager.py
@@ -83,6 +83,11 @@ def build_hybrid_schema(cache_dir: Path = CACHE_DIR) -> Dict[str, Any]:
         "strange_parts": strange_parts,
     }
 
+    for item in hybrid["items"].values():
+        large = item.get("image_url_large") or item.get("image_url_large", "")
+        small = item.get("image_url") or ""
+        item["image"] = large or small
+
     cache_file = cache_dir / "hybrid_schema.json"
     cache_file.parent.mkdir(parents=True, exist_ok=True)
     cache_file.write_text(json.dumps(hybrid))


### PR DESCRIPTION
## Summary
- unify large/small image URLs when building the hybrid schema
- map spell attributes and legacy bitmask to human-readable names
- keep custom item names in modal only
- ensure placeholder image is used when none provided
- display spells, custom name and description in item modal
- adjust CSS and JS for new fields
- update tests for new behaviour

## Testing
- `pre-commit run --files utils/schema_manager.py utils/inventory_processor.py templates/_user.html static/retry.js tests/test_enrichment.py static/style.css tests/test_inventory_processor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68628abc8de48326a1106dc973722b6a