### PR TITLE
Update SchemaProvider for new schema API

### DIFF
--- a/inventory_scanner.py
+++ b/inventory_scanner.py
@@ -1,6 +1,8 @@
 import os
-import requests
 import sys
+import argparse
+import requests
+from utils.schema_provider import SchemaProvider
 
 API_URL_TEMPLATE = (
     "https://api.steampowered.com/IEconItems_440/GetPlayerItems/v0001/"
@@ -24,11 +26,21 @@ def fetch_inventory(steamid: str) -> dict:
 
 
 def main(args: list[str]) -> None:
-    if not args:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--refresh-schema", action="store_true")
+    parser.add_argument("steamid", nargs="?")
+    opts = parser.parse_args(args)
+
+    if opts.refresh_schema:
+        SchemaProvider().refresh_all()
+        print("\N{CHECK MARK} Schema refreshed")
+        return
+
+    if not opts.steamid:
         print("Usage: python inventory_scanner.py <steamid>")
         sys.exit(1)
 
-    steamid = args[0]
+    steamid = opts.steamid
     data = fetch_inventory(steamid)
     items = data.get("items", [])
     print(f"Found {len(items)} items in inventory for {steamid}")

--- a/tests/test_inventory_scanner.py
+++ b/tests/test_inventory_scanner.py
@@ -26,3 +26,16 @@ def test_main_prints_item_count(monkeypatch, capsys):
     inventory_scanner.main(["123"])
     out = capsys.readouterr().out
     assert "Found 1 items in inventory for 123" in out
+
+
+def test_refresh_schema(monkeypatch, capsys):
+    called = {"refresh": False}
+    monkeypatch.setattr(
+        inventory_scanner.SchemaProvider,
+        "refresh_all",
+        lambda self: called.__setitem__("refresh", True),
+    )
+    inventory_scanner.main(["--refresh-schema"])
+    out = capsys.readouterr().out
+    assert "Schema refreshed" in out
+    assert called["refresh"]

--- a/tests/test_schema_provider.py
+++ b/tests/test_schema_provider.py
@@ -16,13 +16,14 @@ def test_schema_provider(monkeypatch, tmp_path):
     provider = sp.SchemaProvider(base_url="https://example.com", cache_dir=tmp_path)
 
     payloads = {
-        "/items": {"5021": "Key"},
+        "/raw/schema/items": {"5021": {"item_name": "Key"}},
         "/attributes": {"2025": "Killstreak Tier"},
         "/effects": {"Burning Flames": 13},
         "/paints": {"A Color Similar to Slate": 3100495},
         "/origins": {"0": "Timed Drop"},
         "/parts": {"Kills": 64},
         "/qualities": {"Normal": 0},
+        "/properties/defindexes": {"5021": "Key"},
     }
     calls = {key: 0 for key in payloads}
 
@@ -33,13 +34,15 @@ def test_schema_provider(monkeypatch, tmp_path):
 
     monkeypatch.setattr(sp.requests.Session, "get", fake_get)
 
-    assert provider.get_items() == {5021: "Key"}
+    assert provider.get_items() == {5021: {"item_name": "Key"}}
+    assert provider.get_item_by_defindex(5021) == {"item_name": "Key"}
     assert provider.get_attributes() == {2025: "Killstreak Tier"}
     assert provider.get_effects() == {13: "Burning Flames"}
     assert provider.get_paints() == {3100495: "A Color Similar to Slate"}
     assert provider.get_origins() == {0: "Timed Drop"}
     assert provider.get_parts() == {64: "Kills"}
     assert provider.get_qualities() == {0: "Normal"}
+    assert provider.get_defindexes() == {5021: "Key"}
 
     # second calls should hit cache and not increase call counts
     provider.get_items()


### PR DESCRIPTION
## Summary
- use `/raw/schema/items` endpoint and support `/properties/defindexes`
- add lookup helper `get_item_by_defindex`
- cache schema to `schema/items.json`
- log missing defindexes during lookup
- extend `inventory_scanner.py` CLI with `--refresh-schema`
- adjust tests for new behavior

## Testing
- `pre-commit run --files utils/schema_provider.py inventory_scanner.py tests/test_schema_provider.py tests/test_inventory_scanner.py` *(fails: validate-attributes)*

------
https://chatgpt.com/codex/tasks/task_e_6866cdb908d883269226aa5e2670e102