### PR TITLE
Expose item enrichment on frontend

### DIFF
--- a/static/modal.js
+++ b/static/modal.js
@@ -1,0 +1,74 @@
+function attachModalHandlers() {
+  document.querySelectorAll('.item-card').forEach(card => {
+    card.addEventListener('click', () => {
+      const item = JSON.parse(card.dataset.item);
+      const modal = card.closest('.user-card').querySelector('.item-modal');
+      if (!modal) return;
+      populateModal(modal, item);
+      openModal(modal);
+    });
+  });
+  document.querySelectorAll('.item-modal').forEach(modal => {
+    const closeBtn = modal.querySelector('.modal-close');
+    const bg = modal.querySelector('.modal-bg');
+    if (closeBtn) closeBtn.addEventListener('click', () => closeModal(modal));
+    if (bg) bg.addEventListener('click', () => closeModal(modal));
+  });
+}
+
+function openModal(modal) {
+  modal.classList.add('open');
+}
+
+function closeModal(modal) {
+  modal.classList.remove('open');
+}
+
+function populateModal(modal, item) {
+  const dl = modal.querySelector('.modal-details');
+  if (!dl) return;
+  dl.innerHTML = '';
+
+  function addRow(label, value) {
+    if (value === undefined || value === null || value === '' || (Array.isArray(value) && value.length === 0)) return;
+    const dt = document.createElement('dt');
+    dt.textContent = label;
+    const dd = document.createElement('dd');
+    if (typeof value === 'string') {
+      dd.innerHTML = value;
+    } else {
+      dd.textContent = value;
+    }
+    dl.appendChild(dt);
+    dl.appendChild(dd);
+  }
+
+  addRow('Custom Name', item.custom_name);
+  addRow('Spells', item.spells && item.spells.join(', '));
+  addRow('Killstreak Tier', item.killstreak_tier);
+  addRow('Sheen', item.sheen);
+  addRow('Killstreaker', item.killstreaker);
+  if (item.paint_name) {
+    const swatch = `<span class="paint-dot" style="background:${item.paint_hex}"></span>`;
+    addRow('Paint', `${item.paint_name} ${swatch}`);
+  }
+  addRow('Strange Parts', item.strange_parts && item.strange_parts.join(', '));
+  addRow('Origin', item.origin);
+  addRow('Level', item.level);
+  addRow('Unusual Effect', item.unusual_effect);
+  if (typeof item.is_festivized !== 'undefined') {
+    addRow('Festivized', item.is_festivized ? 'Yes' : 'No');
+  }
+}
+
+if (window.attachHandlers) {
+  const oldAttach = window.attachHandlers;
+  window.attachHandlers = function () {
+    oldAttach();
+    attachModalHandlers();
+  };
+} else {
+  window.attachHandlers = attachModalHandlers;
+}
+
+document.addEventListener('DOMContentLoaded', attachModalHandlers);

--- a/static/style.css
+++ b/static/style.css
@@ -150,6 +150,7 @@ button {
   border: 2px solid #FFDD00;
   border-radius: 8px;
   overflow: hidden;
+  position: relative;
   background-color: #1e1e1e;
 }
 
@@ -176,6 +177,97 @@ button {
   text-align: center;
   word-break: break-word;
   color: #fff;
+}
+
+.badge-row {
+  display: flex;
+  gap: 2px;
+  position: absolute;
+  bottom: 2px;
+  left: 2px;
+}
+.badge-row span {
+  font-size: 12px;
+  line-height: 1;
+  filter: drop-shadow(0 0 2px #000);
+}
+
+.paint-dot {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  border: 1px solid #000;
+}
+
+.ks-mark {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  font-size: 10px;
+  line-height: 1;
+  color: #fff;
+  filter: drop-shadow(0 0 2px #000);
+}
+.ks-tier-1::before {
+  content: "\02C4";
+}
+.ks-tier-2::before {
+  white-space: pre;
+  content: "\02C4\A\02C4";
+}
+.ks-tier-3::before {
+  white-space: pre;
+  content: "\02C4\A\02C4\A\02C4";
+}
+
+.item-modal {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.6);
+  z-index: 1000;
+}
+.item-modal.open {
+  display: flex;
+}
+.item-modal .modal-content {
+  background: #222;
+  padding: 12px;
+  border-radius: 8px;
+  max-width: 300px;
+  max-height: 80%;
+  overflow-y: auto;
+  position: relative;
+  color: #fff;
+}
+.item-modal .modal-close {
+  position: absolute;
+  top: 4px;
+  right: 6px;
+  background: transparent;
+  border: none;
+  color: #fff;
+  cursor: pointer;
+  font-size: 16px;
+}
+.item-modal dl {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 4px 8px;
+}
+.item-modal dt {
+  font-weight: bold;
+}
+.item-modal dd {
+  margin: 0 0 4px 0;
 }
 
 .tf2-hours { margin-left: 6px; font-size: 0.9em; }

--- a/templates/_user.html
+++ b/templates/_user.html
@@ -27,19 +27,39 @@
       </button>
       <div class="inventory-container">
         {% for item in user.items %}
-          <div class="item-card" style="border-color: {{ item.quality_color }};">
+          <div class="item-card" style="border-color: {{ item.quality_color }};" data-item="{{ item|tojson | safe }}">
+            {% if item.paint_hex %}
+              <span class="paint-dot" style="background:{{ item.paint_hex }}"></span>
+            {% endif %}
+            {% if item.killstreak_tier %}
+              <span class="ks-mark ks-tier-{{ item.killstreak_tier }}"></span>
+            {% endif %}
             {% if item.final_url %}
               <img class="item-img" src="{{ item.final_url }}" alt="{{ item.name }}" width="64" height="64" onerror="this.style.display='none';">
             {% else %}
               <div class="missing-icon"></div>
             {% endif %}
             <div class="item-name">{{ item.name }}</div>
+            {% if item.badges %}
+              <div class="badge-row">
+                {% for badge in item.badges %}
+                  <span title="{{ badge.title }}">{{ badge.icon }}</span>
+                {% endfor %}
+              </div>
+            {% endif %}
           </div>
         {% endfor %}
       </div>
       <button class="scroll-arrow right" type="button" aria-label="Scroll right">
         <i class="fa-solid fa-chevron-right"></i>
       </button>
+    </div>
+  </div>
+  <div class="item-modal">
+    <div class="modal-bg"></div>
+    <div class="modal-content">
+      <button type="button" class="modal-close">❌</button>
+      <dl class="modal-details"></dl>
     </div>
   </div>
 </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -97,6 +97,7 @@
       window.initialIds = {{ ids|tojson|safe }};
     </script>
     <script src="{{ url_for('static', filename='retry.js') }}"></script>
+    <script src="{{ url_for('static', filename='modal.js') }}"></script>
     <script>
       function attachScrollButtons() {
         document.querySelectorAll('.inventory-scroll').forEach(wrapper => {


### PR DESCRIPTION
## Summary
- add dataset and overlays for item cards
- show badge row when present
- attach item detail modal and script
- update global styles

## Testing
- `pre-commit run --files templates/_user.html templates/index.html static/style.css static/modal.js static/retry.js`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68630e111de08326bbceff00e7e34fce