### PR TITLE
Fix modal test reopen scenario

### DIFF
--- a/tests/test_modal.js
+++ b/tests/test_modal.js
@@ -28,6 +28,14 @@ if (window.document.getElementById('item-modal').classList.contains('open')) {
 if (window.document.querySelector('.modal-body').innerHTML !== '') {
   throw new Error('Modal body should be cleared');
 }
+modal.populateModal('<p>Hello</p>');
+modal.openModal();
+if (!window.document.getElementById('item-modal').classList.contains('open')) {
+  throw new Error('Modal should reopen with open class');
+}
+if (window.document.querySelector('.modal-body').innerHTML.trim() !== '<p>Hello</p>') {
+  throw new Error('Modal body not restored after reopen');
+}
 modal.renderBadges([{ icon: '🌈', title: 'Weapon color spell' }]);
 if (!window.document.querySelector('#modal-badges').textContent.includes('🌈')) {
   throw new Error('Badge not rendered');


### PR DESCRIPTION
## Summary
- extend modal test to verify close/reopen behavior

## Testing
- `npm install`
- `npm test`
- `pre-commit run --files tests/test_modal.js` *(fails: Missing `/workspace/tf2-inventory-scanner/cache/tf2_schema.json`)*

------
https://chatgpt.com/codex/tasks/task_e_686642e4b728832686a1515c2656a73d