### PR TITLE
Enable Codecov coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,8 @@ jobs:
         with:
           name: coverage-${{ matrix.python-version }}
           path: coverage.xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 data/
 cache/
 .venv/
+.coverage

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TF2 Inventory Web App ![CI](https://github.com/dankrr/tf2-inventory-scanner/actions/workflows/ci.yml/badge.svg) ![coverage](https://img.shields.io/badge/coverage-unknown-lightgrey.svg)
+# TF2 Inventory Web App ![CI](https://github.com/dankrr/tf2-inventory-scanner/actions/workflows/ci.yml/badge.svg) [![coverage](https://codecov.io/gh/dankrr/tf2-inventory-scanner/branch/main/graph/badge.svg)](https://codecov.io/gh/dankrr/tf2-inventory-scanner)
 
 This project provides a small Flask application for inspecting the Team Fortress
 2 inventory of one or more Steam users. It accepts SteamIDs in several formats


### PR DESCRIPTION
## Summary
- upload coverage results to Codecov in CI
- show Codecov badge in `README`
- ignore coverage output locally

## Testing
- `pre-commit run --files .github/workflows/ci.yml README.md .gitignore`

------
https://chatgpt.com/codex/tasks/task_e_68658b2a38988326859ffb83ce1509ae