### PR TITLE
Add auto schema refetch

### DIFF
--- a/tests/test_local_data.py
+++ b/tests/test_local_data.py
@@ -40,6 +40,43 @@ def test_load_files_missing(tmp_path, monkeypatch):
         ld.load_files()
 
 
+def test_load_files_auto_refetch(tmp_path, monkeypatch, capsys):
+    attr_file = tmp_path / "attributes.json"
+    items_file = tmp_path / "items.json"
+    particles_file = tmp_path / "particles.json"
+    qual_file = tmp_path / "qualities.json"
+
+    monkeypatch.setattr(ld, "ATTRIBUTES_FILE", attr_file)
+    monkeypatch.setattr(ld, "PARTICLES_FILE", particles_file)
+    monkeypatch.setattr(ld, "ITEMS_FILE", items_file)
+    monkeypatch.setattr(ld, "QUALITIES_FILE", qual_file)
+
+    payloads = {
+        "attributes": [{"defindex": 1, "name": "Attr"}],
+        "items": [{"defindex": 1, "name": "One"}],
+        "particles": [{"id": 1, "name": "P"}],
+        "qualities": {"1": "Unique"},
+    }
+
+    def fake_fetch(self, endpoint):
+        for key, ep in ld.SchemaProvider.ENDPOINTS.items():
+            if endpoint == ep:
+                return payloads[key]
+        raise KeyError(endpoint)
+
+    monkeypatch.setattr(ld.SchemaProvider, "_fetch", fake_fetch)
+
+    ld.SCHEMA_ATTRIBUTES = {}
+    ld.ITEMS_BY_DEFINDEX = {}
+    ld.PARTICLE_NAMES = {}
+    ld.QUALITIES_BY_INDEX = {}
+
+    ld.load_files(auto_refetch=True)
+    out = capsys.readouterr().out
+    assert "Downloaded" in out
+    assert ld.SCHEMA_ATTRIBUTES[1]["name"] == "Attr"
+
+
 def test_clean_items_game_parses_all():
     sample = {
         "items_game": {


### PR DESCRIPTION
## Summary
- auto-download missing schema cache files in `local_data.load_files`
- print downloaded files when fallback happens
- cover refetch case in tests

## Testing
- `pre-commit run --files utils/local_data.py tests/test_local_data.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68673b06e24c832682020fbfc0f2e23b