### PR TITLE
Centralize modal open/close and fix race

### DIFF
--- a/static/modal.js
+++ b/static/modal.js
@@ -1,5 +1,6 @@
 (function (global) {
   let initialized = false;
+  let closeTimer = null;
 
   function getModal() {
     return document.getElementById('item-modal');
@@ -13,6 +14,10 @@
   function openModal() {
     const modal = getModal();
     if (!modal) return;
+    if (closeTimer) {
+      clearTimeout(closeTimer);
+      closeTimer = null;
+    }
     if (typeof modal.showModal === 'function') {
       modal.showModal();
     } else {
@@ -30,15 +35,16 @@
     const modal = getModal();
     if (!modal) return;
     modal.classList.remove('open');
-    setTimeout(() => {
+    closeTimer = setTimeout(() => {
       if (typeof modal.close === 'function') {
         modal.close();
       } else {
         modal.style.display = 'none';
       }
+      const body = getBody();
+      if (body) body.innerHTML = '';
+      closeTimer = null;
     }, 200);
-    const body = getBody();
-    if (body) body.innerHTML = '';
   }
 
   function updateModal(html) {

--- a/tests/test_modal.js
+++ b/tests/test_modal.js
@@ -25,9 +25,6 @@ modal.closeModal();
 if (window.document.getElementById('item-modal').classList.contains('open')) {
   throw new Error('Modal should be closed');
 }
-if (window.document.querySelector('.modal-body').innerHTML !== '') {
-  throw new Error('Modal body should be cleared');
-}
 modal.populateModal('<p>Hello</p>');
 modal.openModal();
 if (!window.document.getElementById('item-modal').classList.contains('open')) {
@@ -48,5 +45,15 @@ modal.renderBadges([{ icon: '🌈', title: 'Weapon color spell' }]);
 if (!window.document.querySelector('#modal-badges').textContent.includes('🌈')) {
   throw new Error('Badge not rendered');
 }
-console.log('Modal tests passed');
+modal.closeModal();
+modal.showItemModal('<p>Race</p>');
+setTimeout(() => {
+  if (!window.document.getElementById('item-modal').classList.contains('open')) {
+    throw new Error('Modal should stay open after quick reopen');
+  }
+  if (!window.document.querySelector('.modal-body').innerHTML.includes('Race')) {
+    throw new Error('Modal body lost content after quick reopen');
+  }
+  console.log('Modal tests passed');
+}, 250);
 


### PR DESCRIPTION
## Summary
- fix race condition in modal open and close
- update modal tests for new async logic

## Testing
- `node tests/test_modal.js`
- `pre-commit run --files static/modal.js static/retry.js tests/test_modal.js README.md templates/index.html` *(fails: ModuleNotFoundError: No module named 'vdf')*

------
https://chatgpt.com/codex/tasks/task_e_68664bcab0248326b871e5e06d41e089