### PR TITLE
Fix missing method in SchemaProvider and ItemEnricher initialization

### DIFF
--- a/utils/item_enricher.py
+++ b/utils/item_enricher.py
@@ -20,12 +20,12 @@ class ItemEnricher:
 
     def __init__(self, provider: SchemaProvider | None = None) -> None:
         self.provider = provider or SchemaProvider()
-        self.items = self.provider.get_items()
         self.attrs = self.provider.get_attributes()
         self.effects = self.provider.get_effects()
         self.parts = self.provider.get_strange_parts()
         self.paints_val = {v: k for k, v in self.provider.get_paints().items()}
         self.qualities_map = {v: k for k, v in self.provider.get_qualities().items()}
+        self._spell_effect_ids: set[int] | None = None
         self._logger = logging.getLogger(__name__)
 
     # ------------------------------------------------------------------
@@ -114,7 +114,7 @@ class ItemEnricher:
         """Return list of item dicts enriched with schema data."""
 
         defindexes = self.provider.get_defindexes()
-        qualities = self.provider.get_qualities()
+        qualities = self.qualities_map
 
         enriched: List[Dict[str, Any]] = []
         for item in raw_items:

--- a/utils/schema_provider.py
+++ b/utils/schema_provider.py
@@ -199,6 +199,10 @@ class SchemaProvider:
     def get_strangeParts(self, *, force: bool = False) -> Dict[int, Any]:
         return self.get_parts(force=force)
 
+    def get_strange_parts(self, *, force: bool = False) -> Dict[int, Any]:
+        """Alias for :meth:`get_parts`."""
+        return self.get_parts(force=force)
+
     def get_item_by_defindex(self, defindex: int) -> Dict[str, Any] | None:
         items = self.get_items()
         item = items.get(defindex)


### PR DESCRIPTION
## Summary
- add missing `get_strange_parts` alias in `SchemaProvider`
- initialise `_spell_effect_ids` in `ItemEnricher`
- avoid unneeded schema fetches in `ItemEnricher`
- use cached quality mapping

## Testing
- `pre-commit run black --files utils/item_enricher.py utils/schema_provider.py`
- `pre-commit run ruff --files utils/item_enricher.py utils/schema_provider.py`
- `SKIP_VALIDATE=1 pre-commit run validate-attributes --files utils/item_enricher.py utils/schema_provider.py`
- `pre-commit run pytest --files utils/item_enricher.py utils/schema_provider.py` *(fails: KeyError in schema provider tests)*

------
https://chatgpt.com/codex/tasks/task_e_6867083914708326bfa9384354195557