### PR TITLE
Fix weapon spell IDs

### DIFF
--- a/tests/test_spells.py
+++ b/tests/test_spells.py
@@ -8,7 +8,7 @@ def test_all_spell_types():
             {"defindex": 134, "value": 3005},  # Bruised Purple Footprints
             {"defindex": 134, "value": 702},  # Spectral Spectrum
             {"defindex": 1004, "value": 9},  # Voices from Below
-            {"defindex": 3002, "value": 1},  # Squash Rockets
+            {"defindex": 1009, "value": 1},  # Squash Rockets
         ]
     }
     badges, names = _extract_spells(dummy, is_weapon=True)

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -130,9 +130,9 @@ WEAPON_SPELLS = {
     1005: "Pumpkin Bombs",
     1006: "Halloween Fire",
     1007: "Exorcism",
-    3001: "Gourd Grenades",
-    3002: "Squash Rockets",
-    3003: "Sentry Quad-Pumpkins",
+    1008: "Gourd Grenades",
+    1009: "Squash Rockets",
+    1010: "Sentry Quad-Pumpkins",
 }
 
 # ---- PAINT SPELL SPECIAL CASE (defindex 2043 == Die Job) ----


### PR DESCRIPTION
## Summary
- correct weapon spell particle IDs in constants
- update spell tests accordingly

## Testing
- `pre-commit run --files utils/constants.py tests/test_spells.py`
- `pytest tests/test_spells.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6866797ac71c83268b7e02402f37e65b