### PR TITLE
Add weapon color spell support

### DIFF
--- a/static/modal.js
+++ b/static/modal.js
@@ -43,6 +43,18 @@
     if (body) body.innerHTML = html;
   }
 
+  function renderBadges(badges) {
+    const box = document.getElementById('modal-badges');
+    if (!box) return;
+    box.innerHTML = '';
+    (badges || []).forEach(b => {
+      const span = document.createElement('span');
+      span.textContent = b.icon;
+      span.title = b.title || '';
+      box.appendChild(span);
+    });
+  }
+
   function initModal() {
     if (initialized) return;
     const modal = getModal();
@@ -56,5 +68,5 @@
     initialized = true;
   }
 
-  global.modal = { initModal, openModal, closeModal, updateModal };
+  global.modal = { initModal, openModal, closeModal, updateModal, renderBadges };
 })(window);

--- a/static/retry.js
+++ b/static/retry.js
@@ -163,17 +163,14 @@ function attachItemModal() {
           });
         }
       }
-      if (badgeBox) {
-        badgeBox.innerHTML = '';
-        (data.badges || []).forEach(b => {
-          const span = document.createElement('span');
-          span.textContent = b.icon;
-          span.title = b.title;
+      if (window.modal && typeof window.modal.renderBadges === 'function') {
+        window.modal.renderBadges(data.badges);
+        const spans = badgeBox ? badgeBox.querySelectorAll('span') : [];
+        spans.forEach(span => {
           span.addEventListener('click', () => {
             const sec = document.getElementById('modal-spells');
             if (sec) sec.scrollIntoView({ behavior: 'smooth' });
           });
-          badgeBox.appendChild(span);
         });
       }
       if (window.modal && typeof window.modal.openModal === 'function') {

--- a/tests/test_modal.js
+++ b/tests/test_modal.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 
 const modalCode = fs.readFileSync('static/modal.js', 'utf8');
 
-const dom = new JSDOM('<!DOCTYPE html><dialog id="item-modal"><div class="modal-body"></div></dialog>', { runScripts: 'dangerously' });
+const dom = new JSDOM('<!DOCTYPE html><dialog id="item-modal"><div id="modal-badges"></div><div class="modal-body"></div></dialog>', { runScripts: 'dangerously' });
 
 const { window } = dom;
 window.document.body.appendChild(window.document.getElementById('item-modal'));
@@ -26,6 +26,10 @@ if (window.document.getElementById('item-modal').classList.contains('open')) {
 }
 if (window.document.querySelector('.modal-body').innerHTML !== '') {
   throw new Error('Modal body should be cleared');
+}
+modal.renderBadges([{ icon: '🌈', title: 'Weapon color spell' }]);
+if (!window.document.querySelector('#modal-badges').textContent.includes('🌈')) {
+  throw new Error('Badge not rendered');
 }
 console.log('Modal tests passed');
 

--- a/tests/test_translate_and_enrich.py
+++ b/tests/test_translate_and_enrich.py
@@ -73,6 +73,7 @@ def test_extract_spells_and_badges(monkeypatch):
             {"value": "Halloween: Team Spirit Footprints"},
             {"value": "Halloween: Pumpkin Bombs"},
             {"value": "Rare Spell: Voices From Below"},
+            {"value": "Weapon Color: Indubitably Green"},
         ],
     }
 
@@ -83,6 +84,7 @@ def test_extract_spells_and_badges(monkeypatch):
         "Team Spirit Footprints",
         "Pumpkin Bombs",
         "Voices From Below",
+        "Indubitably Green",
     ]
     assert spells == expected_spells
     assert flags == {
@@ -91,11 +93,12 @@ def test_extract_spells_and_badges(monkeypatch):
         "has_footprints": True,
         "has_pumpkin_bombs": True,
         "has_voice_lines": True,
+        "has_weapon_color": True,
     }
 
     item = ip._process_item(asset, sf.SCHEMA, {})
     icons = {b["icon"] for b in item["badges"]}
-    assert {"👻", "🫟", "👣", "🗣️"} <= icons
+    assert {"👻", "🫟", "👣", "🗣️", "🌈"} <= icons
 
     items = ip.enrich_inventory({"items": [asset]})
     assert items[0]["modal_spells"] == expected_spells

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -230,6 +230,7 @@ def _extract_spells(
         "has_footprints": False,
         "has_pumpkin_bombs": False,
         "has_voice_lines": False,
+        "has_weapon_color": False,
     }
 
     for desc in asset.get("descriptions", []):
@@ -256,6 +257,12 @@ def _extract_spells(
             flags["has_pumpkin_bombs"] = True
         if "voices" in ltext or "rare spell" in ltext:
             flags["has_voice_lines"] = True
+        if "weapon color" in ltext or "weapon colour" in ltext:
+            flags["has_weapon_color"] = True
+            name = text.split(":", 1)[-1].strip()
+            name = re.sub(r"\(.*?\)$", "", name).strip()
+            if name and name not in spells:
+                spells.append(name)
 
     return spells, flags
 
@@ -438,6 +445,7 @@ def _process_item(
         "paint": spell_flags.get("has_paint_spell"),
         "footprint": spell_flags.get("has_footprints"),
         "vocal": spell_flags.get("has_voice_lines"),
+        "weapon_color": spell_flags.get("has_weapon_color"),
     }
     for cat, present in category_flags.items():
         if not present:
@@ -447,12 +455,14 @@ def _process_item(
             "vocal": "\U0001f5e3\ufe0f",
             "paint": "\U0001fadf",
             "footprint": "\U0001f463",
+            "weapon_color": "\U0001f308",
         }
         title_map = {
             "weapon": "Weapon spell",
             "vocal": "Vocal spell",
             "paint": "Paint spell",
             "footprint": "Footprints spell",
+            "weapon_color": "Weapon color spell",
         }
         badges.append({"icon": icon_map[cat], "title": title_map[cat]})
 
@@ -504,6 +514,8 @@ def _process_item(
         "crate_series_name": crate_series_name,
         "killstreak_effect": ks_effect,
         "spells": spells,
+        "has_footprints": spell_flags.get("has_footprints"),
+        "has_weapon_color": spell_flags.get("has_weapon_color"),
         "badges": badges,  # always present, may be empty
         "strange_parts": strange_parts,
         "strange_count": kill_eater_counts.get(1),


### PR DESCRIPTION
## Summary
- add `has_weapon_color` flag and include footprints/weapon color flags in item JSON
- render badges in modal.js via new `renderBadges` helper
- update retry.js to use badge helper
- test badge rendering in modal.js
- adjust spell extraction test for weapon color

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files utils/inventory_processor.py tests/test_translate_and_enrich.py static/modal.js static/retry.js tests/test_modal.js`
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6865d35eac108326b89e2b4a1cafbec1