### PR TITLE
Add CI and pytest pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-test.txt
+          pip install pre-commit
+      - name: Run pre-commit
+        run: pre-commit run --all-files --show-diff-on-failure --color always
+      - name: Run tests
+        run: pytest --cov --cov-report=xml
+      - name: Upload coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.python-version }}
+          path: coverage.xml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,13 @@ repos:
     rev: v0.4.4
     hooks:
       - id: ruff
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest
+        language: system
+        pass_filenames: false
 # Temporarily disabled due to network blocks
 # - repo: https://github.com/awslabs/git-secrets
 #   rev: 1.3.0


### PR DESCRIPTION
## Summary
- run tests via `pre-commit` using a local pytest hook
- add GitHub Actions CI workflow for Python 3.11 and 3.12
- run `pre-commit` and `pytest --cov` in CI and upload `coverage.xml`

## Testing
- `pre-commit run --all-files`
- `pytest --cov --cov-report=xml`

------
https://chatgpt.com/codex/tasks/task_e_686589dc57288326a34272691c74c73e