### PR TITLE
Add caching for AutoBot TF2 schema

### DIFF
--- a/tests/test_tf2_schema_fetcher.py
+++ b/tests/test_tf2_schema_fetcher.py
@@ -1,0 +1,40 @@
+import json
+from unittest.mock import Mock
+
+import utils.tf2_schema_fetcher as tsf
+
+
+def test_tf2_schema_cache_hit(tmp_path, monkeypatch):
+    cache = tmp_path / "tf2_schema.json"
+    sample = {"items": {"1": {"name": "One"}}}
+    cache.write_text(json.dumps(sample))
+    monkeypatch.setattr(tsf, "CACHE_PATH", cache)
+    monkeypatch.setattr(tsf, "requests", Mock())
+    data = tsf.ensure_schema_cached()
+    assert data == sample
+
+
+def test_tf2_schema_cache_miss(tmp_path, monkeypatch):
+    cache = tmp_path / "tf2_schema.json"
+    monkeypatch.setattr(tsf, "CACHE_PATH", cache)
+
+    class DummyResp:
+        def __init__(self, payload):
+            self.payload = payload
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return self.payload
+
+    response = {"items": {"2": {"name": "Two"}}}
+
+    def fake_get(url, timeout):
+        assert url.endswith("/schema")
+        return DummyResp(response)
+
+    monkeypatch.setattr(tsf.requests, "get", fake_get)
+    data = tsf.ensure_schema_cached()
+    assert data == response
+    assert cache.exists()

--- a/utils/tf2_schema_fetcher.py
+++ b/utils/tf2_schema_fetcher.py
@@ -1,0 +1,46 @@
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Any, Dict
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+BASE = "https://schema.autobot.tf"
+CACHE_PATH = Path("cache/tf2_schema.json")
+TTL = 48 * 60 * 60  # 48 hours
+
+SCHEMA: Dict[str, Any] | None = None
+
+
+def _fetch_schema() -> Dict[str, Any]:
+    """Fetch TF2 schema data from AutoBot."""
+    resp = requests.get(f"{BASE}/schema", timeout=20)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def ensure_schema_cached() -> Dict[str, Any]:
+    """Return cached TF2 schema, fetching if necessary."""
+    global SCHEMA
+
+    if CACHE_PATH.exists():
+        age = time.time() - CACHE_PATH.stat().st_mtime
+        if age < TTL:
+            with CACHE_PATH.open() as fh:
+                SCHEMA = json.load(fh)
+            logger.info("TF2 schema cache HIT: %s keys", len(SCHEMA))
+            return SCHEMA
+
+    data = _fetch_schema()
+    CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with CACHE_PATH.open("w") as fh:
+        json.dump(data, fh)
+    SCHEMA = data
+    logger.info("TF2 schema cache MISS, fetched %s keys", len(SCHEMA))
+    return SCHEMA
+
+
+__all__ = ["ensure_schema_cached"]


### PR DESCRIPTION
## Summary
- implement `utils/tf2_schema_fetcher.py` for caching schema.autobot.tf data
- add tests covering cache hit and miss behaviour for the new fetcher

## Testing
- `pre-commit run --files utils/tf2_schema_fetcher.py tests/test_tf2_schema_fetcher.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862f76decd083268f336bd608440d58