### PR TITLE
Use schema.autobot.tf cache

### DIFF
--- a/scripts/validate_attributes.py
+++ b/scripts/validate_attributes.py
@@ -29,17 +29,17 @@ def main() -> int:
         print("Schema validation skipped.")
         return 0
     try:
-        _, items_game = local_data.load_files()
+        attributes, _ = local_data.load_files()
     except Exception as exc:  # pragma: no cover - filesystem issues
         print(f"\N{CROSS MARK} Failed to load schema: {exc}")
         return 0 if os.getenv("SKIP_VALIDATE") else 1
+    if not attributes:
+        print("Schema not found; skipping validation.")
+        return 0
 
-    attributes = (
-        items_game.get("attributes", {}) if isinstance(items_game, dict) else {}
-    )
     all_ok = True
     for attr_id, label in REQUIRED_ATTRS.items():
-        if str(attr_id) in attributes:
+        if attr_id in attributes:
             print(f"\N{CHECK MARK} {attr_id} {label}")
         else:
             print(f"\N{CROSS MARK} {attr_id} {label}")

--- a/tests/test_app_import.py
+++ b/tests/test_app_import.py
@@ -17,9 +17,9 @@ def test_app_uses_mock_schema(monkeypatch):
     def fake_load():
         from utils import local_data as ld
 
-        ld.TF2_SCHEMA = {"1": {"name": "A"}}
-        ld.ITEMS_GAME_CLEANED = {"1": {"name": "B"}}
-        return ld.TF2_SCHEMA, ld.ITEMS_GAME_CLEANED
+        ld.SCHEMA_ATTRIBUTES = {1: {"name": "Attr"}}
+        ld.ITEMS_BY_DEFINDEX = {1: {"name": "B"}}
+        return ld.SCHEMA_ATTRIBUTES, ld.ITEMS_BY_DEFINDEX
 
     monkeypatch.setattr("utils.local_data.load_files", fake_load)
     monkeypatch.setenv("STEAM_API_KEY", "x")

--- a/tests/test_local_data.py
+++ b/tests/test_local_data.py
@@ -5,25 +5,37 @@ from utils import local_data as ld
 
 
 def test_load_files_success(tmp_path, monkeypatch, capsys):
-    schema_file = tmp_path / "tf2_schema.json"
-    items_file = tmp_path / "items_game_cleaned.json"
-    schema_file.write_text(json.dumps({"items": {"1": {"name": "One"}}}))
-    items_file.write_text(json.dumps({"1": {"name": "A"}}))
-    monkeypatch.setattr(ld, "SCHEMA_FILE", schema_file)
-    monkeypatch.setattr(ld, "ITEMS_GAME_FILE", items_file)
-    ld.TF2_SCHEMA = {}
-    ld.ITEMS_GAME_CLEANED = {}
+    attr_file = tmp_path / "attributes.json"
+    particles_file = tmp_path / "particles.json"
+    items_file = tmp_path / "items.json"
+    qual_file = tmp_path / "qualities.json"
+
+    attr_file.write_text(json.dumps([{"defindex": 1, "name": "Attr"}]))
+    particles_file.write_text(json.dumps([{"id": 1, "name": "P"}]))
+    items_file.write_text(json.dumps([{"defindex": 1, "name": "One"}]))
+    qual_file.write_text(json.dumps({"1": "Unique"}))
+
+    monkeypatch.setattr(ld, "ATTRIBUTES_FILE", attr_file)
+    monkeypatch.setattr(ld, "PARTICLES_FILE", particles_file)
+    monkeypatch.setattr(ld, "ITEMS_FILE", items_file)
+    monkeypatch.setattr(ld, "QUALITIES_FILE", qual_file)
+
+    ld.SCHEMA_ATTRIBUTES = {}
+    ld.ITEMS_BY_DEFINDEX = {}
+    ld.PARTICLE_NAMES = {}
+    ld.QUALITIES_BY_INDEX = {}
     ld.EFFECT_NAMES = {}
+
     ld.load_files()
     out = capsys.readouterr().out
-    assert ld.TF2_SCHEMA["1"]["name"] == "One"
-    assert f"Loaded 1 items from {schema_file}" in out
-    assert "tf2_schema.json may be stale" in out
+    assert ld.SCHEMA_ATTRIBUTES[1]["name"] == "Attr"
+    assert ld.ITEMS_BY_DEFINDEX[1]["name"] == "One"
+    assert "Loaded 1 attributes" in out
 
 
 def test_load_files_missing(tmp_path, monkeypatch):
-    monkeypatch.setattr(ld, "SCHEMA_FILE", tmp_path / "missing.json")
-    monkeypatch.setattr(ld, "ITEMS_GAME_FILE", tmp_path / "missing2.json")
+    monkeypatch.setattr(ld, "ATTRIBUTES_FILE", tmp_path / "missing.json")
+    monkeypatch.setattr(ld, "ITEMS_FILE", tmp_path / "missing2.json")
     with pytest.raises(RuntimeError):
         ld.load_files()
 

--- a/utils/items_game_cache.py
+++ b/utils/items_game_cache.py
@@ -5,7 +5,7 @@ import time
 from pathlib import Path
 from typing import Any, Dict
 
-from utils.local_data import DEFAULT_ITEMS_GAME_FILE, clean_items_game
+from utils.local_data import clean_items_game
 
 import requests
 import vdf
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 RAW_FILE = Path("cache/items_game.txt")
 JSON_FILE = Path("cache/items_game.json")
-CLEANED_FILE = DEFAULT_ITEMS_GAME_FILE
+CLEANED_FILE = Path("cache/items_game_cleaned.json")
 TTL = 48 * 60 * 60  # 48 hours
 
 ITEMS_GAME: Dict[str, Any] | None = None

--- a/utils/local_data.py
+++ b/utils/local_data.py
@@ -5,8 +5,15 @@ from typing import Any, Dict, Tuple
 
 import vdf
 
+# Legacy globals kept for backward compatibility
 TF2_SCHEMA: Dict[str, Any] = {}
 ITEMS_GAME_CLEANED: Dict[str, Any] = {}
+
+# New schema maps sourced from schema.autobot.tf
+SCHEMA_ATTRIBUTES: Dict[int, Dict[str, Any]] = {}
+ITEMS_BY_DEFINDEX: Dict[int, Dict[str, Any]] = {}
+QUALITIES_BY_INDEX: Dict[int, str] = {}
+PARTICLE_NAMES: Dict[int, str] = {}
 EFFECT_NAMES: Dict[str, str] = {}
 PAINT_NAMES: Dict[str, str] = {}
 WEAR_NAMES: Dict[str, str] = {}
@@ -28,10 +35,16 @@ KILLSTREAK_EFFECT_NAMES: Dict[str, str] = {
 }
 
 BASE_DIR = Path(__file__).resolve().parent.parent
-DEFAULT_SCHEMA_FILE = BASE_DIR / "cache" / "tf2_schema.json"
-DEFAULT_ITEMS_GAME_FILE = BASE_DIR / "cache" / "items_game_cleaned.json"
-SCHEMA_FILE = Path(os.getenv("TF2_SCHEMA_FILE", DEFAULT_SCHEMA_FILE))
-ITEMS_GAME_FILE = Path(os.getenv("TF2_ITEMS_GAME_FILE", DEFAULT_ITEMS_GAME_FILE))
+# schema.autobot.tf cache files
+DEFAULT_ATTRIBUTES_FILE = BASE_DIR / "cache" / "schema" / "attributes.json"
+DEFAULT_PARTICLES_FILE = BASE_DIR / "cache" / "schema" / "particles.json"
+DEFAULT_ITEMS_FILE = BASE_DIR / "cache" / "schema" / "items.json"
+DEFAULT_QUALITIES_FILE = BASE_DIR / "cache" / "schema" / "qualities.json"
+
+ATTRIBUTES_FILE = Path(os.getenv("TF2_ATTRIBUTES_FILE", DEFAULT_ATTRIBUTES_FILE))
+PARTICLES_FILE = Path(os.getenv("TF2_PARTICLES_FILE", DEFAULT_PARTICLES_FILE))
+ITEMS_FILE = Path(os.getenv("TF2_ITEMS_FILE", DEFAULT_ITEMS_FILE))
+QUALITIES_FILE = Path(os.getenv("TF2_QUALITIES_FILE", DEFAULT_QUALITIES_FILE))
 DEFAULT_EFFECT_FILE = BASE_DIR / "cache" / "effect_names.json"
 DEFAULT_PAINT_FILE = BASE_DIR / "cache" / "paint_names.json"
 DEFAULT_WEAR_FILE = BASE_DIR / "cache" / "wear_names.json"
@@ -84,59 +97,88 @@ def _load_json_map(path: Path) -> Dict[str, str]:
     return {}
 
 
-def load_files(*, auto_refetch: bool = False) -> Tuple[Dict[str, Any], Dict[str, Any]]:
-    """Load local schema files and populate globals."""
+def load_files(*, auto_refetch: bool = False) -> Tuple[Dict[int, Any], Dict[int, Any]]:
+    """Load local schema files from the schema.autobot.tf cache."""
 
-    global TF2_SCHEMA, ITEMS_GAME_CLEANED, EFFECT_NAMES, PAINT_NAMES, WEAR_NAMES, KILLSTREAK_NAMES, STRANGE_PART_NAMES, PAINTKIT_NAMES, CRATE_SERIES_NAMES
+    global SCHEMA_ATTRIBUTES, ITEMS_BY_DEFINDEX, QUALITIES_BY_INDEX, PARTICLE_NAMES
+    global EFFECT_NAMES, PAINT_NAMES, WEAR_NAMES, KILLSTREAK_NAMES, STRANGE_PART_NAMES, PAINTKIT_NAMES, CRATE_SERIES_NAMES
 
-    schema_path = SCHEMA_FILE.resolve()
-    if not schema_path.exists():
-        raise RuntimeError(f"Missing {schema_path}")
-    with schema_path.open() as f:
+    attr_path = ATTRIBUTES_FILE.resolve()
+    if not attr_path.exists():
+        raise RuntimeError(f"Missing {attr_path}")
+    with attr_path.open() as f:
         data = json.load(f)
+    raw_attrs = data["value"] if isinstance(data, dict) and "value" in data else data
+    mapping: Dict[int, Any] = {}
+    if isinstance(raw_attrs, list):
+        for entry in raw_attrs:
+            if not isinstance(entry, dict) or "defindex" not in entry:
+                continue
+            try:
+                idx = int(entry["defindex"])
+            except (TypeError, ValueError):
+                continue
+            mapping[idx] = entry
+    elif isinstance(raw_attrs, dict):
+        mapping = {int(k): v for k, v in raw_attrs.items() if str(k).isdigit()}
+    SCHEMA_ATTRIBUTES = mapping
+    print(f"\N{CHECK MARK} Loaded {len(SCHEMA_ATTRIBUTES)} attributes from {attr_path}")
 
-    items = data.get("items") or data
-    if not isinstance(items, dict) or not items:
-        raise RuntimeError("tf2_schema.json is empty or invalid")
-
-    if len(items) < 5000 and auto_refetch:
-        try:
-            from . import schema_fetcher
-
-            api_key = os.getenv("STEAM_API_KEY")
-            if not api_key:
-                raise RuntimeError("STEAM_API_KEY is required for refetch")
-            fetched = schema_fetcher._fetch_schema(api_key)
-            schema_path.write_text(json.dumps(fetched))
-            data = fetched
-            items = fetched.get("items") or fetched
-            print(f"Refetched TF2 schema: {len(items)} items -> {schema_path}")
-        except Exception as exc:  # pragma: no cover - network failure
-            print(f"Failed to refetch schema: {exc}")
-
-    TF2_SCHEMA = items
-    EFFECT_NAMES = data.get("effects", {}) if isinstance(data, dict) else {}
-    print(f"\N{CHECK MARK} Loaded {len(TF2_SCHEMA)} items from {schema_path}")
-    if len(TF2_SCHEMA) < 5000:
+    items_path = ITEMS_FILE.resolve()
+    if not items_path.exists():
+        raise RuntimeError(f"Missing {items_path}")
+    with items_path.open() as f:
+        data = json.load(f)
+    raw_items = data["value"] if isinstance(data, dict) and "value" in data else data
+    items_map: Dict[int, Any] = {}
+    if isinstance(raw_items, list):
+        for entry in raw_items:
+            if not isinstance(entry, dict) or "defindex" not in entry:
+                continue
+            try:
+                idx = int(entry["defindex"])
+            except (TypeError, ValueError):
+                continue
+            items_map[idx] = entry
+    elif isinstance(raw_items, dict):
+        items_map = {int(k): v for k, v in raw_items.items() if str(k).isdigit()}
+    ITEMS_BY_DEFINDEX = items_map
+    print(f"\N{CHECK MARK} Loaded {len(ITEMS_BY_DEFINDEX)} items from {items_path}")
+    if len(ITEMS_BY_DEFINDEX) < 5000:
         print(
-            "\N{WARNING SIGN} tf2_schema.json may be stale or incomplete. "
-            "Consider forcing a refetch."
+            "\N{WARNING SIGN} items.json may be stale or incomplete. Consider a refresh."
         )
 
-    items_game_path = ITEMS_GAME_FILE.resolve()
-    if not items_game_path.exists():
-        raise RuntimeError(f"Missing {items_game_path}")
-    with items_game_path.open() as f:
-        ITEMS_GAME_CLEANED = json.load(f)
-    if not isinstance(ITEMS_GAME_CLEANED, dict) or not ITEMS_GAME_CLEANED:
-        raise RuntimeError("items_game_cleaned.json is empty or invalid")
-    print(
-        f"\N{CHECK MARK} Cleaned items_game has {len(ITEMS_GAME_CLEANED)} entries from {items_game_path}"
-    )
-    if len(ITEMS_GAME_CLEANED) < 10000:
-        print(
-            "\N{WARNING SIGN} items_game_cleaned.json may be stale or incomplete. Consider a refresh."
-        )
+    qual_path = QUALITIES_FILE.resolve()
+    if not qual_path.exists():
+        raise RuntimeError(f"Missing {qual_path}")
+    with qual_path.open() as f:
+        data = json.load(f)
+    raw_quals = data["value"] if isinstance(data, dict) and "value" in data else data
+    if isinstance(raw_quals, list):
+        QUALITIES_BY_INDEX = {
+            int(e["id"]): str(e["name"])
+            for e in raw_quals
+            if isinstance(e, dict) and "id" in e and "name" in e
+        }
+    else:
+        QUALITIES_BY_INDEX = {
+            int(k): str(v) for k, v in raw_quals.items() if str(k).isdigit()
+        }
+    print(f"\N{CHECK MARK} Loaded {len(QUALITIES_BY_INDEX)} qualities from {qual_path}")
+
+    particle_path = PARTICLES_FILE.resolve()
+    if not particle_path.exists():
+        raise RuntimeError(f"Missing {particle_path}")
+    with particle_path.open() as f:
+        data = json.load(f)
+    raw_parts = data["value"] if isinstance(data, dict) and "value" in data else data
+    PARTICLE_NAMES = {
+        int(e.get("id")): str(e.get("name"))
+        for e in raw_parts
+        if isinstance(e, dict) and "id" in e and "name" in e
+    }
+    print(f"\N{CHECK MARK} Loaded {len(PARTICLE_NAMES)} particles from {particle_path}")
 
     EFFECT_NAMES = _load_json_map(EFFECT_FILE)
     PAINT_NAMES = _load_json_map(PAINT_FILE)
@@ -159,4 +201,4 @@ def load_files(*, auto_refetch: bool = False) -> Tuple[Dict[str, Any], Dict[str,
     ]:
         if mapping:
             print(f"\N{CHECK MARK} Loaded {len(mapping)} {label} from {path}")
-    return TF2_SCHEMA, ITEMS_GAME_CLEANED
+    return SCHEMA_ATTRIBUTES, ITEMS_BY_DEFINDEX


### PR DESCRIPTION
## Summary
- remove old tf2_schema and items_game file logic
- load attributes, items, particles and qualities from schema.autobot.tf cache
- relax schema validation when cache files are missing
- adjust utilities and tests for new schema maps

## Testing
- `pre-commit run --files utils/local_data.py utils/items_game_cache.py scripts/validate_attributes.py tests/test_local_data.py tests/test_app_import.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68672484ee688326832732ffe61ce9c9