### PR TITLE
Display enriched item info for debugging

### DIFF
--- a/templates/_user.html
+++ b/templates/_user.html
@@ -47,6 +47,21 @@
                 {% endfor %}
               </div>
             {% endif %}
+            {% set e = item.enriched if item.enriched is defined else {} %}
+            <div class="enrichment-debug">
+              {% if e.killstreak_tier %}
+                Killstreak: {{ e.killstreak_tier }}<br>
+              {% endif %}
+              {% if e.spells %}
+                Spells: {{ e.spells | join(', ') }}<br>
+              {% endif %}
+              {% if e.strange_parts %}
+                Strange Parts: {{ e.strange_parts | join(', ') }}<br>
+              {% endif %}
+              {% if e.paint_name %}
+                Paint: {{ e.paint_name }}
+              {% endif %}
+            </div>
           </div>
         {% endfor %}
       </div>


### PR DESCRIPTION
## Summary
- expose killstreaks, spells, parts and paint in the item card

## Testing
- `pre-commit run --files templates/_user.html`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68631b9645908326903272c314c346e0