### PR TITLE
Pre-bind icons and validate URLs

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,9 +2,7 @@ import os
 import re
 import asyncio
 import time
-import json
 import sys
-from pathlib import Path
 from typing import List, Dict, Any
 from types import SimpleNamespace
 
@@ -24,28 +22,11 @@ if not os.getenv("STEAM_API_KEY"):
     )
 
 if "--refresh" in sys.argv[1:]:
-    from utils import schema_fetcher, items_game_cache, local_data, schema_manager
+    from utils import schema_manager
 
-    print(
-        "\N{anticlockwise open circle arrow} Refresh requested: refetching TF2 schema and items_game..."
-    )
-    api_key = os.environ["STEAM_API_KEY"]
-    schema = schema_fetcher._fetch_schema(api_key)
-    Path("cache").mkdir(parents=True, exist_ok=True)
-    Path("cache/tf2_schema.json").write_text(json.dumps(schema))
-    print(f"Fetched {len(schema['items'])} schema items")
-
-    items_game = items_game_cache.update_items_game()
-    cleaned = local_data.clean_items_game(items_game)
-    Path("cache/items_game_cleaned.json").write_text(json.dumps(cleaned))
-    print(f"Saved {len(cleaned)} cleaned item definitions")
-
-    schema_manager.build_hybrid_schema()
-    print("Built hybrid_schema.json")
-    print(
-        "\N{CHECK MARK} Refresh complete. Restart app normally without --refresh to start server."
-    )
-    raise SystemExit(0)
+    print("\N{anticlockwise open circle arrow} Refreshing hybrid schema...")
+    schema_manager.load_hybrid_schema(force_rebuild=True)
+    print("\N{check mark} Refresh complete")
 
 STEAM_API_KEY = os.environ["STEAM_API_KEY"]
 

--- a/static/retry.js
+++ b/static/retry.js
@@ -76,7 +76,14 @@ function attachItemModal() {
       if (!data) return;
       try { data = JSON.parse(data); } catch (e) { return; }
       if (title) title.textContent = data.name || '';
-      if (img) img.src = data.image_url || '';
+      if (img) {
+        img.onerror = () => {
+          const imgSrc = img.getAttribute('src');
+          if (!imgSrc) return; // empty means we already warned
+          img.src = '';
+        };
+        img.src = data.image_url || '';
+      }
       if (details) {
         details.innerHTML = '';
         if (data.custom_name) {

--- a/templates/_user.html
+++ b/templates/_user.html
@@ -28,7 +28,7 @@
       <div class="inventory-container">
         {% for item in user.items %}
           <div class="item-card" style="border-color: {{ item.quality_color }};" data-item='{{ item|tojson|safe }}'>
-            <img class="item-img" src="{{ item.image_url }}" alt="{{ item.base_name }}" width="64" height="64">
+            <img class="item-img" src="{{ item.image_url }}" loading="lazy" />
             <div class="badge-row">{% for b in item.badges or [] %}{{ b }}{% endfor %}</div>
             <div class="item-title">{{ item.base_name }}</div>
           </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -217,7 +217,12 @@
             card.insertBefore(div, card.firstChild);
           };
           img.addEventListener('load', () => img.classList.remove('loading'), { once: true });
-          img.addEventListener('error', () => { img.remove(); showMissing(); }, { once: true });
+          img.addEventListener('error', () => {
+            const imgSrc = img.getAttribute('src');
+            if (!imgSrc) return; // empty means we already warned
+            img.remove();
+            showMissing();
+          }, { once: true });
           if (img.complete) {
             if (img.naturalWidth) img.classList.remove('loading');
             else { img.remove(); showMissing(); }

--- a/tests/test_icons.py
+++ b/tests/test_icons.py
@@ -1,0 +1,31 @@
+import json
+from utils import schema_manager, inventory_processor
+
+
+def test_icons_valid(tmp_path, monkeypatch):
+    schema = {
+        "items": {
+            "1": {
+                "defindex": 1,
+                "name": "One",
+                "image": "https://steamcdn-a.akamaihd.net/apps/440/icons/a.png",
+            },
+            "2": {
+                "defindex": 2,
+                "name": "Two",
+                "image": "https://steamcdn-a.akamaihd.net/apps/440/icons/b.png",
+            },
+        },
+        "qualities": {},
+    }
+    cache = tmp_path / "hybrid_schema.json"
+    cache.write_text(json.dumps(schema))
+    monkeypatch.setattr(schema_manager, "HYBRID_FILE", cache)
+    monkeypatch.setattr(schema_manager, "CACHE_DIR", tmp_path)
+    monkeypatch.setattr(inventory_processor, "HYBRID_SCHEMA", None)
+
+    data = {"items": [{"defindex": 1}, {"defindex": 2}]}
+    items = inventory_processor.process_inventory(data)
+    assert all(
+        i["image_url"].startswith("https://steamcdn-a.akamaihd.net") for i in items
+    )

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -90,7 +90,7 @@ def test_enrich_inventory_uses_image_url_field():
         "6": {
             "defindex": 6,
             "item_name": "Shotgun",
-            "image_url": "shot.png",
+            "image": "https://steamcdn-a.akamaihd.net/apps/440/icons/shot.png",
         }
     }
     sf.QUALITIES = {"0": "Normal"}

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -284,16 +284,11 @@ def enrich_inventory(data: Dict[str, Any]) -> List[Dict[str, Any]]:
             continue
 
         entry = schema_map.get(defindex, {})
-        image_url = entry.get("image") or entry.get("image_url") or ""
-        if image_url and not image_url.startswith("http"):
-            icon = image_url.split("/")[-1].split("?")[0]
-            image_url = f"https://steamcdn-a.akamaihd.net/apps/440/icons/{icon}"
+        image_url = entry.get("image", "")
         if not image_url:
             logger.warning(
-                "No image found for %s (%s)",
+                "Missing image for defindex %s – check schema refresh",
                 defindex,
-                ig_item.get("name")
-                or (schema_entry.get("name") if schema_entry else "Unknown"),
             )
 
         # Prefer name from cleaned items_game if available


### PR DESCRIPTION
## Summary
- create final item image URL while building hybrid schema
- load a fresh hybrid schema with `--refresh`
- log once per missing icon during enrichment
- handle image errors without loops and lazy-load images
- add tests for canonical icon URLs

## Testing
- `pre-commit run --files utils/schema_manager.py utils/inventory_processor.py app.py templates/_user.html templates/index.html static/retry.js tests/test_app_refresh.py tests/test_icons.py tests/test_inventory_processor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862b84450948326be6f0647075c135e