### PR TITLE
Expose constants API

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,13 +9,14 @@ from typing import List, Dict, Any
 from types import SimpleNamespace
 
 from dotenv import load_dotenv
-from flask import Flask, render_template, request, flash
+from flask import Flask, render_template, request, flash, jsonify
 from utils.id_parser import extract_steam_ids
 from utils.schema_fetcher import ensure_schema_cached
 from utils.inventory_processor import enrich_inventory
 from utils import steam_api_client as sac
 from utils import items_game_cache
 from utils import local_data
+from utils import constants as consts
 
 load_dotenv()
 if not os.getenv("STEAM_API_KEY"):
@@ -197,6 +198,20 @@ def _setup_test_mode() -> None:
 def retry_single(steamid64: int):
     """Reprocess a single user and return a rendered snippet."""
     return fetch_and_process_single_user(steamid64)
+
+
+@app.get("/api/constants")
+def api_constants():
+    """Return static constant mappings for client usage."""
+    return jsonify(
+        {
+            "paint_colors": consts.PAINT_COLORS,
+            "sheen_names": consts.SHEEN_NAMES,
+            "killstreak_tiers": consts.KILLSTREAK_TIERS,
+            "killstreak_effects": consts.KILLSTREAK_EFFECTS,
+            "origin_map": consts.ORIGIN_MAP,
+        }
+    )
 
 
 # --- Flask routes -----------------------------------------------------------

--- a/tests/test_constants_api.py
+++ b/tests/test_constants_api.py
@@ -1,0 +1,12 @@
+from utils import constants
+
+
+def test_api_constants_route(app):
+    client = app.test_client()
+    resp = client.get("/api/constants")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["paint_colors"]["3100495"][0] == "A Color Similar to Slate"
+    assert data["sheen_names"]["1"] == constants.SHEEN_NAMES[1]
+    assert data["killstreak_tiers"]["3"] == constants.KILLSTREAK_TIERS[3]
+    assert data["origin_map"]["0"] == constants.ORIGIN_MAP[0]

--- a/translate_and_enrich.py
+++ b/translate_and_enrich.py
@@ -8,6 +8,8 @@ import struct
 import argparse
 import json
 
+from utils.constants import KILLSTREAK_EFFECTS, KILLSTREAK_TIERS, SHEEN_NAMES
+
 
 QUALITY_MAP = {
     0: "Normal",
@@ -23,35 +25,6 @@ QUALITY_MAP = {
     13: "Haunted",
     14: "Collector's",
     15: "Decorated Weapon",
-}
-
-SHEEN_MAP = {
-    1: "Team Shine",
-    2: "Deadly Daffodil",
-    3: "Manndarin",
-    4: "Mean Green",
-    5: "Agonizing Emerald",
-    6: "Villainous Violet",
-    7: "Hot Rod",
-}
-
-KILLSTREAKER_MAP = {
-    2002: "Fire Horns",
-    2003: "Cerebral Discharge",
-    2004: "Tornado",
-    2005: "Flames",
-    2006: "Singularity",
-    2007: "Incinerator",
-    2008: "Hypno-Beam",
-    2009: "Tesla Coil",
-    2010: "Hellish Inferno",
-    2011: "Fireworks",
-}
-
-KILLSTREAK_TIER_MAP = {
-    1: "Killstreak",
-    2: "Specialized Killstreak",
-    3: "Professional Killstreak",
 }
 
 
@@ -165,13 +138,13 @@ def enrich_inventory(
             )
             ks_tier = maps.get("killstreak_names", {}).get(
                 str(kst)
-            ) or KILLSTREAK_TIER_MAP.get(kst)
+            ) or KILLSTREAK_TIERS.get(kst)
 
         sheen_val = _attr_value(attrs, 2014)
         sheen = None
         if sheen_val is not None:
             sv = int(float(sheen_val)) if isinstance(sheen_val, str) else int(sheen_val)
-            sheen = maps.get("killstreak_names", {}).get(str(sv)) or SHEEN_MAP.get(sv)
+            sheen = maps.get("killstreak_names", {}).get(str(sv)) or SHEEN_NAMES.get(sv)
 
         ks_eff_val = _attr_value(attrs, 2013)
         ks_effect = None
@@ -183,7 +156,7 @@ def enrich_inventory(
             )
             ks_effect = maps.get("killstreak_names", {}).get(
                 str(ksv)
-            ) or KILLSTREAKER_MAP.get(ksv)
+            ) or KILLSTREAK_EFFECTS.get(ksv)
 
         paint_id = _attr_value(attrs, 142) or _attr_value(attrs, 261)
         paint_name = None

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,15 @@
+from .constants import (
+    PAINT_COLORS,
+    SHEEN_NAMES,
+    KILLSTREAK_TIERS,
+    KILLSTREAK_EFFECTS,
+    ORIGIN_MAP,
+)
+
+__all__ = [
+    "PAINT_COLORS",
+    "SHEEN_NAMES",
+    "KILLSTREAK_TIERS",
+    "KILLSTREAK_EFFECTS",
+    "ORIGIN_MAP",
+]

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -1,0 +1,87 @@
+"""Static maps for paint colors, killstreak tiers and other enums."""
+
+# Map of killstreak tier id -> readable name
+KILLSTREAK_TIERS = {
+    1: "Killstreak",
+    2: "Specialized Killstreak",
+    3: "Professional Killstreak",
+}
+
+# Map of sheen id -> name
+SHEEN_NAMES = {
+    1: "Team Shine",
+    2: "Deadly Daffodil",
+    3: "Manndarin",
+    4: "Mean Green",
+    5: "Agonizing Emerald",
+    6: "Villainous Violet",
+    7: "Hot Rod",
+}
+
+# Map of item origin id -> human readable string
+ORIGIN_MAP = {
+    0: "Timed Drop",
+    1: "Achievement",
+    2: "Purchased",
+    3: "Traded",
+    4: "Crafted",
+    5: "Store Promotion",
+    6: "Gifted",
+    7: "Support Promotion",
+    8: "Found in Crate",
+    9: "Earned",
+    10: "Third-Party Promotion",
+    11: "Purchased",
+    12: "Halloween Drop",
+    13: "Package Item",
+    14: "Store Promotion",
+    15: "Foreign",
+}
+
+# Map of paint id -> (name, hex color)
+PAINT_COLORS = {
+    3100495: ("A Color Similar to Slate", "#2F4F4F"),
+    8208497: ("A Deep Commitment to Purple", "#7D4071"),
+    8208498: ("A Distinctive Lack of Hue", "#141414"),
+    15185211: ("A Mann's Mint", "#BCDDB3"),
+    12955537: ("After Eight", "#2D2D24"),
+    8289918: ("Dark Salmon Injustice", "#E9967A"),
+    8421376: ("Indubitably Green", "#729E42"),
+    13595446: ("Mann Co. Orange", "#CF7336"),
+    12377523: ("Muskelmannbraun", "#A57545"),
+    5322826: ("Noble Hatter's Violet", "#51384A"),
+    15787660: ("Pink as Hell", "#FF69B4"),
+    8154199: ("Peculiarly Drab Tincture", "#C5AF91"),
+    4345659: ("Radigan Conagher Brown", "#694D3A"),
+    2960676: ("Color No. 216-190-216", "#D8BED8"),
+    7511618: ("The Bitter Taste of Defeat and Lime", "#32CD32"),
+    15132390: ("Drably Olive", "#808000"),
+    8422108: ("The Color of a Gentlemann's Business Pants", "#FBE85C"),
+    12807213: ("Ye Olde Rustic Colour", "#7C6C57"),
+    1315860: ("An Extraordinary Abundance of Tinge", "#E6E6E6"),
+    12073019: ("Team Spirit", "#B8383B"),
+    15787618: ("An Air of Debonair", "#654740"),
+    8208496: ("Balaclavas Are Forever", "#3B1F23"),
+    8208499: ("Cream Spirit", "#C36C2D"),
+    1757009: ("Operator's Overalls", "#483838"),
+    6901050: ("Waterlogged Lab Coat", "#A9B4C2"),
+    2158218: ("Zepheniah's Greed", "#424F3B"),
+    3874595: ("The Value of Teamwork", "#FFD700"),
+    16341610: ("A Color Most Splendid", "#FFB000"),
+    15158332: ("Australium Gold", "#E7B53B"),
+    13164768: ("Aged Moustache Grey", "#7E7E7E"),
+}
+
+# Map of killstreak effect id -> name
+KILLSTREAK_EFFECTS = {
+    2002: "Fire Horns",
+    2003: "Cerebral Discharge",
+    2004: "Tornado",
+    2005: "Flames",
+    2006: "Singularity",
+    2007: "Incinerator",
+    2008: "Hypno-Beam",
+    2009: "Tesla Coil",
+    2010: "Hellish Inferno",
+    2011: "Fireworks",
+}

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -8,6 +8,13 @@ from pathlib import Path
 import struct
 
 from . import steam_api_client, schema_fetcher, items_game_cache, local_data
+from .constants import (
+    KILLSTREAK_TIERS,
+    SHEEN_NAMES,
+    ORIGIN_MAP,
+    PAINT_COLORS,
+    KILLSTREAK_EFFECTS,
+)
 
 items_game_cache.load_items_game_cleaned()
 
@@ -60,77 +67,6 @@ def _extract_unusual_effect(asset: Dict[str, Any]) -> str | None:
     return None
 
 
-_KILLSTREAK_TIER = {
-    1: "Killstreak",
-    2: "Specialized Killstreak",
-    3: "Professional Killstreak",
-}
-
-_SHEEN_NAMES = {
-    1: "Team Shine",
-    2: "Deadly Daffodil",
-    3: "Manndarin",
-    4: "Mean Green",
-    5: "Agonizing Emerald",
-    6: "Villainous Violet",
-    7: "Hot Rod",
-}
-
-# Map of item origin ID -> human readable string
-ORIGIN_MAP = {
-    0: "Timed Drop",
-    1: "Achievement",
-    2: "Purchased",
-    3: "Traded",
-    4: "Crafted",
-    5: "Store Promotion",
-    6: "Gifted",
-    7: "Support Promotion",
-    8: "Found in Crate",
-    9: "Earned",
-    10: "Third-Party Promotion",
-    11: "Purchased",
-    12: "Halloween Drop",
-    13: "Package Item",
-    14: "Store Promotion",
-    15: "Foreign",
-}
-
-# Map of paint ID -> (name, hex color)
-PAINT_MAP = {
-    3100495: ("A Color Similar to Slate", "#2F4F4F"),
-    8208497: ("A Deep Commitment to Purple", "#7D4071"),
-    8208498: ("A Distinctive Lack of Hue", "#141414"),
-    15185211: ("A Mann's Mint", "#BCDDB3"),
-    12955537: ("After Eight", "#2D2D24"),
-    8289918: ("Dark Salmon Injustice", "#E9967A"),
-    8421376: ("Indubitably Green", "#729E42"),
-    13595446: ("Mann Co. Orange", "#CF7336"),
-    12377523: ("Muskelmannbraun", "#A57545"),
-    5322826: ("Noble Hatter's Violet", "#51384A"),
-    15787660: ("Pink as Hell", "#FF69B4"),
-    8154199: ("Peculiarly Drab Tincture", "#C5AF91"),
-    4345659: ("Radigan Conagher Brown", "#694D3A"),
-    2960676: ("Color No. 216-190-216", "#D8BED8"),
-    7511618: ("The Bitter Taste of Defeat and Lime", "#32CD32"),
-    15132390: ("Drably Olive", "#808000"),
-    8422108: ("The Color of a Gentlemann's Business Pants", "#FBE85C"),
-    12807213: ("Ye Olde Rustic Colour", "#7C6C57"),
-    1315860: ("An Extraordinary Abundance of Tinge", "#E6E6E6"),
-    12073019: ("Team Spirit", "#B8383B"),
-    15787618: ("An Air of Debonair", "#654740"),
-    8208496: ("Balaclavas Are Forever", "#3B1F23"),
-    8208499: ("Cream Spirit", "#C36C2D"),
-    1757009: ("Operator's Overalls", "#483838"),
-    6901050: ("Waterlogged Lab Coat", "#A9B4C2"),
-    2158218: ("Zepheniah's Greed", "#424F3B"),
-    3874595: ("The Value of Teamwork", "#FFD700"),
-    16341610: ("A Color Most Splendid", "#FFB000"),
-    15158332: ("Australium Gold", "#E7B53B"),
-    13164768: ("Aged Moustache Grey", "#7E7E7E"),
-}
-
-
 def _extract_killstreak(asset: Dict[str, Any]) -> Tuple[str | None, str | None]:
     """Return killstreak tier and sheen names if present."""
 
@@ -140,11 +76,11 @@ def _extract_killstreak(asset: Dict[str, Any]) -> Tuple[str | None, str | None]:
         idx = attr.get("defindex")
         val = int(attr.get("float_value", 0))
         if idx == 2025:
-            tier = local_data.KILLSTREAK_NAMES.get(str(val)) or _KILLSTREAK_TIER.get(
+            tier = local_data.KILLSTREAK_NAMES.get(str(val)) or KILLSTREAK_TIERS.get(
                 val
             )
         elif idx == 2014:
-            sheen = _SHEEN_NAMES.get(val)
+            sheen = SHEEN_NAMES.get(val)
     return tier, sheen
 
 
@@ -156,9 +92,9 @@ def _extract_paint(asset: Dict[str, Any]) -> Tuple[str | None, str | None]:
         if idx in (142, 261):
             val = int(attr.get("float_value", 0))
             name = local_data.PAINT_NAMES.get(str(val))
-            hex_color = PAINT_MAP.get(val, (None, None))[1]
+            hex_color = PAINT_COLORS.get(val, (None, None))[1]
             if not name:
-                name = PAINT_MAP.get(val, (None, None))[0]
+                name = PAINT_COLORS.get(val, (None, None))[0]
             if hex_color and not re.match(r"^#[0-9A-Fa-f]{6}$", hex_color):
                 hex_color = None
             return name, hex_color
@@ -262,7 +198,9 @@ def _extract_killstreak_effect(asset: Dict[str, Any]) -> str | None:
         idx = attr.get("defindex")
         if idx == 2013:
             val = int(attr.get("float_value", 0))
-            name = local_data.KILLSTREAK_EFFECT_NAMES.get(str(val))
+            name = local_data.KILLSTREAK_EFFECT_NAMES.get(
+                str(val)
+            ) or KILLSTREAK_EFFECTS.get(val)
             if name:
                 return name
     for desc in asset.get("descriptions", []):


### PR DESCRIPTION
## Summary
- centralize item constants in `utils/constants.py`
- import shared constants into inventory helpers and translation script
- expose constants via `/api/constants`
- test the new constants route

## Testing
- `pytest -q`
- `pre-commit run --files utils/constants.py utils/inventory_processor.py translate_and_enrich.py app.py utils/__init__.py tests/test_constants_api.py`

------
https://chatgpt.com/codex/tasks/task_e_6865ccc587b88326b0e5975e802cd00e