### PR TITLE
Fix items_game URL

### DIFF
--- a/scripts/fetch_data.py
+++ b/scripts/fetch_data.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 AUTOBOT_BASE = "https://schema.autobot.tf"
 ITEMS_GAME_URL = (
     "https://raw.githubusercontent.com/SteamDatabase/GameTracking-TF2/"
-    "master/tf/resource/tf2_base/items_game.txt"
+    "refs/heads/master/tf/scripts/items/items_game.txt"
 )
 
 CACHE_DIR = Path("cache")

--- a/tests/test_fetch_data.py
+++ b/tests/test_fetch_data.py
@@ -21,7 +21,7 @@ def test_fetch_items_game(tmp_path, monkeypatch):
     path = fd.fetch_items_game()
     assert path == tmp_path / "items_game.txt"
     assert path.read_text() == "content"
-    assert "GameTracking-TF2" in captured["url"]
+    assert captured["url"] == fd.ITEMS_GAME_URL
 
 
 def test_fetch_autobot_schema(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- point to the correct items_game.txt URL
- assert the exact URL in fetch_data unit test

## Testing
- `pre-commit run --files scripts/fetch_data.py tests/test_fetch_data.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686306d659508326a6df368f6c265de3