### PR TITLE
Fix paint color dot rendering

### DIFF
--- a/templates/_user.html
+++ b/templates/_user.html
@@ -35,10 +35,9 @@
             {# ─── Badge row ─────────────────────────────────────────────── #}
             <div class="item-badges">
               {# Paint dot (uses hex) #}
-              {% if item.paint_hex %}
-                <span class="paint-dot"
-                      style="background: {{ item.paint_hex or '#555' }};"
-                      title="Paint: {{ item.paint_name }}"></span>
+              {% if item.paint_name %}
+                <span class="paint-dot" style="background-color: {{ item.paint_hex }};"></span>
+                {{ item.paint_name }}
               {% endif %}
 
               {# All the *other* badges. Skip the old paint icons (🎨 / 🖌) #}


### PR DESCRIPTION
## Summary
- add `_process_item` helper to store paint hex and name
- display paint dot before paint name in user template

## Testing
- `pre-commit run --files utils/inventory_processor.py templates/_user.html`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865076e3f148326812c4a66476c278b