### PR TITLE
Run pytest in pre-commit with dummy API key

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     hooks:
       - id: pytest
         name: pytest
-        entry: pytest
+        entry: bash -c 'STEAM_API_KEY=test pytest'
         language: system
         pass_filenames: false
 # Temporarily disabled due to network blocks


### PR DESCRIPTION
## Summary
- set a dummy `STEAM_API_KEY` when running `pytest` via pre-commit so tests do
  not fail if a key is missing

## Testing
- `pre-commit run --files tests/test_inventory_scanner.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865808b2dd083268ee8afd66f20fc6c