### PR TITLE
Fix killstreak mappings

### DIFF
--- a/tests/test_translate_and_enrich.py
+++ b/tests/test_translate_and_enrich.py
@@ -14,7 +14,7 @@ def test_decorated_flamethrower_enrichment():
                 "attributes": [
                     {"defindex": 2025, "value": "3"},
                     {"defindex": 2014, "value": "3"},
-                    {"defindex": 2013, "value": "2000"},
+                    {"defindex": 2013, "value": "2002"},
                     {"defindex": 142, "value": "3100495"},
                     {"defindex": 725, "float_value": 0.2},
                     {"defindex": 834, "value": "350"},
@@ -44,7 +44,7 @@ def test_decorated_flamethrower_enrichment():
 
     assert item["quality"] == "Decorated Weapon"
     assert item["killstreak_tier"] == "Professional Killstreak"
-    assert item["sheen"] == "Mandarin"
+    assert item["sheen"] == "Manndarin"
     assert item["killstreaker"] == "Fire Horns"
     assert item["wear"] == "Field-Tested"
     assert item["paintkit"] == "Warhawk"

--- a/translate_and_enrich.py
+++ b/translate_and_enrich.py
@@ -27,23 +27,24 @@ QUALITY_MAP = {
 SHEEN_MAP = {
     1: "Team Shine",
     2: "Deadly Daffodil",
-    3: "Mandarin",
+    3: "Manndarin",
     4: "Mean Green",
-    5: "Villainous Violet",
-    6: "Hot Rod",
+    5: "Agonizing Emerald",
+    6: "Villainous Violet",
+    7: "Hot Rod",
 }
 
 KILLSTREAKER_MAP = {
-    2000: "Fire Horns",
-    2001: "Cerebral Discharge",
-    2002: "Tornado",
-    2003: "Flames",
-    2004: "Singularity",
-    2005: "Incinerator",
-    2006: "Hypno-Beam",
-    2007: "Tesla Coil",
-    2008: "Hellish Inferno",
-    2009: "Fireworks",
+    2002: "Fire Horns",
+    2003: "Cerebral Discharge",
+    2004: "Tornado",
+    2005: "Flames",
+    2006: "Singularity",
+    2007: "Incinerator",
+    2008: "Hypno-Beam",
+    2009: "Tesla Coil",
+    2010: "Hellish Inferno",
+    2011: "Fireworks",
 }
 
 KILLSTREAK_TIER_MAP = {

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -68,10 +68,11 @@ _KILLSTREAK_TIER = {
 _SHEEN_NAMES = {
     1: "Team Shine",
     2: "Deadly Daffodil",
-    3: "Mandarin",
+    3: "Manndarin",
     4: "Mean Green",
-    5: "Villainous Violet",
-    6: "Hot Rod",
+    5: "Agonizing Emerald",
+    6: "Villainous Violet",
+    7: "Hot Rod",
 }
 
 # Map of item origin ID -> human readable string
@@ -141,7 +142,7 @@ def _extract_killstreak(asset: Dict[str, Any]) -> Tuple[str | None, str | None]:
             tier = local_data.KILLSTREAK_NAMES.get(str(val)) or _KILLSTREAK_TIER.get(
                 val
             )
-        elif idx == 2013:
+        elif idx == 2014:
             sheen = _SHEEN_NAMES.get(val)
     return tier, sheen
 
@@ -222,7 +223,7 @@ def _extract_killstreak_effect(asset: Dict[str, Any]) -> str | None:
 
     for attr in asset.get("attributes", []):
         idx = attr.get("defindex")
-        if idx == 2014:
+        if idx == 2013:
             val = int(attr.get("float_value", 0))
             name = local_data.KILLSTREAK_EFFECT_NAMES.get(str(val))
             if name:

--- a/utils/local_data.py
+++ b/utils/local_data.py
@@ -15,16 +15,16 @@ STRANGE_PART_NAMES: Dict[str, str] = {}
 PAINTKIT_NAMES: Dict[str, str] = {}
 CRATE_SERIES_NAMES: Dict[str, str] = {}
 KILLSTREAK_EFFECT_NAMES: Dict[str, str] = {
-    "2000": "Fire Horns",
-    "2001": "Cerebral Discharge",
-    "2002": "Tornado",
-    "2003": "Flames",
-    "2004": "Singularity",
-    "2005": "Incinerator",
-    "2006": "Hypno-Beam",
-    "2007": "Tesla Coil",
-    "2008": "Hellish Inferno",
-    "2009": "Fireworks",
+    "2002": "Fire Horns",
+    "2003": "Cerebral Discharge",
+    "2004": "Tornado",
+    "2005": "Flames",
+    "2006": "Singularity",
+    "2007": "Incinerator",
+    "2008": "Hypno-Beam",
+    "2009": "Tesla Coil",
+    "2010": "Hellish Inferno",
+    "2011": "Fireworks",
 }
 
 BASE_DIR = Path(__file__).resolve().parent.parent


### PR DESCRIPTION
## Summary
- list all seven sheens for decorated weapons
- swap killstreak attribute indexes
- use official killstreaker IDs
- adjust translate script and tests

## Testing
- `pre-commit run --files utils/inventory_processor.py utils/local_data.py translate_and_enrich.py tests/test_translate_and_enrich.py`

------
https://chatgpt.com/codex/tasks/task_e_6865c2cbc9448326ab15215f0728ac1f