### PR TITLE
Add verbose refresh flag

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,6 +24,7 @@ if not os.getenv("STEAM_API_KEY"):
 
 parser = argparse.ArgumentParser(add_help=False)
 parser.add_argument("--refresh", action="store_true")
+parser.add_argument("--verbose", action="store_true")
 parser.add_argument("--test", action="store_true")
 ARGS, _ = parser.parse_known_args()
 
@@ -34,7 +35,7 @@ if ARGS.refresh:
         "\N{ANTICLOCKWISE OPEN CIRCLE ARROW} Refresh requested: refetching TF2 schema..."
     )
     provider = SchemaProvider(cache_dir="cache/schema")
-    provider.refresh_all()
+    provider.refresh_all(verbose=ARGS.verbose)
     print(
         "\N{CHECK MARK} Refresh complete. Restart app normally without --refresh to start server."
     )

--- a/inventory_scanner.py
+++ b/inventory_scanner.py
@@ -28,11 +28,12 @@ def fetch_inventory(steamid: str) -> dict:
 def main(args: list[str]) -> None:
     parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument("--refresh", action="store_true")
+    parser.add_argument("--verbose", action="store_true")
     parser.add_argument("steamid", nargs="?")
     opts = parser.parse_args(args)
 
     if opts.refresh:
-        SchemaProvider().refresh_all()
+        SchemaProvider().refresh_all(verbose=opts.verbose)
         print("\N{CHECK MARK} Schema refreshed")
         return
 

--- a/main.py
+++ b/main.py
@@ -18,11 +18,12 @@ def main() -> None:
 
     parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument("--refresh", action="store_true")
+    parser.add_argument("--verbose", action="store_true")
     parser.add_argument("steamid", nargs="?")
     args, _ = parser.parse_known_args()
 
     if args.refresh:
-        SchemaProvider().refresh_all()
+        SchemaProvider().refresh_all(verbose=args.verbose)
         print("\N{CHECK MARK} Schema refreshed")
         return
 

--- a/tests/test_app_refresh.py
+++ b/tests/test_app_refresh.py
@@ -4,20 +4,27 @@ import sys
 import pytest
 
 
-def test_refresh_flag_triggers_update(monkeypatch):
-    called = {"schema": False}
+def test_refresh_flag_triggers_update(monkeypatch, capsys):
+    called = {"schema": None}
 
     monkeypatch.setenv("STEAM_API_KEY", "x")
     monkeypatch.setattr("pathlib.Path.write_text", lambda self, text: None)
     monkeypatch.setattr(
         "pathlib.Path.mkdir", lambda self, parents=True, exist_ok=True: None
     )
+
+    def fake_refresh(self, verbose: bool = False):
+        called["schema"] = verbose
+        if verbose:
+            print("cache/schema/items.json - 0 entries")
+
     monkeypatch.setattr(
-        "utils.schema_provider.SchemaProvider.refresh_all",
-        lambda self: called.__setitem__("schema", True),
+        "utils.schema_provider.SchemaProvider.refresh_all", fake_refresh
     )
-    monkeypatch.setattr(sys, "argv", ["app.py", "--refresh"])
+    monkeypatch.setattr(sys, "argv", ["app.py", "--refresh", "--verbose"])
     sys.modules.pop("app", None)
     with pytest.raises(SystemExit):
         importlib.import_module("app")
-    assert called["schema"]
+    out = capsys.readouterr().out
+    assert "cache/schema/items.json - 0 entries" in out
+    assert called["schema"] is True

--- a/tests/test_inventory_scanner.py
+++ b/tests/test_inventory_scanner.py
@@ -29,13 +29,16 @@ def test_main_prints_item_count(monkeypatch, capsys):
 
 
 def test_refresh_schema(monkeypatch, capsys):
-    called = {"refresh": False}
-    monkeypatch.setattr(
-        inventory_scanner.SchemaProvider,
-        "refresh_all",
-        lambda self: called.__setitem__("refresh", True),
-    )
-    inventory_scanner.main(["--refresh"])
+    called = {"refresh": None}
+
+    def fake_refresh(self, verbose: bool = False):
+        called["refresh"] = verbose
+        if verbose:
+            print("schema/items.json - 0 entries")
+
+    monkeypatch.setattr(inventory_scanner.SchemaProvider, "refresh_all", fake_refresh)
+    inventory_scanner.main(["--refresh", "--verbose"])
     out = capsys.readouterr().out
     assert "Schema refreshed" in out
-    assert called["refresh"]
+    assert "schema/items.json - 0 entries" in out
+    assert called["refresh"] is True

--- a/tests/test_schema_provider.py
+++ b/tests/test_schema_provider.py
@@ -109,8 +109,8 @@ def test_refresh_all_resets_attributes_and_creates_files(monkeypatch, tmp_path):
     provider.effects_by_index = {}
     provider.origins_by_index = {}
 
-    logs: list[str] = []
-    monkeypatch.setattr(provider._logger, "info", lambda msg, *a: logs.append(msg % a))
+    printed: list[str] = []
+    monkeypatch.setattr("builtins.print", lambda msg: printed.append(msg))
 
     provider.refresh_all(verbose=True)
 
@@ -128,4 +128,4 @@ def test_refresh_all_resets_attributes_and_creates_files(monkeypatch, tmp_path):
 
     for key in provider.ENDPOINTS:
         fname = f"{tmp_path / key}.json"
-        assert any(fname in msg for msg in logs)
+        assert f"{fname} - 0 entries" in printed

--- a/utils/schema_provider.py
+++ b/utils/schema_provider.py
@@ -99,14 +99,15 @@ class SchemaProvider:
     # ------------------------------------------------------------------
     def refresh_all(self, verbose: bool = False) -> None:
         """Force refresh of all schema files."""
-        fetched = []
+        fetched: list[tuple[Path, int]] = []
         for key, ep in self.ENDPOINTS.items():
-            self._load(key, ep, force=True)
-            fetched.append(self._cache_file(key))
+            data = self._load(key, ep, force=True)
+            count = len(data) if hasattr(data, "__len__") else 0
+            fetched.append((self._cache_file(key), count))
 
         if verbose:
-            for path in fetched:
-                self._logger.info("Fetched %s", path)
+            for path, count in fetched:
+                print(f"{path} - {count} entries")
 
         self.items_by_defindex = None
         self.attributes_by_defindex = None


### PR DESCRIPTION
## Summary
- add optional `--verbose` flag across CLI utilities
- improve `SchemaProvider.refresh_all` with verbose details
- test verbose refresh output for CLI helpers

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files utils/schema_provider.py app.py main.py inventory_scanner.py tests/test_schema_provider.py tests/test_app_refresh.py tests/test_inventory_scanner.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68673cef594c83269a2ec207250e2254