### PR TITLE
Ensure valid JSON in item cards

### DIFF
--- a/templates/_user.html
+++ b/templates/_user.html
@@ -30,7 +30,7 @@
           <div
             class="item-card"
             style="border-color: {{ item.quality_color }};"
-            data-item="{{ item | tojson | safe }}"
+            data-item='{{ item | tojson | safe }}'
           >
             {% if item.paint_hex %}
               <span class="paint-dot" style="background:{{ item.paint_hex }}"></span>


### PR DESCRIPTION
## Summary
- fix `data-item` quoting in `_user.html`
- test that each item card holds parsable JSON

## Testing
- `pre-commit run --files templates/_user.html tests/test_user_template.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863879a29d0832694befbe491a8eaa5