### PR TITLE
Add badges overlay and modal improvements

### DIFF
--- a/static/modal.js
+++ b/static/modal.js
@@ -49,22 +49,29 @@ function populateModal(modal, item) {
     dl.appendChild(dd);
   }
 
-  addRow('Custom Name', item.custom_name);
+  const ks = [];
+  if (item.killstreak_tier) {
+    const map = {1: 'Killstreak', 2: 'Specialized', 3: 'Professional'};
+    ks.push(map[item.killstreak_tier] || item.killstreak_tier);
+  }
+  if (item.sheen) ks.push(item.sheen);
+  if (item.killstreaker) ks.push(item.killstreaker);
+  addRow('Killstreak', ks.join(', '));
+
   addRow('Spells', item.spells && item.spells.join(', '));
-  addRow('Killstreak Tier', item.killstreak_tier);
-  addRow('Sheen', item.sheen);
-  addRow('Killstreaker', item.killstreaker);
   if (item.paint_name) {
     const swatch = `<span class="paint-dot" style="background:${item.paint_hex}"></span>`;
     addRow('Paint', `${item.paint_name} ${swatch}`);
   }
   addRow('Strange Parts', item.strange_parts && item.strange_parts.join(', '));
-  addRow('Origin', item.origin);
-  addRow('Level', item.level);
-  addRow('Unusual Effect', item.unusual_effect);
   if (typeof item.is_festivized !== 'undefined') {
     addRow('Festivized', item.is_festivized ? 'Yes' : 'No');
   }
+  addRow('Unusual Effect', item.unusual_effect);
+  addRow('Custom Name', item.custom_name);
+  addRow('Description', item.custom_description);
+  addRow('Origin', item.origin);
+  addRow('Level', item.level);
 }
 
 if (window.attachHandlers) {

--- a/static/style.css
+++ b/static/style.css
@@ -179,17 +179,29 @@ button {
   color: #fff;
 }
 
-.badge-row {
-  display: flex;
-  gap: 2px;
+.badge-bar {
   position: absolute;
   bottom: 2px;
-  left: 2px;
+  right: 2px;
+  display: flex;
+  gap: 4px;
 }
-.badge-row span {
+
+.badge {
   font-size: 12px;
-  line-height: 1;
-  filter: drop-shadow(0 0 2px #000);
+  line-height: 12px;
+  padding: 1px 2px;
+  background: rgba(0, 0, 0, 0.6);
+  border-radius: 2px;
+}
+
+.badge-paint .paint-dot {
+  position: static;
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  border: 1px solid #000;
 }
 
 .paint-dot {

--- a/templates/_user.html
+++ b/templates/_user.html
@@ -45,9 +45,15 @@
             {% endif %}
             <div class="item-name">{{ item.name }}</div>
             {% if item.badges %}
-              <div class="badge-row">
+              <div class="badge-bar">
                 {% for badge in item.badges %}
-                  <span title="{{ badge.title }}">{{ badge.icon }}</span>
+                  {% if badge.key == 'paint' %}
+                    <span class="badge badge-paint" title="{{ badge.title }}">
+                      <span class="paint-dot" style="background:{{ item.paint_hex }}"></span>
+                    </span>
+                  {% else %}
+                    <span class="badge badge-{{ badge.key }}" title="{{ badge.title }}">{{ badge.icon }}</span>
+                  {% endif %}
                 {% endfor %}
               </div>
             {% endif %}

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -55,6 +55,44 @@ def test_enrich_inventory_skips_unknown_defindex():
     assert items[0]["name"] == "One"
 
 
+def test_enrich_inventory_builds_badges():
+    data = {
+        "items": [
+            {
+                "defindex": 111,
+                "quality": 0,
+                "attributes": [
+                    {
+                        "attribute_class": "set_item_tint_rgb",
+                        "float_value": 16711680,
+                        "account_info": {"personaname": "Team Spirit"},
+                    },
+                    {"attribute_class": "killstreak_tier", "float_value": 3},
+                    {
+                        "attribute_class": "spooky_spell",
+                        "account_info": {
+                            "personaname": "Halloween: Exorcism (spell only)"
+                        },
+                    },
+                    {
+                        "attribute_class": "extra",
+                        "account_info": {
+                            "personaname": "Strange Part: Robots Destroyed"
+                        },
+                    },
+                ],
+            }
+        ]
+    }
+    sf.SCHEMA = {
+        "111": {"defindex": 111, "item_name": "Badge Test", "image_url": "img"}
+    }
+    sf.QUALITIES = {"0": "Normal"}
+    items = ip.enrich_inventory(data)
+    keys = {b["key"] for b in items[0]["badges"]}
+    assert {"paint", "ks3", "spell_exorcism", "strange_parts"}.issubset(keys)
+
+
 def test_get_inventories_adds_user_agent(monkeypatch):
     captured = {}
 

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -181,19 +181,37 @@ def _build_badges(info: Dict[str, Any]) -> List[Dict[str, str]]:
     """Convert parsed attributes to overlay badges."""
 
     badges: List[Dict[str, str]] = []
-    spells = info.get("spells", [])
+    spells = [s.lower() for s in info.get("spells", [])]
+
+    if info.get("paint_hex"):
+        badges.append({"key": "paint", "icon": "🎨", "title": "Painted"})
+
+    if any("footprint" in s for s in spells):
+        badges.append({"key": "spell_footprints", "icon": "👣", "title": "Footprints"})
+    if any("pumpkin" in s for s in spells):
+        badges.append({"key": "spell_pumpkin", "icon": "🎃", "title": "Pumpkin Bombs"})
+    if any("exorcism" in s for s in spells):
+        badges.append({"key": "spell_exorcism", "icon": "👻", "title": "Exorcism"})
+    if any("voices" in s for s in spells):
+        badges.append({"key": "spell_voices", "icon": "🗣", "title": "Voices"})
+
     if info.get("strange_parts"):
-        badges.append({"icon": "\u2699", "title": "Strange Part"})
-    if any("footprint" in s.lower() for s in spells):
-        badges.append({"icon": "\ud83d\udc63", "title": "Footprint Spell"})
-    if any("pumpkin bombs" in s.lower() for s in spells):
-        badges.append({"icon": "\ud83c\udf83", "title": "Pumpkin Bombs Spell"})
-    if any("exorcism" in s.lower() for s in spells):
-        badges.append({"icon": "\ud83d\udc7b", "title": "Exorcism"})
+        badges.append({"key": "strange_parts", "icon": "🔧", "title": "Strange Parts"})
+
+    tier = info.get("killstreak_tier")
+    if tier == 1:
+        badges.append({"key": "ks1", "icon": "›", "title": "Killstreak"})
+    elif tier == 2:
+        badges.append({"key": "ks2", "icon": "≫", "title": "Specialized"})
+    elif tier == 3:
+        badges.append({"key": "ks3", "icon": "≡", "title": "Professional"})
+
     if info.get("is_festivized"):
-        badges.append({"icon": "\u2728", "title": "Festivized"})
+        badges.append({"key": "festivized", "icon": "🎄", "title": "Festivized"})
+
     if info.get("unusual_effect"):
-        badges.append({"icon": "\ud83d\udd25", "title": info["unusual_effect"]})
+        badges.append({"key": "unusual", "icon": "💎", "title": info["unusual_effect"]})
+
     return badges
 
 


### PR DESCRIPTION
## Summary
- enrich inventory items with `badges` for paint, spells, killstreaks, etc.
- display badges in a `.badge-bar` overlay on item cards
- rework modal rows and styling for new badges
- update tests for new badge logic

## Testing
- `pre-commit run --files utils/inventory_processor.py static/modal.js static/style.css templates/_user.html tests/test_inventory_processor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686382e1bb0c8326a0c65038736838c1