### PR TITLE
Refactor enrichment to use live schema

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ def main() -> None:
 
     parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument("--refresh-schema", action="store_true")
-    parser.add_argument("steamid", nargs="?", default="76561198177872379")
+    parser.add_argument("steamid", nargs="?")
     args, _ = parser.parse_known_args()
 
     if args.refresh_schema:
@@ -25,17 +25,36 @@ def main() -> None:
         print("\N{CHECK MARK} Schema refreshed")
         return
 
+    schema = SchemaProvider()
+    enricher = ItemEnricher(schema)
+
+    raw_items = None
     steamid = args.steamid
+    if not steamid:
+        if input("Load cached inventory? [y/N] ").strip().lower().startswith("y"):
+            path = input("Path to JSON file: ").strip()
+            try:
+                with open(path) as f:
+                    raw_items = json.load(f)
+            except Exception as exc:
+                print(f"Failed to load {path}: {exc}")
+                return
+        else:
+            steamid = input("Steam64 ID: ").strip()
 
-    try:
-        schema = SchemaProvider()
-        inventory_provider = InventoryProvider(os.getenv("STEAM_API_KEY"))
-        enricher = ItemEnricher(schema)
+    if raw_items is None:
+        try:
+            inventory_provider = InventoryProvider(os.getenv("STEAM_API_KEY"))
+            raw_items = inventory_provider.get_inventory(steamid)
+        except Exception as exc:  # network errors, private inventory, etc.
+            print(f"Failed to fetch inventory for {steamid}: {exc}")
+            return
+        if input("Cache inventory? [y/N] ").strip().lower().startswith("y"):
+            from pathlib import Path
 
-        raw_items = inventory_provider.get_inventory(steamid)
-    except Exception as exc:  # network errors, private inventory, etc.
-        print(f"Failed to fetch inventory for {steamid}: {exc}")
-        return
+            cache_dir = Path("cached_inventories")
+            cache_dir.mkdir(exist_ok=True)
+            (cache_dir / f"{steamid}.json").write_text(json.dumps(raw_items))
 
     enriched = enricher.enrich_inventory(raw_items)
 

--- a/tests/test_item_enricher.py
+++ b/tests/test_item_enricher.py
@@ -6,12 +6,22 @@ def test_enrich_inventory(monkeypatch):
     provider = SchemaProvider(base_url="https://example.com")
 
     monkeypatch.setattr(provider, "get_defindexes", lambda: {100: "Rocket"})
-    monkeypatch.setattr(provider, "get_qualities", lambda: {6: "Unique"})
-    monkeypatch.setattr(provider, "get_paints", lambda: {1: "Team Spirit"})
-    monkeypatch.setattr(provider, "get_killstreaks", lambda: {2: "Specialized"})
+    monkeypatch.setattr(provider, "get_qualities", lambda: {"Unique": 6})
+    monkeypatch.setattr(provider, "get_paints", lambda: {"Team Spirit": 1})
+    monkeypatch.setattr(
+        provider,
+        "get_attributes",
+        lambda: {
+            142: {"defindex": 142, "class": "set_item_tint_rgb"},
+            2025: {"defindex": 2025, "name": "killstreak tier"},
+            2013: {"defindex": 2013, "name": "killstreak sheen"},
+            2014: {"defindex": 2014, "name": "killstreak effect"},
+            134: {"defindex": 134, "class": "set_attached_particle"},
+            5000: {"defindex": 5000},
+        },
+    )
     monkeypatch.setattr(provider, "get_effects", lambda: {55: "Hot"})
-    monkeypatch.setattr(provider, "get_paintkits", lambda: {3: "Warhawk"})
-    monkeypatch.setattr(provider, "get_strangeParts", lambda: {"5000": "Kills"})
+    monkeypatch.setattr(provider, "get_strange_parts", lambda: {5000: "Kills"})
 
     enricher = ItemEnricher(provider)
 
@@ -39,9 +49,8 @@ def test_enrich_inventory(monkeypatch):
     assert item["name"] == "Rocket"
     assert item["quality"] == "Unique"
     assert item["paint"] == "Team Spirit"
-    assert item["killstreak_tier"] == "Specialized"
+    assert item["killstreak_tier"] == "Specialized Killstreak"
     assert item["sheen"] == "Hot"
     assert item["killstreaker"] == "Hot"
     assert item["unusual_effect"] == "Hot"
-    assert item["paintkit"] == "Warhawk"
     assert item["strange_parts"] == ["Kills"]

--- a/tests/test_schema_provider.py
+++ b/tests/test_schema_provider.py
@@ -17,11 +17,11 @@ def test_schema_provider(monkeypatch, tmp_path):
 
     payloads = {
         "/raw/schema/items": {"5021": {"item_name": "Key"}},
-        "/attributes": {"2025": "Killstreak Tier"},
-        "/effects": {"Burning Flames": 13},
+        "/attributes": {"2025": {"name": "Killstreak Tier"}},
+        "/effects": {"Burning Flames": {"id": 13, "name": "Burning Flames"}},
         "/paints": {"A Color Similar to Slate": 3100495},
         "/origins": {"0": "Timed Drop"},
-        "/parts": {"Kills": 64},
+        "/parts": {"Kills": {"id": 64, "name": "Kills"}},
         "/qualities": {"Normal": 0},
         "/properties/defindexes": {"5021": "Key"},
     }
@@ -36,12 +36,12 @@ def test_schema_provider(monkeypatch, tmp_path):
 
     assert provider.get_items() == {5021: {"item_name": "Key"}}
     assert provider.get_item_by_defindex(5021) == {"item_name": "Key"}
-    assert provider.get_attributes() == {2025: "Killstreak Tier"}
-    assert provider.get_effects() == {13: "Burning Flames"}
-    assert provider.get_paints() == {3100495: "A Color Similar to Slate"}
+    assert provider.get_attributes() == {2025: {"name": "Killstreak Tier"}}
+    assert provider.get_effects() == {13: {"id": 13, "name": "Burning Flames"}}
+    assert provider.get_paints() == {"A Color Similar to Slate": 3100495}
     assert provider.get_origins() == {0: "Timed Drop"}
-    assert provider.get_parts() == {64: "Kills"}
-    assert provider.get_qualities() == {0: "Normal"}
+    assert provider.get_parts() == {64: {"id": 64, "name": "Kills"}}
+    assert provider.get_qualities() == {"Normal": 0}
     assert provider.get_defindexes() == {5021: "Key"}
 
     # second calls should hit cache and not increase call counts
@@ -77,9 +77,11 @@ def test_schema_provider_list_payload(monkeypatch, tmp_path):
     monkeypatch.setattr(sp.requests.Session, "get", fake_get)
 
     assert provider.get_items() == {5021: {"defindex": 5021, "item_name": "Key"}}
-    assert provider.get_attributes() == {2025: "Killstreak Tier"}
-    assert provider.get_effects() == {13: "Burning Flames"}
-    assert provider.get_paints() == {3100495: "A Color Similar to Slate"}
+    assert provider.get_attributes() == {
+        2025: {"defindex": 2025, "name": "Killstreak Tier"}
+    }
+    assert provider.get_effects() == {13: {"id": 13, "name": "Burning Flames"}}
+    assert provider.get_paints() == {"A Color Similar to Slate": 3100495}
     assert provider.get_origins() == {0: "Timed Drop"}
-    assert provider.get_parts() == {64: "Kills"}
-    assert provider.get_qualities() == {0: "Normal"}
+    assert provider.get_parts() == {64: {"id": 64, "name": "Kills"}}
+    assert provider.get_qualities() == {"Normal": 0}


### PR DESCRIPTION
## Summary
- support interactive cached inventory in `main.py`
- expand `SchemaProvider` with `_unwrap_and_index` helper and simpler data maps
- refactor `ItemEnricher` to use schema-driven attributes
- update schema and enricher unit tests

## Testing
- `ruff check utils/item_enricher.py utils/schema_provider.py tests/test_item_enricher.py tests/test_schema_provider.py main.py`
- `pre-commit run --files utils/item_enricher.py utils/schema_provider.py main.py tests/test_item_enricher.py tests/test_schema_provider.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6866fddd20448326ae669361e31a70ac