### PR TITLE
Make schema refresh verbose by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Submit any supported SteamID format. Each user panel shows the avatar, TF2 playt
 - Item schema is cached automatically via `SchemaProvider` in
   `utils/schema_provider.py`. Pass `base_url` to use a mirror. Update it with:
   ```bash
-  python app.py --refresh  # fetch latest schema files
+  python app.py --refresh  # fetch latest schema files (shows progress)
   python main.py --refresh
   ```
 - Inspect a single user's inventory from the command line (defaults to a demo

--- a/app.py
+++ b/app.py
@@ -35,7 +35,7 @@ if ARGS.refresh:
         "\N{ANTICLOCKWISE OPEN CIRCLE ARROW} Refresh requested: refetching TF2 schema..."
     )
     provider = SchemaProvider(cache_dir="cache/schema")
-    provider.refresh_all(verbose=ARGS.verbose)
+    provider.refresh_all(verbose=True)
     print(
         "\N{CHECK MARK} Refresh complete. Restart app normally without --refresh to start server."
     )

--- a/inventory_scanner.py
+++ b/inventory_scanner.py
@@ -33,7 +33,7 @@ def main(args: list[str]) -> None:
     opts = parser.parse_args(args)
 
     if opts.refresh:
-        SchemaProvider().refresh_all(verbose=opts.verbose)
+        SchemaProvider().refresh_all(verbose=True)
         print("\N{CHECK MARK} Schema refreshed")
         return
 

--- a/main.py
+++ b/main.py
@@ -23,7 +23,7 @@ def main() -> None:
     args, _ = parser.parse_known_args()
 
     if args.refresh:
-        SchemaProvider().refresh_all(verbose=args.verbose)
+        SchemaProvider().refresh_all(verbose=True)
         print("\N{CHECK MARK} Schema refreshed")
         return
 


### PR DESCRIPTION
## Summary
- always show progress when refreshing the schema
- document verbose output in usage docs

## Testing
- `pytest -q`
- `pre-commit run --files app.py main.py inventory_scanner.py README.md`

------
https://chatgpt.com/codex/tasks/task_e_68674545f8008326a6c402364cffb8fd