### PR TITLE
Fix qualities file loading

### DIFF
--- a/tests/test_local_data.py
+++ b/tests/test_local_data.py
@@ -77,6 +77,31 @@ def test_load_files_auto_refetch(tmp_path, monkeypatch, capsys):
     assert ld.SCHEMA_ATTRIBUTES[1]["name"] == "Attr"
 
 
+def test_load_files_name_key_quality(tmp_path, monkeypatch):
+    attr_file = tmp_path / "attributes.json"
+    particles_file = tmp_path / "particles.json"
+    items_file = tmp_path / "items.json"
+    qual_file = tmp_path / "qualities.json"
+
+    attr_file.write_text(json.dumps([{"defindex": 1, "name": "Attr"}]))
+    particles_file.write_text(json.dumps([{"id": 1, "name": "P"}]))
+    items_file.write_text(json.dumps([{"defindex": 1, "name": "One"}]))
+    qual_file.write_text(json.dumps({"Unique": 1}))
+
+    monkeypatch.setattr(ld, "ATTRIBUTES_FILE", attr_file)
+    monkeypatch.setattr(ld, "PARTICLES_FILE", particles_file)
+    monkeypatch.setattr(ld, "ITEMS_FILE", items_file)
+    monkeypatch.setattr(ld, "QUALITIES_FILE", qual_file)
+
+    ld.SCHEMA_ATTRIBUTES = {}
+    ld.ITEMS_BY_DEFINDEX = {}
+    ld.PARTICLE_NAMES = {}
+    ld.QUALITIES_BY_INDEX = {}
+
+    ld.load_files()
+    assert ld.QUALITIES_BY_INDEX == {1: "Unique"}
+
+
 def test_clean_items_game_parses_all():
     sample = {
         "items_game": {

--- a/utils/local_data.py
+++ b/utils/local_data.py
@@ -176,10 +176,12 @@ def load_files(*, auto_refetch: bool = False) -> Tuple[Dict[int, Any], Dict[int,
             for e in raw_quals
             if isinstance(e, dict) and "id" in e and "name" in e
         }
+    elif isinstance(raw_quals, dict):
+        by_key = {int(k): str(v) for k, v in raw_quals.items() if str(k).isdigit()}
+        by_value = {int(v): str(k) for k, v in raw_quals.items() if str(v).isdigit()}
+        QUALITIES_BY_INDEX = by_key or by_value
     else:
-        QUALITIES_BY_INDEX = {
-            int(k): str(v) for k, v in raw_quals.items() if str(k).isdigit()
-        }
+        QUALITIES_BY_INDEX = {}
     print(f"\N{CHECK MARK} Loaded {len(QUALITIES_BY_INDEX)} qualities from {qual_path}")
 
     particle_path = required["particles"]


### PR DESCRIPTION
## Summary
- handle qualities.json with name->id mapping
- add regression test for reversed qualities mapping

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files utils/local_data.py tests/test_local_data.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867493370f8832689232e60a32e7f6c