### PR TITLE
Fix item image handling and styling

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -158,6 +158,12 @@ button {
   transform: translateY(-2px) scale(1.03);
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.5);
 }
+.item-card img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  background-color: #111;
+}
 .item-img {
   max-width: 64px;
   max-height: 64px;

--- a/templates/_user.html
+++ b/templates/_user.html
@@ -38,8 +38,8 @@
             {% if item.killstreak_tier %}
               <span class="ks-mark ks-tier-{{ item.killstreak_tier }}"></span>
             {% endif %}
-            {% if item.final_url %}
-              <img class="item-img" src="{{ item.final_url }}" alt="{{ item.name }}" width="64" height="64" onerror="this.style.display='none';">
+            {% if item.image_url %}
+              <img class="item-img" src="{{ item.image_url }}" alt="{{ item.name }}" width="64" height="64" loading="lazy" onerror="this.style.display='none';">
             {% else %}
               <div class="missing-icon"></div>
             {% endif %}

--- a/tests/test_user_template.py
+++ b/tests/test_user_template.py
@@ -18,7 +18,7 @@ def app(monkeypatch):
 @pytest.mark.parametrize(
     "context",
     [
-        {"user": {"items": [{"name": "Foo", "final_url": ""}]}},
+        {"user": {"items": [{"name": "Foo", "final_url": "", "image_url": ""}]}},
         {"user": {"items": []}},
         {"user": {}},
     ],
@@ -35,7 +35,13 @@ def test_item_card_has_valid_json(app):
         app_module = importlib.import_module("app")
         user = {
             "items": [
-                {"name": "Foo", "final_url": "", "quality_color": "#fff", "badges": []}
+                {
+                    "name": "Foo",
+                    "final_url": "",
+                    "image_url": "",
+                    "quality_color": "#fff",
+                    "badges": [],
+                }
             ]
         }
         user_ns = app_module.normalize_user_payload(user)


### PR DESCRIPTION
## Summary
- avoid recomputing TF2 item icon URLs by using `image_url`
- render item images with lazy loading and new CSS to prevent flicker
- update template tests for the new field

## Testing
- `pre-commit run --files templates/_user.html static/style.css tests/test_user_template.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686391c349b88326b7c03ebd4235ac82