### PR TITLE
Add badges for paint and warpaint

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -231,3 +231,28 @@ def test_user_template_safe(monkeypatch, status):
 
     with app.app.app_context():
         app.render_template("_user.html", user=user)
+
+
+def test_paint_and_paintkit_badges(monkeypatch):
+    data = {
+        "items": [
+            {
+                "defindex": 9000,
+                "quality": 6,
+                "attributes": [
+                    {"defindex": 142, "float_value": 3100495},
+                    {"defindex": 834, "float_value": 350},
+                ],
+            }
+        ]
+    }
+    sf.SCHEMA = {"9000": {"defindex": 9000, "item_name": "Painted", "image_url": ""}}
+    sf.QUALITIES = {"6": "Unique"}
+    monkeypatch.setattr(ld, "PAINT_NAMES", {"3100495": "Test Paint"}, False)
+    monkeypatch.setattr(ld, "PAINTKIT_NAMES", {"350": "Test Kit"}, False)
+
+    items = ip.enrich_inventory(data)
+    badges = items[0]["badges"]
+
+    assert {"icon": "\U0001f3a8", "title": "Paint: Test Paint"} in badges
+    assert {"icon": "\U0001f58c", "title": "Warpaint: Test Kit"} in badges

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -237,7 +237,7 @@ def _extract_killstreak_effect(asset: Dict[str, Any]) -> str | None:
 
 
 def _extract_spells(
-    asset: Dict[str, Any]
+    asset: Dict[str, Any],
 ) -> Tuple[List[Dict[str, str]], Dict[str, bool]]:
     """Return spell details and boolean flags for badge mapping."""
 
@@ -406,6 +406,11 @@ def _process_item(
             "footprint": "Footprints spell",
         }
         badges.append({"icon": icon_map[cat], "title": title_map[cat]})
+
+    if paint_name:
+        badges.append({"icon": "\U0001f3a8", "title": f"Paint: {paint_name}"})
+    if paintkit_name:
+        badges.append({"icon": "\U0001f58c", "title": f"Warpaint: {paintkit_name}"})
 
     item = {
         "defindex": defindex,


### PR DESCRIPTION
## Summary
- append paint and warpaint badges in `_process_item`
- test that badges appear when paint or paintkit data exists

## Testing
- `pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865114f435c8326a75c8ed4379d30cd