### PR TITLE
Centralize modal logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ Submit any supported SteamID format. Each user panel shows the avatar, TF2 playt
 
 ## Modals
 
-All modal behaviour is centralized in `static/modal.js`. Other scripts, such as
-`retry.js`, call its `openModal`, `closeModal`, and `updateModal` functions to
-control dialog windows.
+All modal behaviour is centralized in `static/modal.js`. Other scripts use
+its helper functions and should never manipulate the modal DOM directly.
+Use `showItemModal(html)` to populate and display the dialog.
 
 ## Testing
 

--- a/docs/ENRICHMENT_PIPELINE.md
+++ b/docs/ENRICHMENT_PIPELINE.md
@@ -1,7 +1,8 @@
 # Enrichment Pipeline Overview
 
-The UI interacts with the backend through `retry.js` and now delegates all modal
-operations to `modal.js`.
+The UI interacts with the backend through `retry.js` and delegates all modal
+operations to `modal.js`. Item details are rendered via
+`showItemModal(html)`.
 
 ```mermaid
 flowchart LR

--- a/static/modal.js
+++ b/static/modal.js
@@ -127,8 +127,21 @@
       const span = document.createElement('span');
       span.textContent = b.icon;
       span.title = b.title || '';
+      span.addEventListener('click', () => {
+        const sec = document.getElementById('modal-spells');
+        if (sec) sec.scrollIntoView({ behavior: 'smooth' });
+      });
       box.appendChild(span);
     });
+  }
+
+  function showItemModal(html) {
+    if (!html) {
+      console.warn('Empty modal HTML!');
+      return;
+    }
+    populateModal(html);
+    openModal();
   }
 
   function initModal() {
@@ -150,6 +163,7 @@
     closeModal,
     populateModal,
     renderBadges,
+    showItemModal,
     generateModalHTML,
     updateHeader,
   };

--- a/static/retry.js
+++ b/static/retry.js
@@ -62,39 +62,26 @@ function loadUsers(ids) {
 }
 
 function attachItemModal() {
-  const modal = document.getElementById('item-modal');
-  if (!modal) return;
-  const badgeBox = document.getElementById('modal-badges');
-
   document.querySelectorAll('.item-card').forEach(card => {
     card.addEventListener('click', () => {
       let data = card.dataset.item;
       if (!data) return;
-      try { data = JSON.parse(data); } catch (e) { return; }
+      try {
+        data = JSON.parse(data);
+      } catch (e) {
+        return;
+      }
       if (window.modal && typeof window.modal.updateHeader === 'function') {
         window.modal.updateHeader(data);
-      } else {
-        const t = document.getElementById('modal-title');
-        const eBox = document.getElementById('modal-effect');
-        if (t) t.textContent = data.custom_name || data.name || '';
-        if (eBox) eBox.textContent = data.unusual_effect || '';
       }
       if (window.modal && typeof window.modal.generateModalHTML === 'function') {
         const html = window.modal.generateModalHTML(data);
-        window.modal.populateModal(html);
+        if (window.modal.showItemModal) {
+          window.modal.showItemModal(html);
+        }
       }
       if (window.modal && typeof window.modal.renderBadges === 'function') {
         window.modal.renderBadges(data.badges);
-        const spans = badgeBox ? badgeBox.querySelectorAll('span') : [];
-        spans.forEach(span => {
-          span.addEventListener('click', () => {
-            const sec = document.getElementById('modal-spells');
-            if (sec) sec.scrollIntoView({ behavior: 'smooth' });
-          });
-        });
-      }
-      if (window.modal && typeof window.modal.openModal === 'function') {
-        window.modal.openModal();
       }
     });
   });

--- a/tests/test_modal.js
+++ b/tests/test_modal.js
@@ -36,6 +36,14 @@ if (!window.document.getElementById('item-modal').classList.contains('open')) {
 if (window.document.querySelector('.modal-body').innerHTML.trim() !== '<p>Hello</p>') {
   throw new Error('Modal body not restored after reopen');
 }
+modal.closeModal();
+modal.showItemModal('<p>Hello again</p>');
+if (!window.document.getElementById('item-modal').classList.contains('open')) {
+  throw new Error('showItemModal should open the modal');
+}
+if (!window.document.querySelector('.modal-body').innerHTML.includes('Hello again')) {
+  throw new Error('showItemModal should populate modal HTML');
+}
 modal.renderBadges([{ icon: '🌈', title: 'Weapon color spell' }]);
 if (!window.document.querySelector('#modal-badges').textContent.includes('🌈')) {
   throw new Error('Badge not rendered');


### PR DESCRIPTION
## Summary
- export `showItemModal` helper
- delegate item card clicks to `showItemModal`
- attach badge scroll logic inside `renderBadges`
- document new modal workflow
- test the new helper

## Testing
- `pre-commit run --files static/modal.js static/retry.js tests/test_modal.js README.md docs/ENRICHMENT_PIPELINE.md` *(fails: ModuleNotFoundError: No module named 'vdf')*
- `node tests/test_modal.js`

------
https://chatgpt.com/codex/tasks/task_e_686647cf53ac8326adaa1c0ddabee17d