### PR TITLE
Fix paint extraction from value attribute

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -267,6 +267,28 @@ def test_paint_and_paintkit_badges(monkeypatch):
     } in badges
 
 
+def test_paint_extracted_from_value(monkeypatch):
+    data = {
+        "items": [
+            {
+                "defindex": 9000,
+                "quality": 6,
+                "attributes": [
+                    {"defindex": 142, "value": 15158332},
+                ],
+            }
+        ]
+    }
+    sf.SCHEMA = {"9000": {"defindex": 9000, "item_name": "Painted", "image_url": ""}}
+    sf.QUALITIES = {"6": "Unique"}
+    monkeypatch.setattr(ld, "PAINT_NAMES", {}, False)
+
+    items = ip.enrich_inventory(data)
+    item = items[0]
+    assert item["paint_name"] == "Australium Gold"
+    assert item["paint_hex"] == "#E7B53B"
+
+
 def test_schema_name_used_for_key():
     data = {"items": [{"defindex": 5021, "quality": 6}]}
     sf.SCHEMA = {"5021": {"defindex": 5021, "item_name": "Mann Co. Supply Crate Key"}}

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -152,7 +152,13 @@ def _extract_paint(asset: Dict[str, Any]) -> Tuple[str | None, str | None]:
     for attr in asset.get("attributes", []):
         idx = attr.get("defindex")
         if idx in (142, 261):
-            val = int(attr.get("float_value", 0))
+            raw = attr.get("float_value")
+            if raw is None:
+                raw = attr.get("value")
+            try:
+                val = int(raw)
+            except (TypeError, ValueError):
+                continue
             entry = local_data.PAINT_NAMES.get(str(val))
             name = None
             hex_color = None


### PR DESCRIPTION
## Summary
- handle paint attributes stored in `value`
- test extraction when paint ID is set via `value`

## Testing
- `pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865548276b08326b3f7ba1617ff7aa4