### PR TITLE
Improve error handling around inventory enrichment

### DIFF
--- a/app.py
+++ b/app.py
@@ -91,7 +91,12 @@ def fetch_inventory(steamid64: str) -> Dict[str, Any]:
         status, data = sac.fetch_inventory(steamid64)
     items: List[Dict[str, Any]] = []
     if status == "parsed":
-        items = enrich_inventory(data)
+        try:
+            items = enrich_inventory(data)
+        except Exception:
+            app.logger.exception("Failed to enrich inventory for %s", steamid64)
+            status = "failed"
+            items = []
     return {"items": items, "status": status}
 
 


### PR DESCRIPTION
## Summary
- protect enrich_inventory() call with try/except
- propagate failed status when enrichment fails

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68675051c7b08326ae999e02e64088f4