### PR TITLE
Refactor spell detection and cleanup tests

### DIFF
--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -5,7 +5,6 @@ from utils import local_data as ld
 
 @pytest.fixture(autouse=True)
 def reset_schema(monkeypatch):
-    ld.TF2_SCHEMA = {}
     ld.ITEMS_GAME_CLEANED = {}
     ld.ITEMS_BY_DEFINDEX = {}
 
@@ -31,15 +30,20 @@ def test_enrichment_full_attributes(monkeypatch):
             }
         ]
     }
-    ld.TF2_SCHEMA = {"111": {"defindex": 111, "item_name": "Rocket Launcher"}}
     ld.ITEMS_BY_DEFINDEX = {111: {"item_name": "Rocket Launcher"}}
     ld.QUALITIES_BY_INDEX = {11: "Strange"}
     monkeypatch.setattr(
         ld,
         "SCHEMA_ATTRIBUTES",
         {
-            1009: {"description_string": "Exorcism"},
-            2001: {"description_string": "Chromatic Corruption"},
+            1009: {
+                "description_string": "Exorcism",
+                "attribute_class": "halloween_death_ghosts",
+            },
+            2001: {
+                "description_string": "Chromatic Corruption",
+                "attribute_class": "halloween_green_flames",
+            },
         },
         False,
     )
@@ -78,7 +82,6 @@ def test_unknown_values_warn(monkeypatch, caplog):
             }
         ]
     }
-    ld.TF2_SCHEMA = {"111": {"defindex": 111, "item_name": "Rocket Launcher"}}
     ld.ITEMS_BY_DEFINDEX = {111: {"item_name": "Rocket Launcher"}}
     ld.QUALITIES_BY_INDEX = {11: "Strange"}
 

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -8,20 +8,12 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def reset_data(monkeypatch):
-    ld.TF2_SCHEMA = {}
     ld.ITEMS_GAME_CLEANED = {}
     ld.ITEMS_BY_DEFINDEX = {}
 
 
 def test_enrich_inventory():
     data = {"items": [{"defindex": 111, "quality": 11}]}
-    ld.TF2_SCHEMA = {
-        "111": {
-            "defindex": 111,
-            "item_name": "Rocket Launcher",
-            "image_url": "https://steamcommunity-a.akamaihd.net/economy/image/img/360fx360f",
-        }
-    }
     ld.ITEMS_BY_DEFINDEX = {
         111: {
             "item_name": "Rocket Launcher",
@@ -47,9 +39,6 @@ def test_enrich_inventory_unusual_effect():
                 "descriptions": [{"value": "Unusual Effect: Burning Flames"}],
             }
         ]
-    }
-    ld.TF2_SCHEMA = {
-        "222": {"defindex": 222, "item_name": "Team Captain", "image_url": "img"}
     }
     ld.ITEMS_BY_DEFINDEX = {222: {"item_name": "Team Captain", "image_url": "img"}}
     ld.QUALITIES_BY_INDEX = {5: "Unusual"}
@@ -78,7 +67,6 @@ def test_unusual_effect_only_for_allowed_qualities(quality, expected):
             }
         ]
     }
-    ld.TF2_SCHEMA = {"333": {"defindex": 333, "item_name": "Cap", "image_url": ""}}
     ld.ITEMS_BY_DEFINDEX = {333: {"item_name": "Cap", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {5: "Unusual", 11: "Haunted", 6: "Unique"}
     ld.EFFECT_NAMES = {"13": "Burning Flames"}
@@ -92,14 +80,6 @@ def test_unusual_effect_only_for_allowed_qualities(quality, expected):
 
 def test_process_inventory_handles_missing_icon():
     data = {"items": [{"defindex": 1}, {"defindex": 2}]}
-    ld.TF2_SCHEMA = {
-        "1": {
-            "defindex": 1,
-            "item_name": "One",
-            "image_url": "https://steamcommunity-a.akamaihd.net/economy/image/a/360fx360f",
-        },
-        "2": {"defindex": 2, "item_name": "Two", "image_url": ""},
-    }
     ld.ITEMS_BY_DEFINDEX = {
         1: {
             "item_name": "One",
@@ -122,7 +102,6 @@ def test_process_inventory_handles_missing_icon():
 def test_enrich_inventory_preserves_absolute_url():
     data = {"items": [{"defindex": 5, "quality": 0}]}
     url = "http://example.com/icon.png"
-    ld.TF2_SCHEMA = {"5": {"defindex": 5, "item_name": "Abs", "image_url": url}}
     ld.ITEMS_BY_DEFINDEX = {5: {"item_name": "Abs", "image_url": url}}
     ld.QUALITIES_BY_INDEX = {0: "Normal"}
     items = ip.enrich_inventory(data)
@@ -131,7 +110,6 @@ def test_enrich_inventory_preserves_absolute_url():
 
 def test_enrich_inventory_skips_unknown_defindex():
     data = {"items": [{"defindex": 1}, {"defindex": 2}]}
-    ld.TF2_SCHEMA = {"1": {"defindex": 1, "item_name": "One", "image_url": "a"}}
     ld.ITEMS_BY_DEFINDEX = {1: {"item_name": "One", "image_url": "a"}}
     ld.QUALITIES_BY_INDEX = {}
     items = ip.enrich_inventory(data)
@@ -141,7 +119,6 @@ def test_enrich_inventory_skips_unknown_defindex():
 
 def test_custom_name_stored_separately(monkeypatch):
     data = {"items": [{"defindex": 444, "quality": 6, "custom_name": "Named"}]}
-    ld.TF2_SCHEMA = {"444": {"defindex": 444, "item_name": "Thing", "image_url": ""}}
     ld.ITEMS_BY_DEFINDEX = {444: {"item_name": "Thing", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {6: "Unique"}
     items = ip.enrich_inventory(data)
@@ -151,7 +128,6 @@ def test_custom_name_stored_separately(monkeypatch):
 
 def test_unusual_effect_quality_filter(monkeypatch):
     data = {"items": [{"defindex": 500, "quality": 5, "effect": 15}]}
-    ld.TF2_SCHEMA = {"500": {"defindex": 500, "item_name": "Hat", "image_url": ""}}
     ld.ITEMS_BY_DEFINDEX = {500: {"item_name": "Hat", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {5: "Unusual"}
     ld.EFFECT_NAMES = {"15": "Burning Flames"}
@@ -160,7 +136,6 @@ def test_unusual_effect_quality_filter(monkeypatch):
 
     # quality not allowed
     data = {"items": [{"defindex": 501, "quality": 6, "effect": 15}]}
-    ld.TF2_SCHEMA = {"501": {"defindex": 501, "item_name": "Thing", "image_url": ""}}
     ld.ITEMS_BY_DEFINDEX = {501: {"item_name": "Thing", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {6: "Unique"}
     items = ip.enrich_inventory(data)
@@ -262,9 +237,6 @@ def test_paint_and_paintkit_badges(monkeypatch):
             }
         ]
     }
-    ld.TF2_SCHEMA = {
-        "9000": {"defindex": 9000, "item_name": "Painted", "image_url": ""}
-    }
     ld.ITEMS_BY_DEFINDEX = {9000: {"item_name": "Painted", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {6: "Unique"}
     monkeypatch.setattr(ld, "PAINT_NAMES", {"3100495": "Test Paint"}, False)
@@ -279,9 +251,6 @@ def test_paint_and_paintkit_badges(monkeypatch):
 
 def test_schema_name_used_for_key():
     data = {"items": [{"defindex": 5021, "quality": 6}]}
-    ld.TF2_SCHEMA = {
-        "5021": {"defindex": 5021, "item_name": "Mann Co. Supply Crate Key"}
-    }
     ld.ITEMS_BY_DEFINDEX = {5021: {"item_name": "Mann Co. Supply Crate Key"}}
     ld.ITEMS_GAME_CLEANED = {"5021": {"name": "Decoder Ring"}}
     ld.QUALITIES_BY_INDEX = {6: "Unique"}
@@ -291,7 +260,6 @@ def test_schema_name_used_for_key():
 
 def test_placeholder_name_falls_back_to_schema():
     data = {"items": [{"defindex": 1001, "quality": 6}]}
-    ld.TF2_SCHEMA = {"1001": {"defindex": 1001, "item_name": "Sniper Rifle"}}
     ld.ITEMS_BY_DEFINDEX = {1001: {"item_name": "Sniper Rifle"}}
     ld.ITEMS_GAME_CLEANED = {"1001": {"name": "rifle"}}
     ld.QUALITIES_BY_INDEX = {6: "Unique"}
@@ -309,7 +277,6 @@ def test_paintkit_appended_to_name(monkeypatch):
             }
         ]
     }
-    ld.TF2_SCHEMA = {"15141": {"defindex": 15141, "item_name": "Flamethrower"}}
     ld.ITEMS_BY_DEFINDEX = {15141: {"item_name": "Flamethrower"}}
     ld.ITEMS_GAME_CLEANED = {"15141": {"name": "tf_weapon_flamethrower"}}
     monkeypatch.setattr(ld, "PAINTKIT_NAMES", {"350": "Warhawk"}, False)
@@ -333,7 +300,6 @@ def test_kill_eater_fields(monkeypatch):
             }
         ]
     }
-    ld.TF2_SCHEMA = {"111": {"defindex": 111, "item_name": "Thing", "image_url": ""}}
     ld.ITEMS_BY_DEFINDEX = {111: {"item_name": "Thing", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {11: "Strange"}
     monkeypatch.setattr(

--- a/tests/test_spells.py
+++ b/tests/test_spells.py
@@ -7,11 +7,26 @@ def test_all_spell_types(monkeypatch):
         ld,
         "SCHEMA_ATTRIBUTES",
         {
-            1009: {"description_string": "Exorcism"},
-            2000: {"description_string": "Bruised Purple Footprints"},
-            2001: {"description_string": "Spectral Spectrum"},
-            1010: {"description_string": "Spy's Creepy Croon"},
-            3003: {"description_string": "Squash Rockets"},
+            1009: {
+                "description_string": "Exorcism",
+                "attribute_class": "halloween_death_ghosts",
+            },
+            2000: {
+                "description_string": "Bruised Purple Footprints",
+                "attribute_class": "halloween_footstep_type",
+            },
+            2001: {
+                "description_string": "Spectral Spectrum",
+                "attribute_class": "halloween_green_flames",
+            },
+            1010: {
+                "description_string": "Spy's Creepy Croon",
+                "attribute_class": "halloween_voice_modulation",
+            },
+            3003: {
+                "description_string": "Squash Rockets",
+                "attribute_class": "halloween_pumpkin_explosions",
+            },
         },
         False,
     )

--- a/tests/test_translate_and_enrich.py
+++ b/tests/test_translate_and_enrich.py
@@ -56,7 +56,6 @@ def test_decorated_flamethrower_enrichment():
 
 
 def test_extract_spells_and_badges(monkeypatch):
-    ld.TF2_SCHEMA = {"501": {"defindex": 501, "item_name": "Gun", "image_url": ""}}
     ld.ITEMS_BY_DEFINDEX = {501: {"item_name": "Gun", "image_url": ""}}
     ld.ITEMS_GAME_CLEANED = {}
 
@@ -64,11 +63,26 @@ def test_extract_spells_and_badges(monkeypatch):
         ld,
         "SCHEMA_ATTRIBUTES",
         {
-            1009: {"description_string": "Exorcism"},
-            2001: {"description_string": "Chromatic Corruption"},
-            2000: {"description_string": "Team Spirit Footprints"},
-            3001: {"description_string": "Pumpkin Bombs"},
-            1010: {"description_string": "Spy's Creepy Croon"},
+            1009: {
+                "description_string": "Exorcism",
+                "attribute_class": "halloween_death_ghosts",
+            },
+            2001: {
+                "description_string": "Chromatic Corruption",
+                "attribute_class": "halloween_green_flames",
+            },
+            2000: {
+                "description_string": "Team Spirit Footprints",
+                "attribute_class": "halloween_footstep_type",
+            },
+            3001: {
+                "description_string": "Pumpkin Bombs",
+                "attribute_class": "halloween_pumpkin_explosions",
+            },
+            1010: {
+                "description_string": "Spy's Creepy Croon",
+                "attribute_class": "halloween_voice_modulation",
+            },
         },
         False,
     )

--- a/tests/test_utils_extras.py
+++ b/tests/test_utils_extras.py
@@ -11,16 +11,11 @@ def test_convert_to_steam64():
 
 @pytest.fixture(autouse=True)
 def reset_data():
-    ld.TF2_SCHEMA = {}
     ld.ITEMS_BY_DEFINDEX = {}
 
 
 def test_process_inventory_sorting():
     data = {"items": [{"defindex": 2}, {"defindex": 1}]}
-    ld.TF2_SCHEMA = {
-        "1": {"defindex": 1, "item_name": "A", "image_url": "b"},
-        "2": {"defindex": 2, "item_name": "B", "image_url": "a"},
-    }
     ld.ITEMS_BY_DEFINDEX = {
         1: {"item_name": "A", "image_url": "b"},
         2: {"item_name": "B", "image_url": "a"},

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -39,6 +39,15 @@ QUALITY_MAP = {
     15: ("Decorated Weapon", "#FAFAFA"),
 }
 
+# Attribute class names that correspond to Halloween spell effects
+SPELL_CLASSES = {
+    "halloween_death_ghosts",
+    "halloween_voice_modulation",
+    "halloween_pumpkin_explosions",
+    "halloween_green_flames",
+    "halloween_footstep_type",
+}
+
 
 def _extract_unusual_effect(asset: Dict[str, Any]) -> str | None:
     """Return the unusual effect name from attributes or descriptions."""
@@ -284,6 +293,10 @@ def _extract_spells(asset: Dict[str, Any]) -> tuple[list[dict], list[str]]:
 
         info = attr_map.get(idx)
         if not isinstance(info, dict):
+            continue
+
+        attr_class = info.get("attribute_class")
+        if attr_class not in SPELL_CLASSES:
             continue
 
         name = info.get("description_string") or info.get("name")


### PR DESCRIPTION
## Summary
- restrict spell detection to known attribute classes
- update test fixtures to include attribute classes
- remove `TF2_SCHEMA` references from tests

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files utils/inventory_processor.py tests/test_spells.py tests/test_translate_and_enrich.py tests/test_enrichment.py tests/test_inventory_processor.py tests/test_utils_extras.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68677c0872c88326a8aa59beed626a21