### PR TITLE
Refactor inventory enrichment for standardized output

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -254,8 +254,17 @@ def test_paint_and_paintkit_badges(monkeypatch):
     items = ip.enrich_inventory(data)
     badges = items[0]["badges"]
 
-    assert {"icon": "\U0001f3a8", "title": "Paint: Test Paint"} in badges
-    assert {"icon": "\U0001f58c", "title": "Warpaint: Test Kit"} in badges
+    assert {
+        "icon": "\U0001f3a8",
+        "title": "Paint: Test Paint",
+        "color": "#2F4F4F",
+        "type": "paint",
+    } in badges
+    assert {
+        "icon": "\U0001f58c",
+        "title": "Warpaint: Test Kit",
+        "type": "warpaint",
+    } in badges
 
 
 def test_schema_name_used_for_key():

--- a/tests/test_translate_and_enrich.py
+++ b/tests/test_translate_and_enrich.py
@@ -92,7 +92,7 @@ def test_extract_spells_and_badges(monkeypatch):
 
     item = ip._process_item(asset, sf.SCHEMA, {})
     icons = {b["icon"] for b in item["badges"]}
-    assert {"👻", "🫟", "👣", "🗣️"} <= icons
+    assert {"👻", "🧪", "👣", "🗣️"} <= icons
 
     items = ip.enrich_inventory({"items": [asset]})
     assert items[0]["modal_spells"] == expected_spells


### PR DESCRIPTION
## Summary
- refactor badge creation into `_generate_badges`
- add `standardize_item` and `enrich_and_standardize` helpers
- expose additional item fields for id, attributes and spell flags
- update paint extraction for better color lookup
- adjust tests for new badge structure

## Testing
- `pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py tests/test_translate_and_enrich.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68653965ba2c832683fbfd9882416156