### PR TITLE
Improve schema refresh messaging

### DIFF
--- a/tests/test_app_refresh.py
+++ b/tests/test_app_refresh.py
@@ -16,7 +16,8 @@ def test_refresh_flag_triggers_update(monkeypatch, capsys):
     def fake_refresh(self, verbose: bool = False):
         called["schema"] = verbose
         if verbose:
-            print("cache/schema/items.json - 0 entries")
+            print("Fetching items...")
+            print("\N{CHECK MARK} Saved cache/schema/items.json (0 entries)")
 
     monkeypatch.setattr(
         "utils.schema_provider.SchemaProvider.refresh_all", fake_refresh
@@ -26,5 +27,6 @@ def test_refresh_flag_triggers_update(monkeypatch, capsys):
     with pytest.raises(SystemExit):
         importlib.import_module("app")
     out = capsys.readouterr().out
-    assert "cache/schema/items.json - 0 entries" in out
+    assert "Fetching items..." in out
+    assert "✓ Saved cache/schema/items.json (0 entries)" in out
     assert called["schema"] is True

--- a/tests/test_inventory_scanner.py
+++ b/tests/test_inventory_scanner.py
@@ -34,11 +34,13 @@ def test_refresh_schema(monkeypatch, capsys):
     def fake_refresh(self, verbose: bool = False):
         called["refresh"] = verbose
         if verbose:
-            print("schema/items.json - 0 entries")
+            print("Fetching items...")
+            print("\N{CHECK MARK} Saved schema/items.json (0 entries)")
 
     monkeypatch.setattr(inventory_scanner.SchemaProvider, "refresh_all", fake_refresh)
     inventory_scanner.main(["--refresh", "--verbose"])
     out = capsys.readouterr().out
     assert "Schema refreshed" in out
-    assert "schema/items.json - 0 entries" in out
+    assert "Fetching items..." in out
+    assert "✓ Saved schema/items.json (0 entries)" in out
     assert called["refresh"] is True

--- a/tests/test_schema_provider.py
+++ b/tests/test_schema_provider.py
@@ -128,4 +128,5 @@ def test_refresh_all_resets_attributes_and_creates_files(monkeypatch, tmp_path):
 
     for key in provider.ENDPOINTS:
         fname = f"{tmp_path / key}.json"
-        assert f"{fname} - 0 entries" in printed
+        assert f"Fetching {key}..." in printed
+        assert f"\N{CHECK MARK} Saved {fname} (0 entries)" in printed

--- a/utils/schema_provider.py
+++ b/utils/schema_provider.py
@@ -99,15 +99,14 @@ class SchemaProvider:
     # ------------------------------------------------------------------
     def refresh_all(self, verbose: bool = False) -> None:
         """Force refresh of all schema files."""
-        fetched: list[tuple[Path, int]] = []
         for key, ep in self.ENDPOINTS.items():
+            if verbose:
+                print(f"Fetching {key}...")
             data = self._load(key, ep, force=True)
             count = len(data) if hasattr(data, "__len__") else 0
-            fetched.append((self._cache_file(key), count))
-
-        if verbose:
-            for path, count in fetched:
-                print(f"{path} - {count} entries")
+            if verbose:
+                path = self._cache_file(key)
+                print(f"\N{CHECK MARK} Saved {path} ({count} entries)")
 
         self.items_by_defindex = None
         self.attributes_by_defindex = None


### PR DESCRIPTION
## Summary
- log progress while fetching schema files
- update tests for new progress messages

## Testing
- `pre-commit run --files utils/schema_provider.py tests/test_schema_provider.py tests/test_inventory_scanner.py tests/test_app_refresh.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867418897408326a1b69adc28b9806d