### PR TITLE
Add offline test mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,18 @@ The files are stored under `cache/` as `tf2_schema.json`, `items_game.txt` and
 `items_game_cleaned.json`. Start the server normally without `--refresh` once
 the update completes.
 
+### Offline test mode
+
+You can run the app without hitting the Steam API by supplying `--test`.
+The first run prompts for a SteamID64 and caches the inventory JSON under
+`cached_inventories/`.
+
+```bash
+python app.py --test
+```
+
+If a cached inventory exists, you can choose to use it or fetch a fresh copy.
+
 ### Deploy
 
 The app can be deployed to any platform that supports Python 3.12. For Docker:

--- a/templates/index.html
+++ b/templates/index.html
@@ -110,7 +110,11 @@
         </div>
     </form>
 
-    <div id="user-container"></div>
+    <div id="user-container">
+        {% for user in users %}
+            {% include "_user.html" %}
+        {% endfor %}
+    </div>
 
     <dialog id="item-modal">
       <div class="modal-header">


### PR DESCRIPTION
## Summary
- implement `--test` CLI option in `app.py`
- preload cached inventories and reuse them when offline
- render preloaded user cards in the index template
- document offline test mode in README

## Testing
- `pre-commit run --files app.py templates/index.html README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863e11845308326a7de9e2cf1e13681