### PR TITLE
Add attribute validation script and CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r requirements-test.txt
           pip install pre-commit
+      - name: Validate attributes
+        run: python scripts/validate_attributes.py
       - name: Run pre-commit
         run: pre-commit run --all-files --show-diff-on-failure --color always
       - name: Run tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,11 @@ repos:
       - id: ruff
   - repo: local
     hooks:
+      - id: validate-attributes
+        name: validate attributes
+        entry: bash -c 'PYTHONPATH=. python scripts/validate_attributes.py'
+        language: system
+        pass_filenames: false
       - id: pytest
         name: pytest
         entry: bash -c 'STEAM_API_KEY=test pytest'

--- a/scripts/validate_attributes.py
+++ b/scripts/validate_attributes.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+"""Check that required attributes exist in the local schema."""
+
+from __future__ import annotations
+
+import os
+
+from utils import local_data
+
+# attribute defindex -> human readable name
+REQUIRED_ATTRS = {
+    134: "Unusual Effect",
+    142: "Paint Color",
+    261: "Paint Color (legacy)",
+    725: "Wear",
+    834: "Paintkit",
+    2025: "Killstreak Tier",
+    2014: "Killstreak Sheen",
+    2013: "Killstreaker",
+    187: "Crate Series",
+    866: "Paintkit Seed Lo",
+    867: "Paintkit Seed Hi",
+}
+
+
+def main() -> int:
+    """Load schema and print status for each required attribute."""
+    if os.getenv("SKIP_VALIDATE"):
+        print("Schema validation skipped.")
+        return 0
+    try:
+        _, items_game = local_data.load_files()
+    except Exception as exc:  # pragma: no cover - filesystem issues
+        print(f"\N{CROSS MARK} Failed to load schema: {exc}")
+        return 0 if os.getenv("SKIP_VALIDATE") else 1
+
+    attributes = (
+        items_game.get("attributes", {}) if isinstance(items_game, dict) else {}
+    )
+    all_ok = True
+    for attr_id, label in REQUIRED_ATTRS.items():
+        if str(attr_id) in attributes:
+            print(f"\N{CHECK MARK} {attr_id} {label}")
+        else:
+            print(f"\N{CROSS MARK} {attr_id} {label}")
+            all_ok = False
+    return 0 if all_ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `scripts/validate_attributes.py` to report schema coverage
- call validation script in CI and pre-commit

## Testing
- `pre-commit run --files scripts/validate_attributes.py .pre-commit-config.yaml .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_6865d0a467448326bea7cee54f283df4