### PR TITLE
Fix item image URL display and modal parsing

### DIFF
--- a/static/retry.js
+++ b/static/retry.js
@@ -74,7 +74,12 @@ function attachItemModal() {
     card.addEventListener('click', () => {
       let data = card.dataset.item;
       if (!data) return;
-      try { data = JSON.parse(data); } catch (e) { return; }
+      try {
+        data = JSON.parse(data);
+      } catch (e) {
+        console.error('Invalid item data', e, data);
+        return;
+      }
       if (title) title.textContent = data.name || '';
       if (img) img.src = data.image_url || '';
       if (details) {

--- a/static/style.css
+++ b/static/style.css
@@ -157,18 +157,10 @@ button {
   transform: translateY(-2px) scale(1.03);
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.5);
 }
-.item-img {
-  max-width: 64px;
-  max-height: 64px;
-  margin-bottom: 6px;
-}
-.missing-icon {
+.item-card img {
   width: 100%;
-  height: 50%;
-  background: #444;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  height: 100%;
+  object-fit: contain;
 }
 
 .item-name {

--- a/templates/_user.html
+++ b/templates/_user.html
@@ -27,8 +27,8 @@
       </button>
       <div class="inventory-container">
         {% for item in user.items %}
-          <div class="item-card" style="border-color: {{ item.quality_color }};" data-item='{{ item|tojson|safe }}'>
-            <img class="item-img" src="{{ item.image_url }}" alt="{{ item.name }}" width="64" height="64" onerror="this.src='/static/placeholder.png';">
+          <div class="item-card" style="border-color: {{ item.quality_color }};" data-item="{{ item | tojson | safe }}">
+            <img src="{{ item.image_url }}">
             <div class="badge-row">{% for b in item.badges or [] %}{{ b }}{% endfor %}</div>
             <div class="item-title">{{ item.name }}</div>
           </div>

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -283,7 +283,9 @@ def enrich_inventory(data: Dict[str, Any]) -> List[Dict[str, Any]]:
         if not (schema_entry or ig_item):
             continue
 
-        image_url = schema_map.get(defindex, {}).get("image", "/static/placeholder.png")
+        image_url = (
+            schema_map.get(defindex, {}).get("image") or "/static/placeholder.png"
+        )
 
         # Prefer name from cleaned items_game if available
         base_name = (


### PR DESCRIPTION
## Summary
- always output item image URL without fallback attributes
- size item images with layout-safe CSS rules
- log invalid JSON in the item modal handler
- restore placeholder logic for schema items missing an image

## Testing
- `pre-commit run --files templates/_user.html static/style.css static/retry.js utils/inventory_processor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686394f604f08326abb7dd4634d7007c