### PR TITLE
Add inventory_scanner tests

### DIFF
--- a/tests/test_inventory_scanner.py
+++ b/tests/test_inventory_scanner.py
@@ -1,0 +1,28 @@
+import inventory_scanner
+import pytest
+
+
+class DummyResp:
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return {"result": {"items": [{"defindex": 1, "quality": 6}]}}
+
+
+def test_main_usage(capsys):
+    with pytest.raises(SystemExit) as exc:
+        inventory_scanner.main([])
+    out = capsys.readouterr().out
+    assert "Usage" in out
+    assert exc.value.code == 1
+
+
+def test_main_prints_item_count(monkeypatch, capsys):
+    monkeypatch.setenv("STEAM_API_KEY", "x")
+    monkeypatch.setattr(
+        inventory_scanner.requests, "get", lambda url, timeout=10: DummyResp()
+    )
+    inventory_scanner.main(["123"])
+    out = capsys.readouterr().out
+    assert "Found 1 items in inventory for 123" in out


### PR DESCRIPTION
## Summary
- add new tests for the inventory_scanner CLI utility

## Testing
- `pre-commit run --files tests/test_inventory_scanner.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68658287d18c83269596d695df460227