### PR TITLE
Improve paint badge display

### DIFF
--- a/static/retry.js
+++ b/static/retry.js
@@ -117,23 +117,18 @@ function attachItemModal() {
           const div = document.createElement('div');
           if (data.paint_hex) {
             const sw = document.createElement('span');
-            sw.style.display = 'inline-block';
-            sw.style.width = '12px';
-            sw.style.height = '12px';
-            sw.style.marginRight = '4px';
-            sw.style.border = '1px solid #333';
-            sw.style.borderRadius = '50%';
+            sw.classList.add('paint-dot');
             sw.style.background = data.paint_hex;
             div.appendChild(sw);
           }
           div.appendChild(document.createTextNode('Paint: ' + data.paint_name));
-
-  if (data.custom_description) {
-    const cd = document.createElement("div");
-    cd.textContent = "Custom Desc: " + data.custom_description;
-    attrs.appendChild(cd);
-  }
           attrs.appendChild(div);
+        }
+
+        if (data.custom_description) {
+          const cd = document.createElement('div');
+          cd.textContent = 'Custom Desc: ' + data.custom_description;
+          attrs.appendChild(cd);
         }
 
         if (Array.isArray(data.strange_parts) && data.strange_parts.length) {

--- a/static/style.css
+++ b/static/style.css
@@ -191,6 +191,17 @@ button {
   color: #fff;
 }
 
+/* ───── Paint colour dot (used in card & modal) ───────────────────── */
+.paint-dot {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  margin-right: 4px;
+  border: 1px solid #333;
+  border-radius: 50%;
+  vertical-align: middle;
+}
+
 .tf2-hours { margin-left: 6px; font-size: 0.9em; }
 
 .page-footer {

--- a/templates/_user.html
+++ b/templates/_user.html
@@ -32,16 +32,24 @@
                style="border-color: {{ item.quality_color }};"
                data-item='{{ item|tojson|safe }}'>
 
-            {# badge bar (bottom-right) #}
-            {% if item.badges %}
+            {# ─── Badge row ─────────────────────────────────────────────── #}
             <div class="item-badges">
+              {# Paint dot (uses hex) #}
+              {% if item.paint_hex %}
+                <span class="paint-dot"
+                      style="background: {{ item.paint_hex or '#555' }};"
+                      title="Paint: {{ item.paint_name }}"></span>
+              {% endif %}
+
+              {# All the *other* badges. Skip the old paint icons (🎨 / 🖌) #}
               {% for badge in item.badges %}
-                <span class="badge"
-                      {% if badge.color %} style="color:{{ badge.color }}"{% endif %}
-                      title="{{ badge.title }}">{{ badge.icon }}</span>
+                {% if badge not in ["🎨", "🖌"] %}
+                  <span class="badge"
+                        {% if badge.color %} style="color:{{ badge.color }}"{% endif %}
+                        title="{{ badge.title }}">{{ badge.icon }}</span>
+                {% endif %}
               {% endfor %}
             </div>
-            {% endif %}
             {% if item.image_url %}
               <img class="item-img" src="{{ item.image_url }}" alt="{{ item.name }}" width="64" height="64" onerror="this.style.display='none';">
             {% else %}


### PR DESCRIPTION
## Summary
- display new paint dot in item cards
- use new badge logic in retry modal
- style paint dot in CSS

## Testing
- `pre-commit run --files templates/_user.html static/retry.js static/style.css`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686484b1be28832693377d0c3a3a4774