### PR TITLE
Update item badge display and modal info

### DIFF
--- a/static/retry.js
+++ b/static/retry.js
@@ -88,20 +88,16 @@ function attachItemModal() {
       if (details) {
         details.innerHTML = '';
         const attrs = document.createElement('div');
+        // ── Killstreak row ─────────────────────────
         if (data.killstreak_tier) {
+          const tierMap = {1: 'Killstreak', 2: 'Specialized', 3: 'Professional'};
+          const ksParts = [];
+          ksParts.push(tierMap[data.killstreak_tier] || data.killstreak_tier);
+          if (data.sheen) ksParts.push(data.sheen);
+          if (data.killstreak_effect) ksParts.push(data.killstreak_effect);
           const ks = document.createElement('div');
-          ks.textContent = data.killstreak_tier;
+          ks.textContent = 'Killstreak: ' + ksParts.join(', ');
           attrs.appendChild(ks);
-          if (data.sheen) {
-            const sh = document.createElement('div');
-            sh.textContent = '\u2022 Sheen: ' + data.sheen;
-            attrs.appendChild(sh);
-          }
-          if (data.killstreak_effect) {
-            const ke = document.createElement('div');
-            ke.textContent = '\u2022 Effect: ' + data.killstreak_effect;
-            attrs.appendChild(ke);
-          }
         }
 
         [
@@ -129,6 +125,12 @@ function attachItemModal() {
             div.appendChild(sw);
           }
           div.appendChild(document.createTextNode('Paint: ' + data.paint_name));
+          attrs.appendChild(div);
+        }
+
+        if (Array.isArray(data.strange_parts) && data.strange_parts.length) {
+          const div = document.createElement('div');
+          div.textContent = 'Strange Parts: ' + data.strange_parts.join(', ');
           attrs.appendChild(div);
         }
 

--- a/static/style.css
+++ b/static/style.css
@@ -151,11 +151,24 @@ button {
   border-radius: 8px;
   overflow: hidden;
   background-color: #1e1e1e;
+  position: relative; /* ensure badges overlay */
 }
 
 .item-card:hover {
   transform: translateY(-2px) scale(1.03);
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.5);
+}
+.item-badges{
+  position:absolute;
+  right:2px;
+  bottom:2px;
+  display:flex;
+  gap:2px;
+  pointer-events:none;
+  font-size:14px;
+}
+.item-badges .badge{
+  filter:drop-shadow(0 0 2px #0008);
 }
 .item-img {
   max-width: 64px;

--- a/templates/_user.html
+++ b/templates/_user.html
@@ -27,12 +27,21 @@
       </button>
       <div class="inventory-container">
         {% for item in user.items %}
-          <div class="item-card" style="border-color: {{ item.quality_color }};" data-item='{{ item|tojson|safe }}'>
+          {# ↑ keep border-color for quality #}
+          <div class="item-card"
+               style="border-color: {{ item.quality_color }};"
+               data-item='{{ item|tojson|safe }}'>
+
+            {# badge bar (bottom-right) #}
+            {% if item.badges %}
             <div class="item-badges">
-              {% for badge in item.badges or [] %}
-                <span title="{{ badge.title }}">{{ badge.icon }}</span>
+              {% for badge in item.badges %}
+                <span class="badge"
+                      {% if badge.color %} style="color:{{ badge.color }}"{% endif %}
+                      title="{{ badge.title }}">{{ badge.icon }}</span>
               {% endfor %}
             </div>
+            {% endif %}
             {% if item.image_url %}
               <img class="item-img" src="{{ item.image_url }}" alt="{{ item.name }}" width="64" height="64" onerror="this.style.display='none';">
             {% else %}

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -286,6 +286,22 @@ def enrich_inventory(data: Dict[str, Any]) -> List[Dict[str, Any]]:
         spell_lines, spell_flags = _extract_spells(asset)
         strange_parts = _extract_strange_parts(asset)
 
+        badges: List[Dict[str, str]] = []
+        effect = _extract_unusual_effect(asset)
+        if effect:
+            badges.append({"icon": "★", "title": effect, "color": "#8650AC"})
+        if ks_effect:
+            badges.append({"icon": "⚔", "title": f"Killstreaker: {ks_effect}"})
+        for key, icon, title in [
+            ("has_exorcism", "\U0001f47b", "Exorcism"),
+            ("has_paint_spell", "\U0001f3a8", "Paint spell"),
+            ("has_footprints", "\U0001f463", "Footprints spell"),
+            ("has_pumpkin_bombs", "\U0001f383", "Pumpkin Bombs"),
+            ("has_voice_lines", "\u2728", "Rare spell"),
+        ]:
+            if spell_flags.get(key):
+                badges.append({"icon": icon, "title": title})
+
         item = {
             "defindex": defindex,
             "name": display_name,
@@ -325,25 +341,9 @@ def enrich_inventory(data: Dict[str, Any]) -> List[Dict[str, Any]]:
             "paint_hex": paint_hex,
             "killstreak_effect": ks_effect,
             "spells": spell_lines,
+            "badges": badges,  # always present, may be empty
             "strange_parts": strange_parts,
         }
-        badges = []
-        effect = _extract_unusual_effect(asset)
-        if effect:
-            badges.append({"icon": "★", "title": effect, "color": "#8650AC"})
-        if ks_effect:
-            badges.append({"icon": "⚔", "title": f"Killstreaker: {ks_effect}"})
-        for key, icon, title in [
-            ("has_exorcism", "\U0001f47b", "Exorcism"),
-            ("has_paint_spell", "\U0001f3a8", "Paint spell"),
-            ("has_footprints", "\U0001f463", "Footprints spell"),
-            ("has_pumpkin_bombs", "\U0001f383", "Pumpkin Bombs"),
-            ("has_voice_lines", "\u2728", "Rare spell"),
-        ]:
-            if spell_flags.get(key):
-                badges.append({"icon": icon, "title": title})
-        if badges:
-            item["badges"] = badges
         items.append(item)
 
     return items


### PR DESCRIPTION
## Summary
- improve item-card badge handling in `_user.html`
- enhance badge and item overlay styling
- add killstreak and strange part info in modal JS
- always include `badges` field in inventory data

## Testing
- `pre-commit run --files templates/_user.html static/style.css static/retry.js utils/inventory_processor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863aa4f008c83269826cf2531d94b69