### PR TITLE
Remove verbose flag and always print schema refresh details

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Submit any supported SteamID format. Each user panel shows the avatar, TF2 playt
   ```bash
   python app.py --refresh  # fetch latest schema files
   python main.py --refresh
+  # verbose output is enabled automatically; no --verbose flag required
   ```
 - Inspect a single user's inventory from the command line (defaults to a demo
   ID if omitted):

--- a/app.py
+++ b/app.py
@@ -24,7 +24,6 @@ if not os.getenv("STEAM_API_KEY"):
 
 parser = argparse.ArgumentParser(add_help=False)
 parser.add_argument("--refresh", action="store_true")
-parser.add_argument("--verbose", action="store_true")
 parser.add_argument("--test", action="store_true")
 ARGS, _ = parser.parse_known_args()
 
@@ -35,7 +34,7 @@ if ARGS.refresh:
         "\N{ANTICLOCKWISE OPEN CIRCLE ARROW} Refresh requested: refetching TF2 schema..."
     )
     provider = SchemaProvider(cache_dir="cache/schema")
-    provider.refresh_all(verbose=ARGS.verbose)
+    provider.refresh_all(verbose=True)
     print(
         "\N{CHECK MARK} Refresh complete. Restart app normally without --refresh to start server."
     )

--- a/inventory_scanner.py
+++ b/inventory_scanner.py
@@ -28,12 +28,11 @@ def fetch_inventory(steamid: str) -> dict:
 def main(args: list[str]) -> None:
     parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument("--refresh", action="store_true")
-    parser.add_argument("--verbose", action="store_true")
     parser.add_argument("steamid", nargs="?")
     opts = parser.parse_args(args)
 
     if opts.refresh:
-        SchemaProvider().refresh_all(verbose=opts.verbose)
+        SchemaProvider().refresh_all(verbose=True)
         print("\N{CHECK MARK} Schema refreshed")
         return
 

--- a/main.py
+++ b/main.py
@@ -18,12 +18,11 @@ def main() -> None:
 
     parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument("--refresh", action="store_true")
-    parser.add_argument("--verbose", action="store_true")
     parser.add_argument("steamid", nargs="?")
     args, _ = parser.parse_known_args()
 
     if args.refresh:
-        SchemaProvider().refresh_all(verbose=args.verbose)
+        SchemaProvider().refresh_all(verbose=True)
         print("\N{CHECK MARK} Schema refreshed")
         return
 

--- a/tests/test_app_refresh.py
+++ b/tests/test_app_refresh.py
@@ -21,7 +21,7 @@ def test_refresh_flag_triggers_update(monkeypatch, capsys):
     monkeypatch.setattr(
         "utils.schema_provider.SchemaProvider.refresh_all", fake_refresh
     )
-    monkeypatch.setattr(sys, "argv", ["app.py", "--refresh", "--verbose"])
+    monkeypatch.setattr(sys, "argv", ["app.py", "--refresh"])
     sys.modules.pop("app", None)
     with pytest.raises(SystemExit):
         importlib.import_module("app")

--- a/tests/test_inventory_scanner.py
+++ b/tests/test_inventory_scanner.py
@@ -37,7 +37,7 @@ def test_refresh_schema(monkeypatch, capsys):
             print("schema/items.json - 0 entries")
 
     monkeypatch.setattr(inventory_scanner.SchemaProvider, "refresh_all", fake_refresh)
-    inventory_scanner.main(["--refresh", "--verbose"])
+    inventory_scanner.main(["--refresh"])
     out = capsys.readouterr().out
     assert "Schema refreshed" in out
     assert "schema/items.json - 0 entries" in out

--- a/utils/schema_provider.py
+++ b/utils/schema_provider.py
@@ -97,7 +97,7 @@ class SchemaProvider:
         return {}
 
     # ------------------------------------------------------------------
-    def refresh_all(self, verbose: bool = False) -> None:
+    def refresh_all(self, verbose: bool = True) -> None:
         """Force refresh of all schema files."""
         fetched: list[tuple[Path, int]] = []
         for key, ep in self.ENDPOINTS.items():
@@ -105,9 +105,8 @@ class SchemaProvider:
             count = len(data) if hasattr(data, "__len__") else 0
             fetched.append((self._cache_file(key), count))
 
-        if verbose:
-            for path, count in fetched:
-                print(f"{path} - {count} entries")
+        for path, count in fetched:
+            print(f"{path} - {count} entries")
 
         self.items_by_defindex = None
         self.attributes_by_defindex = None


### PR DESCRIPTION
## Summary
- ensure schema counts print even if verbose=False is passed
- keep refresh command behaviour so `--refresh` prints detailed output automatically

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files utils/schema_provider.py app.py main.py inventory_scanner.py tests/test_app_refresh.py tests/test_inventory_scanner.py README.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68673f55c514832686459906adb9d341