### PR TITLE
Use schema globals in item processor

### DIFF
--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -423,7 +423,7 @@ def _preferred_base_name(defindex: str, schema_entry: Dict[str, Any]) -> str:
     return name or f"Item #{defindex}"
 
 
-def _process_item(asset: Dict[str, Any]) -> Dict[str, Any] | None:
+def _process_item(asset: dict) -> dict | None:
     """Return an enriched item dictionary for a single asset."""
 
     defindex_raw = asset.get("defindex", 0)
@@ -448,7 +448,10 @@ def _process_item(asset: Dict[str, Any]) -> Dict[str, Any] | None:
         base_name = f"{base_name} ({paintkit_name})"
 
     quality_id = asset.get("quality", 0)
-    q_name, q_col = QUALITY_MAP.get(quality_id, ("Unknown", "#B2B2B2"))
+    q_name = local_data.QUALITIES_BY_INDEX.get(quality_id)
+    if not q_name:
+        q_name = QUALITY_MAP.get(quality_id, ("Unknown",))[0]
+    q_col = QUALITY_MAP.get(quality_id, ("", "#B2B2B2"))[1]
     display_name = _build_item_name(base_name, q_name, asset)
 
     ks_tier, sheen = _extract_killstreak(asset)


### PR DESCRIPTION
## Summary
- update `_process_item` to reference local_data maps

## Testing
- `pre-commit run --files utils/inventory_processor.py tests/test_translate_and_enrich.py tests/test_inventory_processor.py tests/test_enrichment.py tests/test_spells.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68677705076c8326b3329b410b5dbb84