### PR TITLE
Add fixture and route tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,26 @@
 import sys
 from pathlib import Path
+import importlib
+import asyncio
+
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+@pytest.fixture
+def app(monkeypatch):
+    """Return Flask app with env and schema mocks."""
+
+    monkeypatch.setenv("STEAM_API_KEY", "x")
+    monkeypatch.setattr("utils.schema_fetcher.ensure_schema_cached", lambda: {})
+    monkeypatch.setattr("utils.local_data.load_files", lambda: ({}, {}))
+    monkeypatch.setattr(
+        "utils.items_game_cache.ensure_future",
+        lambda *a, **k: asyncio.get_event_loop().create_future(),
+    )
+
+    mod = importlib.import_module("app")
+    importlib.reload(mod)
+    mod.app.secret_key = "test"
+    return mod.app

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -1,0 +1,40 @@
+import importlib
+
+
+def test_get_home_displays_preloaded_user(app):
+    mod = importlib.import_module("app")
+    user = mod.normalize_user_payload(
+        {
+            "steamid": "1",
+            "avatar": "",
+            "username": "Test",
+            "playtime": 0,
+            "status": "parsed",
+            "items": [],
+        }
+    )
+    app.config["PRELOADED_USERS"] = [user]
+    app.config["TEST_STEAMID"] = "1"
+    client = app.test_client()
+    resp = client.get("/")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert 'id="user-1"' in html
+
+
+def test_post_invalid_ids_flash(app):
+    client = app.test_client()
+    resp = client.post("/", data={"steamids": "foobar"})
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert "No valid Steam IDs found!" in html
+
+
+def test_post_valid_ids_sets_initial_ids(app):
+    client = app.test_client()
+    steamid = "76561198034301681"
+    resp = client.post("/", data={"steamids": steamid})
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert steamid in html
+    assert "window.initialIds" in html


### PR DESCRIPTION
## Summary
- add an app fixture in `tests/conftest.py` to preload env vars and mock schema
- test rendering of `/` via Flask test client
- check flashing of invalid IDs and `initialIds` script output

## Testing
- `pre-commit run --files tests/conftest.py tests/test_flask_routes.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865862217c88326939f7fc6d6cdeda7