### PR TITLE
Fix custom name and unusual effect display

### DIFF
--- a/static/retry.js
+++ b/static/retry.js
@@ -65,6 +65,7 @@ function attachItemModal() {
   const modal = document.getElementById('item-modal');
   if (!modal) return;
   const title = document.getElementById('modal-title');
+  const effectBox = document.getElementById('modal-effect');
   const img = document.getElementById('modal-img');
   const details = document.getElementById('modal-details');
   const badgeBox = document.getElementById('modal-badges');
@@ -83,7 +84,8 @@ function attachItemModal() {
       let data = card.dataset.item;
       if (!data) return;
       try { data = JSON.parse(data); } catch (e) { return; }
-      if (title) title.textContent = data.name || '';
+      if (title) title.textContent = data.custom_name || data.name || '';
+      if (effectBox) effectBox.textContent = data.unusual_effect || '';
       if (img) img.src = data.image_url || '';
       if (details) {
         details.innerHTML = '';
@@ -125,11 +127,6 @@ function attachItemModal() {
             div.appendChild(sw);
           }
           div.appendChild(document.createTextNode('Paint: ' + data.paint_name));
-  if (data.custom_name) {
-    const cn = document.createElement("div");
-    cn.textContent = "Custom Name: " + data.custom_name;
-    attrs.appendChild(cn);
-  }
 
   if (data.custom_description) {
     const cd = document.createElement("div");

--- a/templates/index.html
+++ b/templates/index.html
@@ -76,8 +76,13 @@
         }
         #item-modal .modal-header {
             display: flex;
-            justify-content: space-between;
-            align-items: center;
+            flex-direction: column;
+            align-items: flex-start;
+            position: relative;
+        }
+        .modal-effect {
+            font-weight: bold;
+            color: #8650AC;
         }
         #modal-details div { margin-top: 2px; }
         .item-badges { position: absolute; top: 2px; right: 2px; display: flex; gap: 2px; }
@@ -109,6 +114,7 @@
 
     <dialog id="item-modal">
       <div class="modal-header">
+        <div id="modal-effect" class="modal-effect"></div>
         <h3 id="modal-title"></h3>
         <div id="modal-badges" class="item-badges"></div>
       </div>

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -214,24 +214,16 @@ def _extract_strange_parts(asset: Dict[str, Any]) -> List[str]:
 
 
 def _build_item_name(base: str, quality: str, asset: Dict[str, Any]) -> str:
-    """Return the display name prefixed with quality/effect."""
+    """Return the display name prefixed with quality and killstreak info."""
 
     parts: List[str] = []
     ks_tier, sheen = _extract_killstreak(asset)
-    effect = _extract_unusual_effect(asset)
 
     if ks_tier:
         parts.append(ks_tier)
 
-    quality_id = asset.get("quality")
-
-    if effect and quality_id in (5, 13):
-        parts.append(effect)
-        if quality not in ("Unique", "Normal", "Unusual"):
-            parts.append(quality)
-    else:
-        if quality not in ("Unique", "Normal"):
-            parts.append(quality)
+    if quality not in ("Unique", "Normal"):
+        parts.append(quality)
 
     parts.append(base)
 
@@ -292,7 +284,7 @@ def enrich_inventory(data: Dict[str, Any]) -> List[Dict[str, Any]]:
 
         badges: List[Dict[str, str]] = []
         effect = _extract_unusual_effect(asset)
-        if effect:
+        if effect and quality_id in (5, 11):
             badges.append({"icon": "★", "title": effect, "color": "#8650AC"})
         if ks_effect:
             badges.append({"icon": "⚔", "title": f"Killstreaker: {ks_effect}"})
@@ -306,7 +298,7 @@ def enrich_inventory(data: Dict[str, Any]) -> List[Dict[str, Any]]:
             if spell_flags.get(key):
                 badges.append({"icon": icon, "title": title})
 
-        item_name = asset.get("custom_name") or display_name
+        item_name = display_name
 
         item = {
             "defindex": defindex,
@@ -343,6 +335,7 @@ def enrich_inventory(data: Dict[str, Any]) -> List[Dict[str, Any]]:
             "origin": ORIGIN_MAP.get(asset.get("origin")),
             "custom_name": asset.get("custom_name"),
             "custom_description": asset.get("custom_desc"),
+            "unusual_effect": effect if quality_id in (5, 11) else None,
             "killstreak_tier": ks_tier,
             "sheen": sheen,
             "paint_name": paint_name,


### PR DESCRIPTION
## Summary
- keep schema name in `item.name` and put custom name in `item.custom_name`
- extract unusual effect separately and show it only for Unusual/Haunted items
- adjust modal layout and JavaScript to display custom name and effect
- update tests for the new behaviour

## Testing
- `pre-commit run --files utils/inventory_processor.py templates/index.html static/retry.js tests/test_inventory_processor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863ded86e6083268bb40777cbdf722a