### PR TITLE
Add test for item badge JSON

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -4,6 +4,18 @@
 #
 #    pip-compile --generate-hashes --output-file=requirements.lock requirements.txt
 #
+beautifulsoup4==4.13.4 \
+    --hash=sha256:9bbbb14bfde9d79f38b8cd5f8c7c85f4b8f2523190ebed90e950a8dea4cb1c4b \
+    --hash=sha256:dbb3c4e1ceae6aefebdaf2423247260cd062430a410e38c66f2baa50a8437195 \
+    # via -r requirements.txt
+soupsieve==2.7 \
+    --hash=sha256:6e60cc5c1ffaf1cebcc12e8188320b72071e922c2e897f737cadce79ad5d30c4 \
+    --hash=sha256:ad282f9b6926286d2ead4750552c8a6142bc4c783fd66b0293547c8fe6ae126a \
+    # via beautifulsoup4
+typing-extensions==4.14.0 \
+    --hash=sha256:a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af \
+    --hash=sha256:8676b788e32f02ab42d9e7c61324048ae4c6d844a399eebace3d4979d75ceef4 \
+    # via beautifulsoup4
 blinker==1.9.0 \
     --hash=sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf \
     --hash=sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pytest==8.4.0
 pytest-cov==6.2.1
 responses==0.25.0
 vdf==3.4
+beautifulsoup4==4.13.4

--- a/tests/test_user_badges.py
+++ b/tests/test_user_badges.py
@@ -1,0 +1,48 @@
+import importlib
+import json
+
+import pytest
+from flask import render_template_string
+from bs4 import BeautifulSoup
+
+HTML = '{% include "_user.html" %}'
+
+
+@pytest.fixture
+def app(monkeypatch):
+    monkeypatch.setenv("STEAM_API_KEY", "x")
+    monkeypatch.setattr("utils.schema_fetcher.ensure_schema_cached", lambda: {})
+    monkeypatch.setattr("utils.local_data.load_files", lambda: ({}, {}))
+    mod = importlib.import_module("app")
+    importlib.reload(mod)
+    return mod.app
+
+
+def test_item_badges_rendered(app):
+    item = {
+        "name": "Rocket Launcher",
+        "image_url": "http://example.com/rl.png",
+        "quality_color": "#fff",
+        "badges": [
+            {"icon": "★", "title": "Unusual", "color": "#b00"},
+            {"icon": "🎩", "title": "Vintage"},
+            {"icon": "😎", "title": "Cool"},
+        ],
+    }
+    user = {
+        "steamid": "1",
+        "profile": "",
+        "avatar": "",
+        "username": "Test",
+        "playtime": 0,
+        "status": "parsed",
+        "items": [item],
+    }
+    with app.app_context():
+        app_module = importlib.import_module("app")
+        user_ns = app_module.normalize_user_payload(user)
+        html = render_template_string(HTML, user=user_ns)
+    soup = BeautifulSoup(html, "html.parser")
+    card = soup.find("div", class_="item-card")
+    data = json.loads(card["data-item"])
+    assert data["badges"] == item["badges"]


### PR DESCRIPTION
## Summary
- add BeautifulSoup to dependencies
- lock new dependencies
- ensure user data template includes item badge list via new unit test

## Testing
- `pre-commit run --files tests/test_user_badges.py requirements.txt requirements.lock`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68651651b8508326bc9b0055ae01fa54