### PR TITLE
Add debug logs for paint detection

### DIFF
--- a/static/retry.js
+++ b/static/retry.js
@@ -84,6 +84,7 @@ function attachItemModal() {
       let data = card.dataset.item;
       if (!data) return;
       try { data = JSON.parse(data); } catch (e) { return; }
+      console.log('Paint HEX for', data.market_hash_name, data.paint_hex);
       if (title) title.textContent = data.custom_name || data.name || '';
       if (effectBox) effectBox.textContent = data.unusual_effect || '';
       if (img) img.src = data.image_url || '';

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -149,6 +149,9 @@ def _extract_killstreak(asset: Dict[str, Any]) -> Tuple[str | None, str | None]:
 def _extract_paint(asset: Dict[str, Any]) -> Tuple[str | None, str | None]:
     """Return paint name and hex color if present."""
 
+    # Debug: show raw values so we can confirm paint IDs like 15158332
+    print("Paint attr IDs:", [a.get("value") for a in asset.get("attributes", [])])
+
     for attr in asset.get("attributes", []):
         idx = attr.get("defindex")
         if idx in (142, 261):
@@ -500,6 +503,7 @@ def _process_item(
     ks_tier, sheen = _extract_killstreak(asset)
     ks_effect = _extract_killstreak_effect(asset)
     paint_name, paint_hex = _extract_paint(asset)
+    print("Resolved Paint:", paint_name, paint_hex)
     wear_name = _extract_wear(asset)
     crate_series_name = _extract_crate_series(asset)
     spells, spell_flags = _extract_spells(asset)


### PR DESCRIPTION
## Summary
- add debug printing of paint attribute IDs
- log resolved paint name + hex when processing an item
- print paint hex in the JS modal for debugging

## Testing
- `pre-commit run --files utils/inventory_processor.py static/retry.js`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686559a96aa083268475d85baaf9b391