### PR TITLE
Add enrichment tests with logger warnings

### DIFF
--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -1,0 +1,88 @@
+import pytest
+from utils import inventory_processor as ip
+from utils import schema_fetcher as sf
+from utils import items_game_cache as ig
+from utils import local_data as ld
+
+
+@pytest.fixture(autouse=True)
+def no_items_game(monkeypatch):
+    monkeypatch.setattr(ig, "ensure_items_game_cached", lambda: {})
+    monkeypatch.setattr(ig, "ITEM_BY_DEFINDEX", {}, False)
+    ld.TF2_SCHEMA = {}
+    ld.ITEMS_GAME_CLEANED = {}
+
+
+def test_enrichment_full_attributes(monkeypatch):
+    data = {
+        "items": [
+            {
+                "defindex": 111,
+                "quality": 11,
+                "attributes": [
+                    {"defindex": 2025, "float_value": 3},
+                    {"defindex": 2014, "float_value": 3},
+                    {"defindex": 2013, "float_value": 2003},
+                    {"defindex": 725, "float_value": 0.2},
+                    {"defindex": 214, "value": 10},
+                    {"defindex": 292, "value": 64},
+                    {"defindex": 379, "value": 5},
+                    {"defindex": 380, "value": 70},
+                ],
+                "descriptions": [
+                    {"value": "Halloween: Exorcism"},
+                    {"value": "Paint Spell: Chromatic Corruption"},
+                ],
+            }
+        ]
+    }
+    sf.SCHEMA = {"111": {"defindex": 111, "item_name": "Rocket Launcher"}}
+    sf.QUALITIES = {"11": "Strange"}
+    monkeypatch.setattr(
+        ld, "STRANGE_PART_NAMES", {"64": "Kills", "70": "Robots"}, False
+    )
+
+    items = ip.enrich_inventory(data)
+    item = items[0]
+
+    assert item["killstreak_tier"] == "Professional Killstreak"
+    assert item["sheen"] == "Manndarin"
+    assert item["killstreak_effect"] == "Cerebral Discharge"
+    assert item["wear_name"] == "Field-Tested"
+    assert item["strange_count"] == 10
+    assert item["score_type"] == "Kills"
+    assert item["spells"] == ["Exorcism", "Chromatic Corruption"]
+
+
+def test_unknown_values_warn(monkeypatch, caplog):
+    caplog.set_level("WARNING")
+    data = {
+        "items": [
+            {
+                "defindex": 111,
+                "quality": 11,
+                "attributes": [
+                    {"defindex": 2025, "float_value": 99},
+                    {"defindex": 2014, "float_value": 99},
+                    {"defindex": 2013, "float_value": 9999},
+                    {"defindex": 725, "float_value": 1.5},
+                    {"defindex": 214, "value": "bad"},
+                    {"defindex": 300, "value": 1},
+                    {"defindex": "abc", "value": 2},
+                ],
+            }
+        ]
+    }
+    sf.SCHEMA = {"111": {"defindex": 111, "item_name": "Rocket Launcher"}}
+    sf.QUALITIES = {"11": "Strange"}
+
+    ip.enrich_inventory(data)
+
+    text = caplog.text
+    assert "Unknown killstreak tier id" in text
+    assert "Unknown sheen id" in text
+    assert "Unknown killstreak effect id" in text
+    assert "Wear value out of range" in text
+    assert "Invalid kill-eater value" in text
+    assert "Unknown kill-eater index" in text
+    assert "Invalid kill-eater defindex" in text

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -79,8 +79,12 @@ def _extract_killstreak(asset: Dict[str, Any]) -> Tuple[str | None, str | None]:
             tier = local_data.KILLSTREAK_NAMES.get(str(val)) or KILLSTREAK_TIERS.get(
                 val
             )
+            if tier is None:
+                logger.warning("Unknown killstreak tier id: %s", val)
         elif idx == 2014:
             sheen = SHEEN_NAMES.get(val)
+            if sheen is None:
+                logger.warning("Unknown sheen id: %s", val)
     return tier, sheen
 
 
@@ -157,7 +161,10 @@ def _extract_wear(asset: Dict[str, Any]) -> str | None:
             try:
                 val = float(raw)
             except (TypeError, ValueError):
+                logger.warning("Invalid wear value: %r", raw)
                 continue
+            if not 0 <= val <= 1:
+                logger.warning("Wear value out of range: %s", val)
             name = local_data.WEAR_NAMES.get(str(int(val)))
             return name or _wear_tier(val)
 
@@ -203,6 +210,7 @@ def _extract_killstreak_effect(asset: Dict[str, Any]) -> str | None:
             ) or KILLSTREAK_EFFECTS.get(val)
             if name:
                 return name
+            logger.warning("Unknown killstreak effect id: %s", val)
     for desc in asset.get("descriptions", []):
         if not isinstance(desc, dict):
             continue
@@ -306,6 +314,7 @@ def _extract_kill_eater_info(
         try:
             idx = int(idx_raw)
         except (TypeError, ValueError):
+            logger.warning("Invalid kill-eater defindex: %r", idx_raw)
             continue
 
         val_raw = (
@@ -314,6 +323,7 @@ def _extract_kill_eater_info(
         try:
             val = int(float(val_raw))
         except (TypeError, ValueError):
+            logger.warning("Invalid kill-eater value for %s: %r", idx, val_raw)
             continue
 
         if idx == 214:
@@ -328,6 +338,10 @@ def _extract_kill_eater_info(
                 counts[(idx - 379) // 2 + 2] = val
             else:  # even -> score_type_X
                 types[(idx - 380) // 2 + 2] = val
+        elif idx in (214, 292):
+            pass
+        else:
+            logger.warning("Unknown kill-eater index: %s", idx)
 
     return counts, types
 


### PR DESCRIPTION
## Summary
- add warnings for unmapped killstreak, sheen, wear and kill-eater attributes
- create `test_enrichment.py` to validate killstreak tiers, sheens, wear names, spells and kill-eater counts
- test unknown values trigger logger warnings

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files tests/test_enrichment.py utils/inventory_processor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865d5a94c5c8326abf6b1bfe769a816