### PR TITLE
Fix item image URL lookup

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -84,6 +84,20 @@ def test_enrich_inventory_preserves_absolute_url():
     assert items[0]["image_url"] == url
 
 
+def test_enrich_inventory_uses_image_url_field():
+    data = {"items": [{"defindex": 6, "quality": 0}]}
+    sf.SCHEMA = {
+        "6": {
+            "defindex": 6,
+            "item_name": "Shotgun",
+            "image_url": "shot.png",
+        }
+    }
+    sf.QUALITIES = {"0": "Normal"}
+    items = ip.enrich_inventory(data)
+    assert items[0]["image_url"].endswith("shot.png")
+
+
 def test_enrich_inventory_skips_unknown_defindex():
     data = {"items": [{"defindex": 1}, {"defindex": 2}]}
     sf.SCHEMA = {"1": {"defindex": 1, "item_name": "One", "image": "a"}}

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -283,7 +283,11 @@ def enrich_inventory(data: Dict[str, Any]) -> List[Dict[str, Any]]:
         if not (schema_entry or ig_item):
             continue
 
-        image_url = schema_map.get(defindex, {}).get("image", "")
+        entry = schema_map.get(defindex, {})
+        image_url = entry.get("image") or entry.get("image_url") or ""
+        if image_url and not image_url.startswith("http"):
+            icon = image_url.split("/")[-1].split("?")[0]
+            image_url = f"https://steamcdn-a.akamaihd.net/apps/440/icons/{icon}"
         if not image_url:
             logger.warning(
                 "No image found for %s (%s)",


### PR DESCRIPTION
## Summary
- ensure `enrich_inventory` resolves image URLs from either `image` or `image_url`
- if a relative path is provided build the full Steam CDN URL
- test that `image_url` field is respected

## Testing
- `pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862a3d44d50832692020ae3bdf73ad8