### PR TITLE
Add spell badges & paint fixes

### DIFF
--- a/templates/_user.html
+++ b/templates/_user.html
@@ -35,9 +35,8 @@
             {# ─── Badge row ─────────────────────────────────────────────── #}
             <div class="item-badges">
               {# Paint dot (uses hex) #}
-              {% if item.paint_name %}
-                <span class="paint-dot" style="background-color: {{ item.paint_hex }};"></span>
-                {{ item.paint_name }}
+              {% if item.paint_hex %}
+                <span class="paint-dot" style="background-color: {{ item.paint_hex }};" title="Paint: {{ item.paint_name }}"></span>
               {% endif %}
 
               {# All the *other* badges. Skip the old paint icons (🎨 / 🖌) #}


### PR DESCRIPTION
## Summary
- display paint dot with tooltip
- parse multiple spells and map to categories
- build modal spell list with icons
- show one badge per spell category

## Testing
- `pre-commit run --files utils/inventory_processor.py templates/_user.html`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68650de4a6c083268933be5af65a9de4