### PR TITLE
Refactor modal HTML generation

### DIFF
--- a/static/modal.js
+++ b/static/modal.js
@@ -45,6 +45,80 @@
     populateModal(html);
   }
 
+  function escapeHtml(str) {
+    return String(str || '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function generateModalHTML(data) {
+    if (!data) return '';
+    const esc = escapeHtml;
+    const attrs = [];
+
+    if (data.killstreak_tier) {
+      const tierMap = { 1: 'Killstreak', 2: 'Specialized', 3: 'Professional' };
+      const ksParts = [];
+      ksParts.push(tierMap[data.killstreak_tier] || data.killstreak_tier);
+      if (data.sheen) ksParts.push(esc(data.sheen));
+      let ksHtml = 'Killstreak: ' + ksParts.join(', ');
+      if (data.killstreak_effect) {
+        ksHtml += ', <span class="ks-effect">' + esc(data.killstreak_effect) + '</span>';
+      }
+      attrs.push('<div>' + ksHtml + '</div>');
+    }
+
+    ;[
+      ['Type', data.item_type_name],
+      ['Level', data.level],
+      ['Origin', data.origin],
+    ].forEach(([label, value]) => {
+      if (!value) return;
+      attrs.push('<div>' + esc(label) + ': ' + esc(value) + '</div>');
+    });
+
+    if (data.paint_name) {
+      let html = '<div>';
+      if (data.paint_hex) {
+        html += '<span class="paint-dot" style="background:' + esc(data.paint_hex) + '"></span>';
+      }
+      html += 'Paint: ' + esc(data.paint_name) + '</div>';
+      attrs.push(html);
+    }
+
+    if (data.wear_name) attrs.push('<div>Wear: ' + esc(data.wear_name) + '</div>');
+
+    if (data.paintkit_name) attrs.push('<div>Paintkit: ' + esc(data.paintkit_name) + '</div>');
+
+    if (data.crate_series_name) attrs.push('<div>Crate series: ' + esc(data.crate_series_name) + '</div>');
+
+    if (data.custom_description) attrs.push('<div>Custom Desc: ' + esc(data.custom_description) + '</div>');
+
+    if (Array.isArray(data.strange_parts) && data.strange_parts.length) {
+      attrs.push('<div>Strange Parts: ' + data.strange_parts.map(esc).join(', ') + '</div>');
+    }
+
+    let spells = '';
+    if (Array.isArray(data.spells) && data.spells.length) {
+      spells += '<h4 id="modal-spells">Spells</h4>';
+      spells += data.spells.map(sp => '<div>' + esc(sp) + '</div>').join('');
+    }
+
+    const details = attrs.join('') + spells;
+    const imgTag = '<img src="' + esc(data.image_url || '') + '" width="64" height="64" alt="">';
+    return imgTag + '<div id="modal-details">' + details + '</div>';
+  }
+
+  function updateHeader(data) {
+    const title = document.getElementById('modal-title');
+    const effectBox = document.getElementById('modal-effect');
+    if (title) title.textContent = data.custom_name || data.name || '';
+    if (effectBox) effectBox.textContent = data.unusual_effect || '';
+  }
+
   function renderBadges(badges) {
     const box = document.getElementById('modal-badges');
     if (!box) return;
@@ -76,5 +150,7 @@
     closeModal,
     populateModal,
     renderBadges,
+    generateModalHTML,
+    updateHeader,
   };
 })(window);

--- a/static/retry.js
+++ b/static/retry.js
@@ -64,10 +64,6 @@ function loadUsers(ids) {
 function attachItemModal() {
   const modal = document.getElementById('item-modal');
   if (!modal) return;
-  const title = document.getElementById('modal-title');
-  const effectBox = document.getElementById('modal-effect');
-  const img = document.getElementById('modal-img');
-  const details = document.getElementById('modal-details');
   const badgeBox = document.getElementById('modal-badges');
 
   document.querySelectorAll('.item-card').forEach(card => {
@@ -75,93 +71,17 @@ function attachItemModal() {
       let data = card.dataset.item;
       if (!data) return;
       try { data = JSON.parse(data); } catch (e) { return; }
-      if (title) title.textContent = data.custom_name || data.name || '';
-      if (effectBox) effectBox.textContent = data.unusual_effect || '';
-      if (img) img.src = data.image_url || '';
-      if (details) {
-        details.innerHTML = '';
-        const attrs = document.createElement('div');
-        // ── Killstreak row ─────────────────────────
-        if (data.killstreak_tier) {
-          const tierMap = {1: 'Killstreak', 2: 'Specialized', 3: 'Professional'};
-          const ksParts = [];
-          ksParts.push(tierMap[data.killstreak_tier] || data.killstreak_tier);
-          if (data.sheen) ksParts.push(data.sheen);
-          const ks = document.createElement('div');
-          let ksHtml = 'Killstreak: ' + ksParts.join(', ');
-          if (data.killstreak_effect) {
-            ksHtml += ', <span class="ks-effect">' + data.killstreak_effect + '</span>';
-          }
-          ks.innerHTML = ksHtml;
-          attrs.appendChild(ks);
-        }
-
-        [
-          ['Type', data.item_type_name],
-          ['Level', data.level],
-          ['Origin', data.origin]
-        ].forEach(([label, value]) => {
-          if (!value) return;
-          const div = document.createElement('div');
-          div.textContent = label + ': ' + value;
-          attrs.appendChild(div);
-        });
-
-        if (data.paint_name) {
-          const div = document.createElement('div');
-          if (data.paint_hex) {
-            const sw = document.createElement('span');
-            sw.classList.add('paint-dot');
-            sw.style.background = data.paint_hex;
-            div.appendChild(sw);
-          }
-          div.appendChild(document.createTextNode('Paint: ' + data.paint_name));
-          attrs.appendChild(div);
-        }
-
-        if (data.wear_name) {
-          const div = document.createElement('div');
-          div.textContent = 'Wear: ' + data.wear_name;
-          attrs.appendChild(div);
-        }
-
-        if (data.paintkit_name) {
-          const div = document.createElement('div');
-          div.textContent = 'Paintkit: ' + data.paintkit_name;
-          attrs.appendChild(div);
-        }
-
-        if (data.crate_series_name) {
-          const div = document.createElement('div');
-          div.textContent = 'Crate series: ' + data.crate_series_name;
-          attrs.appendChild(div);
-        }
-
-        if (data.custom_description) {
-          const cd = document.createElement('div');
-          cd.textContent = 'Custom Desc: ' + data.custom_description;
-          attrs.appendChild(cd);
-        }
-
-        if (Array.isArray(data.strange_parts) && data.strange_parts.length) {
-          const div = document.createElement('div');
-          div.textContent = 'Strange Parts: ' + data.strange_parts.join(', ');
-          attrs.appendChild(div);
-        }
-
-        details.appendChild(attrs);
-
-        if (Array.isArray(data.spells) && data.spells.length) {
-          const head = document.createElement('h4');
-          head.textContent = 'Spells';
-          head.id = 'modal-spells';
-          details.appendChild(head);
-          data.spells.forEach(sp => {
-            const sdiv = document.createElement('div');
-            sdiv.textContent = sp;
-            details.appendChild(sdiv);
-          });
-        }
+      if (window.modal && typeof window.modal.updateHeader === 'function') {
+        window.modal.updateHeader(data);
+      } else {
+        const t = document.getElementById('modal-title');
+        const eBox = document.getElementById('modal-effect');
+        if (t) t.textContent = data.custom_name || data.name || '';
+        if (eBox) eBox.textContent = data.unusual_effect || '';
+      }
+      if (window.modal && typeof window.modal.generateModalHTML === 'function') {
+        const html = window.modal.generateModalHTML(data);
+        window.modal.populateModal(html);
       }
       if (window.modal && typeof window.modal.renderBadges === 'function') {
         window.modal.renderBadges(data.badges);


### PR DESCRIPTION
## Summary
- move modal item HTML generation into `modal.js`
- simplify `retry.js` to call new helpers for modal content

## Testing
- `pre-commit run --files static/retry.js` *(fails: ModuleNotFoundError: No module named 'vdf')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686640d112c88326a78bee4b6b0a2e64