### PR TITLE
Remove --verbose flag from refresh commands

### DIFF
--- a/utils/schema_provider.py
+++ b/utils/schema_provider.py
@@ -105,9 +105,8 @@ class SchemaProvider:
             count = len(data) if hasattr(data, "__len__") else 0
             fetched.append((self._cache_file(key), count))
 
-        if verbose:
-            for path, count in fetched:
-                print(f"{path} - {count} entries")
+        for path, count in fetched:
+            print(f"{path} - {count} entries")
 
         self.items_by_defindex = None
         self.attributes_by_defindex = None


### PR DESCRIPTION
## Summary
- remove `--verbose` CLI option from `app.py`, `main.py`, and `inventory_scanner.py`
- invoke `SchemaProvider.refresh_all(verbose=True)` when `--refresh` is used
- default `SchemaProvider.refresh_all()` verbose output to `True`
- update README and tests for the new behaviour

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files app.py main.py inventory_scanner.py utils/schema_provider.py tests/test_app_refresh.py tests/test_inventory_scanner.py README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68673f55c514832686459906adb9d341