### PR TITLE
Fix killstreak effect table

### DIFF
--- a/static/retry.js
+++ b/static/retry.js
@@ -96,9 +96,12 @@ function attachItemModal() {
           const ksParts = [];
           ksParts.push(tierMap[data.killstreak_tier] || data.killstreak_tier);
           if (data.sheen) ksParts.push(data.sheen);
-          if (data.killstreak_effect) ksParts.push(data.killstreak_effect);
           const ks = document.createElement('div');
-          ks.textContent = 'Killstreak: ' + ksParts.join(', ');
+          let ksHtml = 'Killstreak: ' + ksParts.join(', ');
+          if (data.killstreak_effect) {
+            ksHtml += ', <span class="ks-effect">' + data.killstreak_effect + '</span>';
+          }
+          ks.innerHTML = ksHtml;
           attrs.appendChild(ks);
         }
 

--- a/static/style.css
+++ b/static/style.css
@@ -170,6 +170,12 @@ button {
 .item-badges .badge{
   filter:drop-shadow(0 0 2px #0008);
 }
+.badge[data-icon="🎯"],
+.badge[data-icon="⚔"]{
+  color:#ff7e30;
+  filter:drop-shadow(0 0 3px #ff7e30);
+}
+.ks-effect{color:#ff7e30;font-weight:bold;}
 .item-img {
   max-width: 64px;
   max-height: 64px;

--- a/templates/_user.html
+++ b/templates/_user.html
@@ -42,7 +42,7 @@
               {# All the *other* badges. Skip the old paint icons (🎨 / 🖌) #}
               {% for badge in item.badges %}
                 {% if badge.icon not in ['🎨', '🖌'] %}
-                  <span class="badge"
+                  <span class="badge" data-icon="{{ badge.icon }}"
                         {% if badge.color %} style="color:{{ badge.color }}"{% endif %}
                         title="{{ badge.title }}">{{ badge.icon }}</span>
                 {% endif %}

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -137,11 +137,11 @@ def _extract_killstreak(asset: Dict[str, Any]) -> Tuple[str | None, str | None]:
     for attr in asset.get("attributes", []):
         idx = attr.get("defindex")
         val = int(attr.get("float_value", 0))
-        if idx in (2025, 2013):
+        if idx == 2025:
             tier = local_data.KILLSTREAK_NAMES.get(str(val)) or _KILLSTREAK_TIER.get(
                 val
             )
-        elif idx == 2014:
+        elif idx == 2013:
             sheen = _SHEEN_NAMES.get(val)
     return tier, sheen
 
@@ -222,8 +222,15 @@ def _extract_killstreak_effect(asset: Dict[str, Any]) -> str | None:
 
     for attr in asset.get("attributes", []):
         idx = attr.get("defindex")
-        if idx in (2013, 2015):
-            name = attr.get("account_info", {}).get("name")
+        if idx == 2014:
+            raw = attr.get("float_value")
+            if raw is None:
+                raw = attr.get("value")
+            try:
+                val = int(float(raw))
+            except (TypeError, ValueError):
+                continue
+            name = local_data.KILLSTREAK_EFFECT_NAMES.get(str(val))
             if name:
                 return name
     for desc in asset.get("descriptions", []):

--- a/utils/local_data.py
+++ b/utils/local_data.py
@@ -14,6 +14,18 @@ KILLSTREAK_NAMES: Dict[str, str] = {}
 STRANGE_PART_NAMES: Dict[str, str] = {}
 PAINTKIT_NAMES: Dict[str, str] = {}
 CRATE_SERIES_NAMES: Dict[str, str] = {}
+KILLSTREAK_EFFECT_NAMES: Dict[str, str] = {
+    # Known professional killstreaker eye effects (IDs 2000-2006)
+    "2000": "Fire Horns",
+    "2001": "Cerebral Discharge",
+    "2002": "Tornado",
+    "2003": "Flames",
+    "2004": "Singularity",
+    "2005": "Incinerator",
+    "2006": "Hypno-Beam",
+    # Entries for 2007+ were previously misidentified as unusual effects and
+    # have been removed pending verification.
+}
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 DEFAULT_SCHEMA_FILE = BASE_DIR / "cache" / "tf2_schema.json"
@@ -24,6 +36,7 @@ DEFAULT_EFFECT_FILE = BASE_DIR / "cache" / "effect_names.json"
 DEFAULT_PAINT_FILE = BASE_DIR / "cache" / "paint_names.json"
 DEFAULT_WEAR_FILE = BASE_DIR / "cache" / "wear_names.json"
 DEFAULT_KILLSTREAK_FILE = BASE_DIR / "cache" / "killstreak_names.json"
+DEFAULT_KS_EFFECT_FILE = BASE_DIR / "cache" / "killstreak_effect_names.json"
 DEFAULT_STRANGE_PART_FILE = BASE_DIR / "cache" / "strange_part_names.json"
 DEFAULT_PAINTKIT_FILE = BASE_DIR / "cache" / "paintkit_names.json"
 DEFAULT_CRATE_SERIES_FILE = BASE_DIR / "cache" / "crate_series_names.json"
@@ -31,6 +44,7 @@ EFFECT_FILE = Path(os.getenv("TF2_EFFECT_FILE", DEFAULT_EFFECT_FILE))
 PAINT_FILE = Path(os.getenv("TF2_PAINT_FILE", DEFAULT_PAINT_FILE))
 WEAR_FILE = Path(os.getenv("TF2_WEAR_FILE", DEFAULT_WEAR_FILE))
 KILLSTREAK_FILE = Path(os.getenv("TF2_KILLSTREAK_FILE", DEFAULT_KILLSTREAK_FILE))
+KILLSTREAK_EFFECT_FILE = Path(os.getenv("TF2_KS_EFFECT_FILE", DEFAULT_KS_EFFECT_FILE))
 STRANGE_PART_FILE = Path(os.getenv("TF2_STRANGE_PART_FILE", DEFAULT_STRANGE_PART_FILE))
 PAINTKIT_FILE = Path(os.getenv("TF2_PAINTKIT_FILE", DEFAULT_PAINTKIT_FILE))
 CRATE_SERIES_FILE = Path(os.getenv("TF2_CRATE_SERIES_FILE", DEFAULT_CRATE_SERIES_FILE))
@@ -128,6 +142,7 @@ def load_files(*, auto_refetch: bool = False) -> Tuple[Dict[str, Any], Dict[str,
     PAINT_NAMES = _load_json_map(PAINT_FILE)
     WEAR_NAMES = _load_json_map(WEAR_FILE)
     KILLSTREAK_NAMES = _load_json_map(KILLSTREAK_FILE)
+    KILLSTREAK_EFFECT_NAMES = _load_json_map(KILLSTREAK_EFFECT_FILE)
     STRANGE_PART_NAMES = _load_json_map(STRANGE_PART_FILE)
     PAINTKIT_NAMES = _load_json_map(PAINTKIT_FILE)
     CRATE_SERIES_NAMES = _load_json_map(CRATE_SERIES_FILE)
@@ -137,6 +152,7 @@ def load_files(*, auto_refetch: bool = False) -> Tuple[Dict[str, Any], Dict[str,
         ("paints", PAINT_NAMES, PAINT_FILE),
         ("wears", WEAR_NAMES, WEAR_FILE),
         ("killstreaks", KILLSTREAK_NAMES, KILLSTREAK_FILE),
+        ("killstreak effects", KILLSTREAK_EFFECT_NAMES, KILLSTREAK_EFFECT_FILE),
         ("strange parts", STRANGE_PART_NAMES, STRANGE_PART_FILE),
         ("paintkits", PAINTKIT_NAMES, PAINTKIT_FILE),
         ("crate series", CRATE_SERIES_NAMES, CRATE_SERIES_FILE),


### PR DESCRIPTION
## Summary
- remove invalid killstreak effect entries
- fix killstreak effect extraction
- style killstreaker badges and modal text
- refine comment for killstreak effect map

## Testing
- `pre-commit run --files utils/local_data.py utils/inventory_processor.py static/retry.js static/style.css templates/_user.html`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686520d90fdc832681a0736476d9882b