### PR TITLE
Update modal handling

### DIFF
--- a/static/modal.js
+++ b/static/modal.js
@@ -10,17 +10,20 @@
     return modal ? modal.querySelector('.modal-body') : null;
   }
 
-  function openModal(html) {
+  function openModal() {
     const modal = getModal();
     if (!modal) return;
-    const body = getBody();
-    if (body && html !== undefined) body.innerHTML = html;
     if (typeof modal.showModal === 'function') {
       modal.showModal();
     } else {
       modal.style.display = 'block';
     }
     modal.classList.add('open');
+  }
+
+  function populateModal(html) {
+    const body = getBody();
+    if (body) body.innerHTML = html;
   }
 
   function closeModal() {
@@ -39,8 +42,7 @@
   }
 
   function updateModal(html) {
-    const body = getBody();
-    if (body) body.innerHTML = html;
+    populateModal(html);
   }
 
   function renderBadges(badges) {
@@ -68,5 +70,11 @@
     initialized = true;
   }
 
-  global.modal = { initModal, openModal, closeModal, updateModal, renderBadges };
+  global.modal = {
+    initModal,
+    openModal,
+    closeModal,
+    populateModal,
+    renderBadges,
+  };
 })(window);

--- a/tests/test_modal.js
+++ b/tests/test_modal.js
@@ -13,7 +13,8 @@ window.document.body.appendChild(script);
 
 const modal = window.modal;
 modal.initModal();
-modal.openModal('<p>Hello</p>');
+modal.populateModal('<p>Hello</p>');
+modal.openModal();
 if (!window.document.getElementById('item-modal').classList.contains('open')) {
   throw new Error('Modal should have open class');
 }


### PR DESCRIPTION
## Summary
- refactor modal API to separate content population from opening
- update tests to new API

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files static/modal.js tests/test_modal.js`

------
https://chatgpt.com/codex/tasks/task_e_68663f980a788326ae937fa00f0526cd