### PR TITLE
Switch to local schema files

### DIFF
--- a/tests/test_local_data.py
+++ b/tests/test_local_data.py
@@ -5,11 +5,11 @@ from utils import local_data as ld
 
 
 def test_load_files_success(tmp_path, monkeypatch, capsys):
-    schema_file = tmp_path / "tf2_schema.json"
+    schema_file = tmp_path / "defindexes.json"
     items_file = tmp_path / "items_game_cleaned.json"
-    schema_file.write_text(json.dumps({"items": {"1": {"name": "One"}}}))
+    schema_file.write_text(json.dumps({"1": {"name": "One"}}))
     items_file.write_text(json.dumps({"1": {"name": "A"}}))
-    monkeypatch.setattr(ld, "SCHEMA_FILE", schema_file)
+    monkeypatch.setattr(ld, "DEFINDEXES_FILE", schema_file)
     monkeypatch.setattr(ld, "ITEMS_GAME_FILE", items_file)
     ld.TF2_SCHEMA = {}
     ld.ITEMS_GAME_CLEANED = {}
@@ -18,11 +18,11 @@ def test_load_files_success(tmp_path, monkeypatch, capsys):
     out = capsys.readouterr().out
     assert ld.TF2_SCHEMA["1"]["name"] == "One"
     assert f"Loaded 1 items from {schema_file}" in out
-    assert "tf2_schema.json may be stale" in out
+    assert "defindexes.json may be stale" in out
 
 
 def test_load_files_missing(tmp_path, monkeypatch):
-    monkeypatch.setattr(ld, "SCHEMA_FILE", tmp_path / "missing.json")
+    monkeypatch.setattr(ld, "DEFINDEXES_FILE", tmp_path / "missing.json")
     monkeypatch.setattr(ld, "ITEMS_GAME_FILE", tmp_path / "missing2.json")
     with pytest.raises(RuntimeError):
         ld.load_files()

--- a/tests/test_schema_fetcher.py
+++ b/tests/test_schema_fetcher.py
@@ -1,74 +1,24 @@
 import json
-
-from unittest.mock import Mock
-
 import utils.schema_fetcher as sf
 
 
-def test_schema_cache_hit(tmp_path, monkeypatch):
-    cache = tmp_path / "tf2_schema.json"
-    sample = {
-        "items": {
-            str(i): {
-                "defindex": i,
-                "name": "Item",
-                "image_url": "https://steamcdn-a.akamaihd.net/apps/440/icons/i.png",
-            }
-            for i in range(5000)
-        },
-        "qualities": {"0": "Normal"},
-    }
-    cache.write_text(json.dumps(sample))
-    monkeypatch.setattr(sf, "CACHE_FILE", cache)
-    monkeypatch.setattr(sf, "requests", Mock())
-    schema = sf.ensure_schema_cached(api_key="k")
-    assert schema == sample["items"]
-
-
-def test_schema_cache_miss(tmp_path, monkeypatch):
-    cache = tmp_path / "tf2_schema.json"
-    monkeypatch.setattr(sf, "CACHE_FILE", cache)
-
-    class DummyResp:
-        def __init__(self, payload):
-            self.payload = payload
-
-        def raise_for_status(self):
-            pass
-
-        def json(self):
-            return self.payload
-
-    responses = [
-        {"result": {"qualities": {"Normal": 0}}},
-        {
-            "result": {
-                "items": [
-                    {
-                        "defindex": 2,
-                        "name": "Other",
-                        "image_url": "u.png",
-                        "image_url_large": None,
-                    }
-                ]
-            }
-        },
-    ]
-    captured = []
-
-    def fake_get(url, timeout):
-        captured.append(url)
-        return DummyResp(responses.pop(0))
-
-    monkeypatch.setattr(sf.requests, "get", fake_get)
-    schema = sf.ensure_schema_cached(api_key="k")
-    assert schema == {
-        "2": {
-            "defindex": 2,
-            "name": "Other",
-            "image_url": "https://steamcdn-a.akamaihd.net/apps/440/icons/u.png",
-        }
-    }
-    assert cache.exists()
-    assert any("GetSchemaOverview" in u for u in captured)
-    assert any("GetSchemaItems" in u for u in captured)
+def test_schema_loads_files(tmp_path, monkeypatch):
+    defs = {"1": {"name": "One"}}
+    quals = {"0": "Normal"}
+    dpath = tmp_path / "defindexes.json"
+    qpath = tmp_path / "qualities.json"
+    dpath.write_text(json.dumps(defs))
+    qpath.write_text(json.dumps(quals))
+    for key in sf.FILES:
+        if key == "defindexes":
+            monkeypatch.setitem(sf.FILES, key, dpath)
+        elif key == "qualities":
+            monkeypatch.setitem(sf.FILES, key, qpath)
+        else:
+            monkeypatch.setitem(sf.FILES, key, tmp_path / f"{key}.json")
+    sf.SCHEMA = None
+    sf.QUALITIES = {}
+    sf.PROPERTIES = {}
+    schema = sf.ensure_schema_cached()
+    assert schema == defs
+    assert sf.QUALITIES == quals

--- a/utils/schema_fetcher.py
+++ b/utils/schema_fetcher.py
@@ -1,106 +1,57 @@
 import json
 import logging
-import os
-import time
 from pathlib import Path
 from typing import Any, Dict
 
-import requests
-
-# Base URL for item icons if the schema provides a relative path
-ICON_BASE = "https://steamcdn-a.akamaihd.net/apps/440/icons/"
-
 logger = logging.getLogger(__name__)
-
-CACHE_FILE = Path("cache/tf2_schema.json")
-TTL = 48 * 60 * 60  # 48 hours
-
 
 SCHEMA: Dict[str, Any] | None = None
 QUALITIES: Dict[str | int, str] = {}
+PROPERTIES: Dict[str, Any] = {}
+
+BASE_DIR = Path("cache")
+FILES = {
+    "schema": BASE_DIR / "schema.json",
+    "defindexes": BASE_DIR / "defindexes.json",
+    "qualities": BASE_DIR / "qualities.json",
+    "killstreaks": BASE_DIR / "killstreaks.json",
+    "effects": BASE_DIR / "effects.json",
+    "paintkits": BASE_DIR / "paintkits.json",
+    "wears": BASE_DIR / "wears.json",
+    "crateseries": BASE_DIR / "crateseries.json",
+    "paints": BASE_DIR / "paints.json",
+    "strangeParts": BASE_DIR / "strangeParts.json",
+    "craftWeapons": BASE_DIR / "craftWeapons.json",
+    "uncraftWeapons": BASE_DIR / "uncraftWeapons.json",
+    "itemGrade_v1": BASE_DIR / "itemGrade_v1.json",
+    "itemGrade_v2": BASE_DIR / "itemGrade_v2.json",
+}
 
 
-def _fetch_schema(api_key: str) -> Dict[str, Any]:
-    """Fetch schema overview and all items from Steam."""
-
-    overview_url = (
-        "https://api.steampowered.com/IEconItems_440/GetSchemaOverview/v1/"
-        f"?key={api_key}"
-    )
-    r = requests.get(overview_url, timeout=20)
-    r.raise_for_status()
-    overview = r.json()["result"]
-    qualities = {str(v): k for k, v in overview.get("qualities", {}).items()}
-
-    items: Dict[str, Any] = {}
-    start = 0
-    while True:
-        items_url = (
-            "https://api.steampowered.com/IEconItems_440/GetSchemaItems/v1/"
-            f"?key={api_key}&start={start}"
-        )
-        r = requests.get(items_url, timeout=20)
-        r.raise_for_status()
-        data = r.json()["result"]
-        for item in data.get("items", []):
-            defindex = str(item.get("defindex"))
-            if not defindex or "name" not in item:
-                continue
-
-            path = (
-                item.get("icon_url")
-                or item.get("image_url")
-                or item.get("image_url_large")
-                or item.get("icon_url_large")
-                or ""
-            )
-            icon = path.split("/")[-1].split("?")[0] if path else ""
-            image_url = f"{ICON_BASE}{icon}" if icon else ""
-
-            items[defindex] = {
-                "defindex": item.get("defindex"),
-                "name": item.get("name"),
-                "image_url": image_url,
-            }
-        if not data.get("next"):
-            break
-        start = data["next"]
-
-    return {"items": items, "qualities": qualities}
+def _load_json(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        logger.info("Missing enrichment file %s", path)
+        return {}
+    try:
+        with path.open() as f:
+            return json.load(f)
+    except Exception as exc:  # pragma: no cover - corrupt file
+        logger.info("Failed to load %s: %s", path, exc)
+        return {}
 
 
-def ensure_schema_cached(api_key: str | None = None) -> Dict[str, Any]:
-    """Return cached item schema mapping, refetching if missing or stale."""
+def ensure_schema_cached() -> Dict[str, Any]:
+    """Load schema and property files into memory."""
 
-    if api_key is None:
-        api_key = os.getenv("STEAM_API_KEY")
+    global SCHEMA, QUALITIES, PROPERTIES
+    if SCHEMA is not None:
+        return SCHEMA
 
-    global SCHEMA, QUALITIES
-    cache_path = CACHE_FILE.resolve()
-    need_fetch = True
-    if cache_path.exists():
-        age = time.time() - cache_path.stat().st_mtime
-        if age < TTL:
-            with cache_path.open() as f:
-                cached = json.load(f)
-            items = cached.get("items", cached)
-            if isinstance(items, dict) and len(items) >= 5000:
-                SCHEMA = items
-                QUALITIES = cached.get("qualities", {})
-                logger.info("Loaded %s items from %s", len(SCHEMA), cache_path)
-                need_fetch = False
-
-    if need_fetch:
-        logger.warning("\N{CROSS MARK} Schema missing or invalid — refetching...")
-        fetched = _fetch_schema(api_key)
-        CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
-        CACHE_FILE.write_text(json.dumps(fetched))
-        SCHEMA = fetched["items"]
-        QUALITIES = fetched["qualities"]
-        logger.info(
-            "\N{CHECK MARK} Fetched and cached full schema with %s items → %s",
-            len(SCHEMA),
-            cache_path,
-        )
-
+    SCHEMA = _load_json(FILES["defindexes"])
+    QUALITIES = _load_json(FILES["qualities"])
+    for key, path in FILES.items():
+        if key in ("defindexes", "qualities"):
+            continue
+        PROPERTIES[key] = _load_json(path)
+    logger.info("Loaded %s items from %s", len(SCHEMA), FILES["defindexes"])
     return SCHEMA


### PR DESCRIPTION
## Summary
- drop Steam schema fetcher and load from local JSON files
- read defindex and effect data via `local_data`
- update hybrid schema builder to merge those files
- adjust tests for new helpers

## Testing
- `pre-commit run --files utils/schema_fetcher.py utils/local_data.py utils/schema_manager.py tests/test_local_data.py tests/test_schema_fetcher.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862d6a35ecc8326bdee37e856c6cb17