### PR TITLE
Add coverage config

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,8 @@
+[run]
+branch = True
+
+[report]
+exclude_lines =
+    pragma: no cover
+    if __name__ == '__main__'
+    manual debug helper

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --cov --cov-config=.coveragerc


### PR DESCRIPTION
## Summary
- add `.coveragerc` with patterns to ignore debug helpers
- configure `pytest` to enable coverage by default

## Testing
- `pre-commit run --files .coveragerc pytest.ini`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686587c061fc8326bd4f9a92f020d49d