### PR TITLE
Fix badge display and enlarge modal

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -184,34 +184,35 @@ button {
   bottom: 2px;
   right: 2px;
   display: flex;
+  flex-wrap: wrap;
   gap: 4px;
 }
 
 .badge {
   font-size: 12px;
   line-height: 12px;
-  padding: 1px 2px;
+  padding: 1px 3px;
   background: rgba(0, 0, 0, 0.6);
-  border-radius: 2px;
-}
-
-.badge-paint .paint-dot {
-  position: static;
-  display: inline-block;
-  width: 8px;
-  height: 8px;
-  border-radius: 2px;
-  border: 1px solid #000;
+  border-radius: 3px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .paint-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: 1px solid #000;
+}
+
+.item-card > .paint-dot {
   position: absolute;
   top: 2px;
   left: 2px;
   width: 6px;
   height: 6px;
-  border-radius: 50%;
-  border: 1px solid #000;
 }
 
 .ks-mark {
@@ -250,6 +251,10 @@ button {
 .item-modal.open {
   display: flex;
 }
+.item-modal.open .modal-content {
+  max-width: 400px;
+  width: 100%;
+}
 .item-modal .modal-content {
   background: #222;
   padding: 12px;
@@ -280,6 +285,7 @@ button {
 }
 .item-modal dd {
   margin: 0 0 4px 0;
+  white-space: pre-wrap;
 }
 
 .tf2-hours { margin-left: 6px; font-size: 0.9em; }

--- a/templates/_user.html
+++ b/templates/_user.html
@@ -30,7 +30,7 @@
           <div
             class="item-card"
             style="border-color: {{ item.quality_color }};"
-            data-item='{{ item | tojson | escape }}'
+            data-item="{{ item | tojson | safe }}"
           >
             {% if item.paint_hex %}
               <span class="paint-dot" style="background:{{ item.paint_hex }}"></span>
@@ -44,19 +44,17 @@
               <div class="missing-icon"></div>
             {% endif %}
             <div class="item-name">{{ item.name }}</div>
-            {% if item.badges %}
-              <div class="badge-bar">
-                {% for badge in item.badges %}
-                  {% if badge.key == 'paint' %}
-                    <span class="badge badge-paint" title="{{ badge.title }}">
-                      <span class="paint-dot" style="background:{{ item.paint_hex }}"></span>
-                    </span>
+            <div class="badge-bar">
+              {% for badge in item.badges %}
+                <span class="badge" title="{{ badge.title }}">
+                  {% if badge.icon == 'swatch' %}
+                    <span class="paint-dot" style="background:{{ badge.color }}"></span>
                   {% else %}
-                    <span class="badge badge-{{ badge.key }}" title="{{ badge.title }}">{{ badge.icon }}</span>
+                    {{ badge.icon }}
                   {% endif %}
-                {% endfor %}
-              </div>
-            {% endif %}
+                </span>
+              {% endfor %}
+            </div>
             {% set e = item.enriched if item.enriched is defined else {} %}
             <div class="enrichment-debug">
               {% if e.killstreak_tier %}

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -89,8 +89,11 @@ def test_enrich_inventory_builds_badges():
     }
     sf.QUALITIES = {"0": "Normal"}
     items = ip.enrich_inventory(data)
-    keys = {b["key"] for b in items[0]["badges"]}
+    badges = items[0]["badges"]
+    keys = {b["key"] for b in badges}
     assert {"paint", "ks3", "spell_exorcism", "strange_parts"}.issubset(keys)
+    paint = next(b for b in badges if b["key"] == "paint")
+    assert paint.get("color") == "#ff0000"
 
 
 def test_get_inventories_adds_user_agent(monkeypatch):

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -184,7 +184,14 @@ def _build_badges(info: Dict[str, Any]) -> List[Dict[str, str]]:
     spells = [s.lower() for s in info.get("spells", [])]
 
     if info.get("paint_hex"):
-        badges.append({"key": "paint", "icon": "🎨", "title": "Painted"})
+        badges.append(
+            {
+                "key": "paint",
+                "icon": "swatch",
+                "title": info.get("paint_name", "Painted"),
+                "color": info["paint_hex"],
+            }
+        )
 
     if any("footprint" in s for s in spells):
         badges.append({"key": "spell_footprints", "icon": "👣", "title": "Footprints"})


### PR DESCRIPTION
## Summary
- render badges with color swatches and safe JSON
- include flex wrapping and styling for badge bar
- enlarge and pre-wrap modal details
- extend badge metadata with color information
- test updated badge generation

## Testing
- `pre-commit run --files templates/_user.html static/style.css static/modal.js utils/inventory_processor.py tests/test_inventory_processor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68638587ea1c8326a369f0ef8958ac9e