### PR TITLE
Add spell badge tests

### DIFF
--- a/tests/test_translate_and_enrich.py
+++ b/tests/test_translate_and_enrich.py
@@ -1,4 +1,8 @@
 from translate_and_enrich import enrich_inventory
+from utils import inventory_processor as ip
+from utils import schema_fetcher as sf
+from utils import local_data as ld
+from utils import items_game_cache as ig
 
 
 def test_decorated_flamethrower_enrichment():
@@ -47,3 +51,48 @@ def test_decorated_flamethrower_enrichment():
     assert "🎯" in item["badges"]
     assert "🖌" in item["badges"]
     assert "🎨" in item["badges"]
+
+
+def test_extract_spells_and_badges(monkeypatch):
+    sf.SCHEMA = {"501": {"defindex": 501, "item_name": "Gun", "image_url": ""}}
+    ld.TF2_SCHEMA = {}
+    ld.ITEMS_GAME_CLEANED = {}
+    monkeypatch.setattr(ig, "ensure_items_game_cached", lambda: {})
+    monkeypatch.setattr(ig, "ITEM_BY_DEFINDEX", {}, False)
+
+    asset = {
+        "defindex": 501,
+        "quality": 6,
+        "attributes": [],
+        "descriptions": [
+            {"value": "Halloween: Exorcism (spell only active during event)"},
+            {"value": "Paint Spell: Chromatic Corruption"},
+            {"value": "Halloween: Team Spirit Footprints"},
+            {"value": "Halloween: Pumpkin Bombs"},
+            {"value": "Rare Spell: Voices From Below"},
+        ],
+    }
+
+    spells, flags = ip._extract_spells(asset)
+    expected_spells = [
+        "Exorcism",
+        "Chromatic Corruption",
+        "Team Spirit Footprints",
+        "Pumpkin Bombs",
+        "Voices From Below",
+    ]
+    assert spells == expected_spells
+    assert flags == {
+        "has_exorcism": True,
+        "has_paint_spell": True,
+        "has_footprints": True,
+        "has_pumpkin_bombs": True,
+        "has_voice_lines": True,
+    }
+
+    item = ip._process_item(asset, sf.SCHEMA, {})
+    icons = {b["icon"] for b in item["badges"]}
+    assert {"👻", "🫟", "👣", "🗣️"} <= icons
+
+    items = ip.enrich_inventory({"items": [asset]})
+    assert items[0]["modal_spells"] == expected_spells

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -392,7 +392,7 @@ def _process_item(
         icon_map = {
             "weapon": "\U0001f47b",
             "vocal": "\U0001f5e3\ufe0f",
-            "paint": "\U0001fa9f",
+            "paint": "\U0001fadf",
             "footprint": "\U0001f463",
         }
         title_map = {


### PR DESCRIPTION
## Summary
- check `_extract_spells` and `_process_item` handling of spell text
- display new paint spell icon
- ensure modal receives spell list

## Testing
- `pre-commit run --files utils/inventory_processor.py tests/test_translate_and_enrich.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68651adac04c832680a935b8788f92cb