### PR TITLE
Use SchemaProvider when refreshing app schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,9 @@ Submit any supported SteamID format. Each user panel shows the avatar, TF2 playt
 - Item schema is cached automatically via `SchemaProvider` in
   `utils/schema_provider.py`. Pass `base_url` to use a mirror. Update it with:
   ```bash
-  python app.py --refresh
-  # refresh simplified schema
-python main.py --refresh-schema
-```
+  python app.py --refresh  # fetch latest schema files
+  python main.py --refresh-schema
+  ```
 - Inspect a single user's inventory from the command line (defaults to a demo
   ID if omitted):
   ```bash

--- a/app.py
+++ b/app.py
@@ -30,13 +30,15 @@ parser.add_argument("--test", action="store_true")
 ARGS, _ = parser.parse_known_args()
 
 if ARGS.refresh:
-    from utils import schema_fetcher, items_game_cache
+    from utils import items_game_cache
+    from utils.schema_provider import SchemaProvider
 
     print(
         "\N{ANTICLOCKWISE OPEN CIRCLE ARROW} Refresh requested: refetching TF2 schema and items_game..."
     )
-    schema = schema_fetcher.refresh_schema()
-    print(f"\N{CHECK MARK} Fetched {len(schema)} schema items")
+    provider = SchemaProvider(cache_dir="cache/schema")
+    provider.refresh_all()
+    print("\N{CHECK MARK} Schema files updated")
 
     cleaned = items_game_cache.load_items_game_cleaned(force_rebuild=True)
     print(f"\N{CHECK MARK} Saved {len(cleaned)} cleaned item definitions")

--- a/tests/test_app_refresh.py
+++ b/tests/test_app_refresh.py
@@ -13,8 +13,8 @@ def test_refresh_flag_triggers_update(monkeypatch):
         "pathlib.Path.mkdir", lambda self, parents=True, exist_ok=True: None
     )
     monkeypatch.setattr(
-        "utils.schema_fetcher.refresh_schema",
-        lambda: called.__setitem__("schema", True) or {"1": {}},
+        "utils.schema_provider.SchemaProvider.refresh_all",
+        lambda self: called.__setitem__("schema", True),
     )
     monkeypatch.setattr(
         "utils.items_game_cache.load_items_game_cleaned",


### PR DESCRIPTION
## Summary
- use `SchemaProvider` to refresh schema files when running `python app.py --refresh`
- update refresh instructions in README
- adjust unit test to patch `SchemaProvider.refresh_all`

## Testing
- `pre-commit run --files app.py tests/test_app_refresh.py README.md` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pytest -k test_app_refresh -q` *(fails: pytest: error: unrecognized arguments: --cov)*

------
https://chatgpt.com/codex/tasks/task_e_68672bc19ed48326a00c428e94b79d52