### PR TITLE
Ensure schema attributes loaded in main

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ from dotenv import load_dotenv
 from utils.item_enricher import ItemEnricher
 from utils.inventory_provider import InventoryProvider
 from utils.schema_provider import SchemaProvider
+from utils import local_data
 
 load_dotenv()
 
@@ -24,6 +25,8 @@ def main() -> None:
         SchemaProvider().refresh_all()
         print("\N{CHECK MARK} Schema refreshed")
         return
+
+    local_data.load_files()
 
     schema = SchemaProvider()
     enricher = ItemEnricher(schema)


### PR DESCRIPTION
## Summary
- import `local_data` and load schema attributes before creating the enricher

## Testing
- `pre-commit run --files main.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68671fd351c483269681cf0d2b8120ac