### PR TITLE
Add demo pipeline for TF2 inventory enrichment

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+import os
+
+from utils.item_enricher import ItemEnricher
+from utils.inventory_provider import InventoryProvider
+from utils.schema_provider import SchemaProvider
+
+
+def main() -> None:
+    """Demonstrate inventory enrichment for a single Steam user."""
+
+    steamid = "76561198034324614"  # hardcoded ID for testing
+
+    try:
+        schema = SchemaProvider()
+        inventory_provider = InventoryProvider(os.getenv("STEAM_API_KEY"))
+        enricher = ItemEnricher(schema)
+
+        raw_items = inventory_provider.get_inventory(steamid)
+    except Exception as exc:  # network errors, private inventory, etc.
+        print(f"Failed to fetch inventory for {steamid}: {exc}")
+        return
+
+    enriched = enricher.enrich_inventory(raw_items)
+
+    for item in enriched[:3]:
+        print(json.dumps(item, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -12,6 +12,7 @@ from .constants import (
     SPELL_BADGE_ICONS,
 )
 from .item_enricher import ItemEnricher
+from .inventory_provider import InventoryProvider
 
 __all__ = [
     "PAINT_COLORS",
@@ -26,4 +27,5 @@ __all__ = [
     "WEAPON_SPELLS",
     "SPELL_BADGE_ICONS",
     "ItemEnricher",
+    "InventoryProvider",
 ]

--- a/utils/inventory_provider.py
+++ b/utils/inventory_provider.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import os
+from typing import List
+
+import requests
+
+
+class InventoryProvider:
+    """Fetch TF2 inventories via the Steam Web API."""
+
+    API_URL = "https://api.steampowered.com/IEconItems_440/GetPlayerItems/v0001/"
+
+    def __init__(self, api_key: str | None = None) -> None:
+        self.api_key = api_key or os.getenv("STEAM_API_KEY")
+        if not self.api_key:
+            raise ValueError("STEAM_API_KEY is required")
+        self._session = requests.Session()
+
+    def get_inventory(self, steamid: str) -> List[dict]:
+        """Return the raw inventory list for ``steamid``."""
+
+        url = f"{self.API_URL}?key={self.api_key}&steamid={steamid}"
+        resp = self._session.get(url, timeout=20)
+        resp.raise_for_status()
+        result = resp.json().get("result", {})
+        if result.get("status") != 1:
+            raise RuntimeError("Inventory private or unavailable")
+        return result.get("items", [])


### PR DESCRIPTION
## Summary
- expose `InventoryProvider` in utils
- implement a simple provider for the Steam Web API
- add `main.py` example to fetch and enrich inventory items

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files utils/inventory_provider.py main.py utils/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_6866a51584ac8326b696cc13db86ac3e