### PR TITLE
Fix CDN image URLs in hybrid schema

### DIFF
--- a/templates/_user.html
+++ b/templates/_user.html
@@ -28,11 +28,7 @@
       <div class="inventory-container">
         {% for item in user.items %}
           <div class="item-card" style="border-color: {{ item.quality_color }};" data-item='{{ item|tojson|safe }}'>
-            {% if item.image_url %}
-              <img class="item-img" src="{{ item.image_url }}" alt="{{ item.name }}" width="64" height="64" onerror="this.style.display='none';">
-            {% else %}
-              <div class="missing-icon"></div>
-            {% endif %}
+            <img class="item-img" src="{{ item.image_url }}" alt="{{ item.name }}" width="64" height="64" onerror="this.src='/static/placeholder.png';">
             <div class="badge-row">{% for b in item.badges or [] %}{{ b }}{% endfor %}</div>
             <div class="item-title">{{ item.name }}</div>
           </div>

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -283,8 +283,7 @@ def enrich_inventory(data: Dict[str, Any]) -> List[Dict[str, Any]]:
         if not (schema_entry or ig_item):
             continue
 
-        base_info = schema_map.get(defindex, {})
-        image_url = base_info.get("image") or "/static/placeholder.png"
+        image_url = schema_map.get(defindex, {}).get("image", "/static/placeholder.png")
 
         # Prefer name from cleaned items_game if available
         base_name = (

--- a/utils/schema_manager.py
+++ b/utils/schema_manager.py
@@ -84,9 +84,13 @@ def build_hybrid_schema(cache_dir: Path = CACHE_DIR) -> Dict[str, Any]:
     }
 
     for item in hybrid["items"].values():
-        large = item.get("image_url_large") or item.get("image_url_large", "")
-        small = item.get("image_url") or ""
-        item["image"] = large or small
+        image = item.get("image_url_large") or item.get("image_url") or ""
+        if isinstance(image, str) and image.startswith("http"):
+            item["image"] = image
+        elif image:
+            item["image"] = f"https://steamcdn-a.akamaihd.net/{image}"
+        else:
+            item["image"] = "/static/placeholder.png"
 
     cache_file = cache_dir / "hybrid_schema.json"
     cache_file.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- normalize schema image URLs to valid CDN links
- pass schema image through inventory processor
- display placeholder image when no URL

## Testing
- `pre-commit run --files utils/schema_manager.py utils/inventory_processor.py templates/_user.html`
- `pytest -q` *(fails: ModuleNotFoundError for `requests`)*

------
https://chatgpt.com/codex/tasks/task_e_68628e7284c883268072a64fa7524ff6