### PR TITLE
Fix spell placeholder strings

### DIFF
--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -35,12 +35,9 @@ def test_enrichment_full_attributes(monkeypatch):
         ld,
         "SCHEMA_ATTRIBUTES",
         {
-            1009: {
-                "description_string": "Exorcism",
-                "attribute_class": "halloween_death_ghosts",
-            },
+            1009: {"name": "Exorcism", "attribute_class": "halloween_death_ghosts"},
             2001: {
-                "description_string": "Chromatic Corruption",
+                "name": "Chromatic Corruption",
                 "attribute_class": "halloween_green_flames",
             },
         },

--- a/tests/test_spells.py
+++ b/tests/test_spells.py
@@ -7,24 +7,21 @@ def test_all_spell_types(monkeypatch):
         ld,
         "SCHEMA_ATTRIBUTES",
         {
-            1009: {
-                "description_string": "Exorcism",
-                "attribute_class": "halloween_death_ghosts",
-            },
+            1009: {"name": "Exorcism", "attribute_class": "halloween_death_ghosts"},
             2000: {
-                "description_string": "Bruised Purple Footprints",
+                "name": "Bruised Purple Footprints",
                 "attribute_class": "halloween_footstep_type",
             },
             2001: {
-                "description_string": "Spectral Spectrum",
+                "name": "Spectral Spectrum",
                 "attribute_class": "halloween_green_flames",
             },
             1010: {
-                "description_string": "Spy's Creepy Croon",
+                "name": "Spy's Creepy Croon",
                 "attribute_class": "halloween_voice_modulation",
             },
             3003: {
-                "description_string": "Squash Rockets",
+                "name": "Squash Rockets",
                 "attribute_class": "halloween_pumpkin_explosions",
             },
         },
@@ -47,3 +44,19 @@ def test_all_spell_types(monkeypatch):
     assert "Spy's Creepy Croon" in names
     assert "Squash Rockets" in names
     assert any(b["icon"] == "👻" for b in badges)
+
+
+def test_placeholder_spell_ignored(monkeypatch):
+    monkeypatch.setattr(
+        ld,
+        "SCHEMA_ATTRIBUTES",
+        {
+            9999: {"name": "%s1", "attribute_class": "halloween_green_flames"},
+        },
+        False,
+    )
+
+    dummy = {"attributes": [{"defindex": 9999}]}
+    badges, names = _extract_spells(dummy)
+    assert badges == []
+    assert names == []

--- a/tests/test_translate_and_enrich.py
+++ b/tests/test_translate_and_enrich.py
@@ -62,24 +62,21 @@ def test_extract_spells_and_badges(monkeypatch):
         ld,
         "SCHEMA_ATTRIBUTES",
         {
-            1009: {
-                "description_string": "Exorcism",
-                "attribute_class": "halloween_death_ghosts",
-            },
+            1009: {"name": "Exorcism", "attribute_class": "halloween_death_ghosts"},
             2001: {
-                "description_string": "Chromatic Corruption",
+                "name": "Chromatic Corruption",
                 "attribute_class": "halloween_green_flames",
             },
             2000: {
-                "description_string": "Team Spirit Footprints",
+                "name": "Team Spirit Footprints",
                 "attribute_class": "halloween_footstep_type",
             },
             3001: {
-                "description_string": "Pumpkin Bombs",
+                "name": "Pumpkin Bombs",
                 "attribute_class": "halloween_pumpkin_explosions",
             },
             1010: {
-                "description_string": "Spy's Creepy Croon",
+                "name": "Spy's Creepy Croon",
                 "attribute_class": "halloween_voice_modulation",
             },
         },

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -442,8 +442,21 @@ def _extract_spells(asset: Dict[str, Any]) -> tuple[list[dict], list[str]]:
         if attr_class not in SPELL_CLASSES:
             continue
 
-        name = info.get("description_string") or info.get("name")
+        # Prefer a human readable name or display_name
+        name = info.get("display_name") or info.get("name")
+        placeholder = info.get("description_string")
+
+        if name and "%s" in name:
+            logger.debug("Skipping unresolved spell name for %s: %s", idx, name)
+            name = None
+        if not name and placeholder and "%s" not in placeholder:
+            name = placeholder
+
         if not name:
+            name = f"Unknown Spell (defindex {idx})"
+
+        if "%s" in name:
+            # unresolved placeholder even after fallback
             continue
 
         icon = _spell_icon(name)


### PR DESCRIPTION
## Summary
- prefer `display_name` or `name` when parsing spell attributes
- drop unresolved placeholders when building spell lists
- update tests for new spell logic
- test ignoring placeholder spell entries

## Testing
- `pre-commit run --files utils/inventory_processor.py tests/test_spells.py tests/test_translate_and_enrich.py tests/test_enrichment.py` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_686787a7bfd8832682641c8a82e9e130