### PR TITLE
Improve image sourcing and refresh flag

### DIFF
--- a/templates/_user.html
+++ b/templates/_user.html
@@ -28,9 +28,9 @@
       <div class="inventory-container">
         {% for item in user.items %}
           <div class="item-card" style="border-color: {{ item.quality_color }};" data-item='{{ item|tojson|safe }}'>
-            <img class="item-img" src="{{ item.image_url }}" alt="{{ item.name }}" width="64" height="64" onerror="this.src='/static/placeholder.png';">
+            <img class="item-img" src="{{ item.image_url }}" alt="{{ item.base_name }}" width="64" height="64">
             <div class="badge-row">{% for b in item.badges or [] %}{{ b }}{% endfor %}</div>
-            <div class="item-title">{{ item.name }}</div>
+            <div class="item-title">{{ item.base_name }}</div>
           </div>
         {% endfor %}
       </div>

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -22,7 +22,7 @@ def test_enrich_inventory():
         "111": {
             "defindex": 111,
             "item_name": "Rocket Launcher",
-            "image": "https://steamcommunity-a.akamaihd.net/economy/image/img/360fx360f",
+            "image": "https://steamcdn-a.akamaihd.net/apps/440/icons/img.png",
         }
     }
     sf.QUALITIES = {"11": "Strange"}
@@ -31,7 +31,7 @@ def test_enrich_inventory():
     assert items[0]["quality"] == "Strange"
     assert items[0]["quality_color"] == "#CF6A32"
     assert items[0]["image_url"].startswith(
-        "https://steamcommunity-a.akamaihd.net/economy/image/"
+        "https://steamcdn-a.akamaihd.net/apps/440/icons/"
     )
 
 
@@ -59,7 +59,7 @@ def test_process_inventory_handles_missing_icon():
         "1": {
             "defindex": 1,
             "item_name": "One",
-            "image": "https://steamcommunity-a.akamaihd.net/economy/image/a/360fx360f",
+            "image": "https://steamcdn-a.akamaihd.net/apps/440/icons/a.png",
         },
         "2": {"defindex": 2, "item_name": "Two", "image": ""},
     }
@@ -69,10 +69,10 @@ def test_process_inventory_handles_missing_icon():
     for item in items:
         if item["name"] == "One":
             assert item["image_url"].startswith(
-                "https://steamcommunity-a.akamaihd.net/economy/image/"
+                "https://steamcdn-a.akamaihd.net/apps/440/icons/"
             )
         else:
-            assert item["image_url"] == "/static/placeholder.png"
+            assert item["image_url"] == ""
 
 
 def test_enrich_inventory_preserves_absolute_url():

--- a/tests/test_schema_fetcher.py
+++ b/tests/test_schema_fetcher.py
@@ -12,7 +12,7 @@ def test_schema_cache_hit(tmp_path, monkeypatch):
             str(i): {
                 "defindex": i,
                 "name": "Item",
-                "image_url": "https://steamcommunity-a.akamaihd.net/economy/image/i/360fx360f",
+                "image_url": "https://steamcdn-a.akamaihd.net/apps/440/icons/i.png",
             }
             for i in range(5000)
         },
@@ -47,7 +47,7 @@ def test_schema_cache_miss(tmp_path, monkeypatch):
                     {
                         "defindex": 2,
                         "name": "Other",
-                        "image_url": "u",
+                        "image_url": "u.png",
                         "image_url_large": None,
                     }
                 ]
@@ -66,7 +66,7 @@ def test_schema_cache_miss(tmp_path, monkeypatch):
         "2": {
             "defindex": 2,
             "name": "Other",
-            "image_url": "https://steamcommunity-a.akamaihd.net/economy/image/u/360fx360f",
+            "image_url": "https://steamcdn-a.akamaihd.net/apps/440/icons/u.png",
         }
     }
     assert cache.exists()

--- a/tests/test_user_template.py
+++ b/tests/test_user_template.py
@@ -29,3 +29,31 @@ def test_user_template_does_not_error(app, context):
         app_module = importlib.import_module("app")
         context["user"] = app_module.normalize_user_payload(context.get("user", {}))
         render_template_string(HTML, **context)
+
+
+def test_user_card_uses_base_name(app):
+    from types import SimpleNamespace
+
+    user = SimpleNamespace(
+        steamid="1",
+        username="User",
+        avatar="",
+        playtime=0.0,
+        profile="#",
+        status="parsed",
+        items=[
+            {
+                "name": "Strange Rocket Launcher",
+                "base_name": "Rocket Launcher",
+                "image_url": "",
+                "custom_name": "My RL",
+                "custom_desc": "Desc",
+            }
+        ],
+    )
+    with app.app_context():
+        html = render_template_string(HTML, user=user)
+        import re
+
+        m = re.search(r'<div class="item-title">([^<]+)</div>', html)
+        assert m and m.group(1) == "Rocket Launcher"

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -283,7 +283,14 @@ def enrich_inventory(data: Dict[str, Any]) -> List[Dict[str, Any]]:
         if not (schema_entry or ig_item):
             continue
 
-        image_url = schema_map.get(defindex, {}).get("image", "/static/placeholder.png")
+        image_url = schema_map.get(defindex, {}).get("image", "")
+        if not image_url:
+            logger.warning(
+                "No image found for %s (%s)",
+                defindex,
+                ig_item.get("name")
+                or (schema_entry.get("name") if schema_entry else "Unknown"),
+            )
 
         # Prefer name from cleaned items_game if available
         base_name = (

--- a/utils/schema_fetcher.py
+++ b/utils/schema_fetcher.py
@@ -7,7 +7,8 @@ from typing import Any, Dict
 
 import requests
 
-CLOUD = "https://steamcommunity-a.akamaihd.net/economy/image/"
+# Base URL for item icons if the schema provides a relative path
+ICON_BASE = "https://steamcdn-a.akamaihd.net/apps/440/icons/"
 
 logger = logging.getLogger(__name__)
 
@@ -47,8 +48,7 @@ def _fetch_schema(api_key: str) -> Dict[str, Any]:
                 continue
 
             path = (
-                item.get("image_url_large")
-                or item.get("image_url")
+                item.get("image_url")
                 or item.get("icon_url_large")
                 or item.get("icon_url")
                 or ""
@@ -56,7 +56,8 @@ def _fetch_schema(api_key: str) -> Dict[str, Any]:
             if path.startswith("http"):
                 image_url = path
             elif path:
-                image_url = f"{CLOUD}{path}/360fx360f"
+                # Some schema entries only provide a relative filename
+                image_url = f"{ICON_BASE}{path.lstrip('/')}"
             else:
                 image_url = ""
 

--- a/utils/schema_manager.py
+++ b/utils/schema_manager.py
@@ -84,13 +84,18 @@ def build_hybrid_schema(cache_dir: Path = CACHE_DIR) -> Dict[str, Any]:
     }
 
     for item in hybrid["items"].values():
-        image = item.get("image_url_large") or item.get("image_url") or ""
+        image = item.get("image_url") or item.get("image_url_large") or ""
         if isinstance(image, str) and image.startswith("http"):
             item["image"] = image
         elif image:
-            item["image"] = f"https://steamcdn-a.akamaihd.net/{image}"
+            item["image"] = f"https://steamcdn-a.akamaihd.net/{image.lstrip('/')}"
         else:
-            item["image"] = "/static/placeholder.png"
+            item["image"] = ""
+            logger.warning(
+                "Missing image for defindex %s (%s)",
+                item.get("defindex"),
+                item.get("name"),
+            )
 
     cache_file = cache_dir / "hybrid_schema.json"
     cache_file.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- refactor schema image URL construction
- log if images are missing
- drop placeholder images and show base item name
- adjust tests for new image logic

## Testing
- `pre-commit run --files utils/schema_fetcher.py utils/schema_manager.py utils/inventory_processor.py templates/_user.html tests/test_inventory_processor.py tests/test_schema_fetcher.py tests/test_user_template.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686294031d548326a8ca79342870e0d8