### PR TITLE
Improve TF2 item card icon handling

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -84,6 +84,26 @@
             font-size: 1.2rem;
         }
         #modal-details div { margin-top: 2px; }
+        .item-card {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: space-between;
+        }
+        .item-img {
+            object-fit: contain;
+            max-width: 100%;
+            max-height: 64px;
+            transition: opacity 0.3s ease;
+        }
+        .item-img.loading { opacity: 0; }
+        .missing-icon-border { border: 2px dashed #555 !important; }
+        .missing-icon-text {
+            font-size: 0.75rem;
+            color: #bbb;
+            text-align: center;
+            padding-top: 12px;
+        }
     </style>
 </head>
 <body>
@@ -184,14 +204,38 @@
           );
         });
       }
+      function enhanceItemImages(root = document) {
+        root.querySelectorAll('.item-card img.item-img').forEach(img => {
+          img.classList.add('loading');
+          const card = img.closest('.item-card');
+          const showMissing = () => {
+            if (!card || card.querySelector('.missing-icon-text')) return;
+            const div = document.createElement('div');
+            div.className = 'missing-icon-text';
+            div.textContent = 'Missing Icon';
+            card.classList.add('missing-icon-border');
+            card.insertBefore(div, card.firstChild);
+          };
+          img.addEventListener('load', () => img.classList.remove('loading'), { once: true });
+          img.addEventListener('error', () => { img.remove(); showMissing(); }, { once: true });
+          if (img.complete) {
+            if (img.naturalWidth) img.classList.remove('loading');
+            else { img.remove(); showMissing(); }
+          }
+        });
+      }
       if (window.attachHandlers) {
         const oldAttach = window.attachHandlers;
         window.attachHandlers = function () {
           oldAttach();
           attachScrollButtons();
+          enhanceItemImages();
         };
       }
-      document.addEventListener('DOMContentLoaded', attachScrollButtons);
+      document.addEventListener('DOMContentLoaded', () => {
+        attachScrollButtons();
+        enhanceItemImages();
+      });
     </script>
 </body>
 </html>

--- a/utils/schema_fetcher.py
+++ b/utils/schema_fetcher.py
@@ -48,18 +48,14 @@ def _fetch_schema(api_key: str) -> Dict[str, Any]:
                 continue
 
             path = (
-                item.get("image_url")
+                item.get("icon_url")
+                or item.get("image_url")
+                or item.get("image_url_large")
                 or item.get("icon_url_large")
-                or item.get("icon_url")
                 or ""
             )
-            if path.startswith("http"):
-                image_url = path
-            elif path:
-                # Some schema entries only provide a relative filename
-                image_url = f"{ICON_BASE}{path.lstrip('/')}"
-            else:
-                image_url = ""
+            icon = path.split("/")[-1].split("?")[0] if path else ""
+            image_url = f"{ICON_BASE}{icon}" if icon else ""
 
             items[defindex] = {
                 "defindex": item.get("defindex"),

--- a/utils/schema_manager.py
+++ b/utils/schema_manager.py
@@ -5,6 +5,8 @@ from typing import Any, Dict
 
 import vdf
 
+ICON_BASE = "https://steamcdn-a.akamaihd.net/apps/440/icons/"
+
 logger = logging.getLogger(__name__)
 
 CACHE_DIR = Path("cache")
@@ -42,13 +44,14 @@ def build_hybrid_schema(cache_dir: Path = CACHE_DIR) -> Dict[str, Any]:
         if item.get("item_type_name"):
             entry["item_type_name"] = item["item_type_name"]
         path = (
-            item.get("image_url_large")
+            item.get("icon_url")
             or item.get("image_url")
+            or item.get("image_url_large")
             or item.get("icon_url_large")
-            or item.get("icon_url")
         )
         if path:
-            entry["image_url"] = path
+            icon = path.split("/")[-1].split("?")[0]
+            entry["image_url"] = icon
         items_map[idx] = entry
 
     overview = _load_json(overview_path).get("result", {})
@@ -84,11 +87,10 @@ def build_hybrid_schema(cache_dir: Path = CACHE_DIR) -> Dict[str, Any]:
     }
 
     for item in hybrid["items"].values():
-        image = item.get("image_url") or item.get("image_url_large") or ""
-        if isinstance(image, str) and image.startswith("http"):
-            item["image"] = image
-        elif image:
-            item["image"] = f"https://steamcdn-a.akamaihd.net/{image.lstrip('/')}"
+        icon = item.get("image_url", "")
+        if icon:
+            icon = icon.split("/")[-1].split("?")[0]
+            item["image"] = f"{ICON_BASE}{icon}"
         else:
             item["image"] = ""
             logger.warning(


### PR DESCRIPTION
## Summary
- pull icon filename from schema and build standard image URL
- generate canonical icon URLs when building the hybrid schema
- style item cards to center images and highlight missing icons
- show placeholder text if icon fails to load

## Testing
- `pre-commit run --files utils/schema_fetcher.py utils/schema_manager.py templates/index.html`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686297e9c42483269a90843c40863010