### PR TITLE
Refactor enrichment pipeline to rely on live schema

### DIFF
--- a/main.py
+++ b/main.py
@@ -49,7 +49,9 @@ def main() -> None:
         except Exception as exc:  # network errors, private inventory, etc.
             print(f"Failed to fetch inventory for {steamid}: {exc}")
             return
-        if input("Cache inventory? [y/N] ").strip().lower().startswith("y"):
+        if not args.steamid and input(
+            "Cache inventory? [y/N] "
+        ).strip().lower().startswith("y"):
             from pathlib import Path
 
             cache_dir = Path("cached_inventories")

--- a/tests/test_item_enricher.py
+++ b/tests/test_item_enricher.py
@@ -5,7 +5,9 @@ from utils.schema_provider import SchemaProvider
 def test_enrich_inventory(monkeypatch):
     provider = SchemaProvider(base_url="https://example.com")
 
-    monkeypatch.setattr(provider, "get_defindexes", lambda: {100: "Rocket"})
+    monkeypatch.setattr(
+        provider, "get_items", lambda: {100: {"defindex": 100, "item_name": "Rocket"}}
+    )
     monkeypatch.setattr(provider, "get_qualities", lambda: {"Unique": 6})
     monkeypatch.setattr(provider, "get_paints", lambda: {"Team Spirit": 1})
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- update `SchemaProvider` endpoints and utilities to parse schema lists and dictionaries
- rework `ItemEnricher` to use live schema lookups only
- adjust CLI caching prompt to skip when SteamID argument is given
- update tests to patch new `get_items` method

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files utils/schema_provider.py utils/item_enricher.py tests/test_item_enricher.py main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68670a76e66c83269f68f4b497d63a1e