### PR TITLE
Add steamid arg to main CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,12 @@ Submit any supported SteamID format. Each user panel shows the avatar, TF2 playt
   ```bash
   python app.py --refresh
   # refresh simplified schema
-  python main.py --refresh-schema
+python main.py --refresh-schema
+```
+- Inspect a single user's inventory from the command line (defaults to a demo
+  ID if omitted):
+  ```bash
+  python main.py <steamid>
   ```
 - Use `--test` to run offline against cached data.
 - Access schema properties directly:

--- a/main.py
+++ b/main.py
@@ -17,6 +17,7 @@ def main() -> None:
 
     parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument("--refresh-schema", action="store_true")
+    parser.add_argument("steamid", nargs="?", default="76561198177872379")
     args, _ = parser.parse_known_args()
 
     if args.refresh_schema:
@@ -24,7 +25,7 @@ def main() -> None:
         print("\N{CHECK MARK} Schema refreshed")
         return
 
-    steamid = "76561198177872379"  # hardcoded ID for testing
+    steamid = args.steamid
 
     try:
         schema = SchemaProvider()

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -1,0 +1,30 @@
+import sys
+import main
+
+
+def test_main_passes_steamid_to_inventory_provider(monkeypatch):
+    called = {"id": None}
+
+    class DummyProvider:
+        def __init__(self, key):
+            pass
+
+        def get_inventory(self, steamid):
+            called["id"] = steamid
+            return []
+
+    class DummyEnricher:
+        def __init__(self, schema):
+            pass
+
+        def enrich_inventory(self, items):
+            return []
+
+    monkeypatch.setenv("STEAM_API_KEY", "x")
+    monkeypatch.setattr(main, "InventoryProvider", DummyProvider)
+    monkeypatch.setattr(main, "ItemEnricher", DummyEnricher)
+    monkeypatch.setattr(main, "SchemaProvider", lambda: None)
+
+    monkeypatch.setattr(sys, "argv", ["main.py", "123"])
+    main.main()
+    assert called["id"] == "123"


### PR DESCRIPTION
## Summary
- add optional positional argument to `main.py`
- update documentation for new CLI usage
- unit test verifying `steamid` argument is passed to `InventoryProvider`

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files main.py tests/test_main_cli.py README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866d4eca9508326be200ceb0dbfb11e