### PR TITLE
Add ItemEnricher utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ Submit any supported SteamID format. Each user panel shows the avatar, TF2 playt
   provider = SchemaProvider()
   qualities = provider.get_qualities()
   ```
+You can also enrich raw inventory items using `ItemEnricher`:
+```python
+from utils.item_enricher import ItemEnricher
+
+enricher = ItemEnricher(provider)
+items = enricher.enrich_inventory(raw_items)
+```
 
 ## Modals
 

--- a/tests/test_item_enricher.py
+++ b/tests/test_item_enricher.py
@@ -1,0 +1,47 @@
+from utils.item_enricher import ItemEnricher
+from utils.schema_provider import SchemaProvider
+
+
+def test_enrich_inventory(monkeypatch):
+    provider = SchemaProvider(base_url="https://example.com")
+
+    monkeypatch.setattr(provider, "get_defindexes", lambda: {100: "Rocket"})
+    monkeypatch.setattr(provider, "get_qualities", lambda: {6: "Unique"})
+    monkeypatch.setattr(provider, "get_paints", lambda: {1: "Team Spirit"})
+    monkeypatch.setattr(provider, "get_killstreaks", lambda: {2: "Specialized"})
+    monkeypatch.setattr(provider, "get_effects", lambda: {55: "Hot"})
+    monkeypatch.setattr(provider, "get_paintkits", lambda: {3: "Warhawk"})
+    monkeypatch.setattr(provider, "get_strangeParts", lambda: {"5000": "Kills"})
+
+    enricher = ItemEnricher(provider)
+
+    raw = [
+        {
+            "id": "1",
+            "defindex": 100,
+            "original_id": "1",
+            "inventory": 123,
+            "quality": 6,
+            "attributes": [
+                {"defindex": 142, "value": 1},
+                {"defindex": 2025, "value": 2},
+                {"defindex": 2013, "value": 55},
+                {"defindex": 2014, "value": 55},
+                {"defindex": 134, "value": 55},
+                {"defindex": 834, "value": 3},
+                {"defindex": 5000, "value": 1},
+            ],
+        }
+    ]
+
+    items = enricher.enrich_inventory(raw)
+    item = items[0]
+    assert item["name"] == "Rocket"
+    assert item["quality"] == "Unique"
+    assert item["paint"] == "Team Spirit"
+    assert item["killstreak_tier"] == "Specialized"
+    assert item["sheen"] == "Hot"
+    assert item["killstreaker"] == "Hot"
+    assert item["unusual_effect"] == "Hot"
+    assert item["paintkit"] == "Warhawk"
+    assert item["strange_parts"] == ["Kills"]

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -11,6 +11,7 @@ from .constants import (
     WEAPON_SPELLS,
     SPELL_BADGE_ICONS,
 )
+from .item_enricher import ItemEnricher
 
 __all__ = [
     "PAINT_COLORS",
@@ -24,4 +25,5 @@ __all__ = [
     "VOCAL_SPELLS",
     "WEAPON_SPELLS",
     "SPELL_BADGE_ICONS",
+    "ItemEnricher",
 ]

--- a/utils/item_enricher.py
+++ b/utils/item_enricher.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from .schema_provider import SchemaProvider
+
+
+class ItemEnricher:
+    """Simple inventory enrichment using :class:`SchemaProvider`."""
+
+    SPELL_NAMES = {
+        "Halloween Fire",
+        "Exorcism",
+        "Pumpkin Bombs",
+        "Gourd Grenades",
+        "Squash Rockets",
+        "Sentry Quad-Pumpkins",
+    }
+
+    def __init__(self, provider: SchemaProvider | None = None) -> None:
+        self.provider = provider or SchemaProvider()
+        self._spell_effect_ids: set[int] | None = None
+
+    # ------------------------------------------------------------------
+    def _load_spell_effect_ids(self) -> set[int]:
+        if self._spell_effect_ids is None:
+            mapping = self.provider.get_effects()
+            self._spell_effect_ids = {
+                eid for eid, name in mapping.items() if name in self.SPELL_NAMES
+            }
+        return self._spell_effect_ids
+
+    # ------------------------------------------------------------------
+    def _enrich_attributes(self, attributes: list) -> Dict[str, Any]:
+        """Return attribute info extracted from ``attributes``."""
+
+        result = {
+            "unusual_effect": None,
+            "paint": None,
+            "killstreak_tier": None,
+            "sheen": None,
+            "killstreaker": None,
+            "strange_parts": [],
+            "paintkit": None,
+        }
+
+        paints = self.provider.get_paints()
+        killstreaks = self.provider.get_killstreaks()
+        effects = self.provider.get_effects()
+        paintkits = self.provider.get_paintkits()
+        strange_parts = self.provider.get_strangeParts()
+        spell_ids = self._load_spell_effect_ids()
+
+        for attr in attributes or []:
+            try:
+                idx = int(attr.get("defindex", 0))
+            except (TypeError, ValueError):
+                continue
+
+            val_raw = attr.get("float_value") if "float_value" in attr else attr.get("value")
+            try:
+                val = int(float(val_raw)) if val_raw is not None else None
+            except (TypeError, ValueError):
+                val = None
+
+            if idx == 142 and val is not None:
+                result["paint"] = paints.get(val) or paints.get(str(val))
+            elif idx == 2025 and val is not None:
+                result["killstreak_tier"] = killstreaks.get(val) or killstreaks.get(str(val))
+            elif idx == 2013 and val is not None:
+                result["sheen"] = effects.get(val) or effects.get(str(val))
+            elif idx == 2014 and val is not None:
+                result["killstreaker"] = effects.get(val) or effects.get(str(val))
+            elif idx == 134 and val is not None:
+                if val not in spell_ids:
+                    result["unusual_effect"] = effects.get(val) or effects.get(str(val))
+            elif idx == 834 and val is not None:
+                result["paintkit"] = paintkits.get(val) or paintkits.get(str(val))
+
+            if str(idx) in strange_parts:
+                name = strange_parts[str(idx)]
+                if name not in result["strange_parts"]:
+                    result["strange_parts"].append(name)
+
+        return result
+
+    # ------------------------------------------------------------------
+    def enrich_inventory(self, raw_items: List[dict]) -> List[Dict[str, Any]]:
+        """Return list of item dicts enriched with schema data."""
+
+        defindexes = self.provider.get_defindexes()
+        qualities = self.provider.get_qualities()
+
+        enriched: List[Dict[str, Any]] = []
+        for item in raw_items:
+            defindex = int(item.get("defindex", 0))
+            quality = int(item.get("quality", 0))
+            attrs = item.get("attributes", [])
+            info = {
+                "id": item.get("id"),
+                "defindex": defindex,
+                "original_id": item.get("original_id"),
+                "inventory": item.get("inventory"),
+                "name": defindexes.get(defindex) or defindexes.get(str(defindex)),
+                "quality": qualities.get(quality) or qualities.get(str(quality)),
+            }
+            info.update(self._enrich_attributes(attrs))
+            enriched.append(info)
+        return enriched


### PR DESCRIPTION
## Summary
- implement `utils.item_enricher.ItemEnricher`
- export new class from utils package
- document usage of ItemEnricher in README
- test new enrichment helper

## Testing
- `SKIP_VALIDATE=1 pre-commit run --all-files`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68669daf0a908326b8156c79e2866af8