### PR TITLE
Add string lookups schema file

### DIFF
--- a/tests/test_schema_provider.py
+++ b/tests/test_schema_provider.py
@@ -24,6 +24,7 @@ def test_schema_provider(monkeypatch, tmp_path):
         "/properties/strangeParts": {"Kills": {"id": 64, "name": "Kills"}},
         "/properties/qualities": {"Normal": 0},
         "/properties/defindexes": {"5021": "Key"},
+        "/raw/schema/string_lookups": {"KillEaterEventType": "Kills"},
     }
     calls = {key: 0 for key in payloads}
 
@@ -42,6 +43,7 @@ def test_schema_provider(monkeypatch, tmp_path):
     assert provider.get_origins() == {0: "Timed Drop"}
     assert provider.get_parts() == {64: {"id": 64, "name": "Kills"}}
     assert provider.get_qualities() == {"Normal": 0}
+    assert provider.get_string_lookups() == {"KillEaterEventType": "Kills"}
     assert provider.get_defindexes() == {5021: "Key"}
 
     # second calls should hit cache and not increase call counts
@@ -52,6 +54,7 @@ def test_schema_provider(monkeypatch, tmp_path):
     provider.get_origins()
     provider.get_parts()
     provider.get_qualities()
+    provider.get_string_lookups()
 
     for endpoint in payloads:
         assert calls[endpoint] == 1
@@ -72,6 +75,9 @@ def test_schema_provider_list_payload(monkeypatch, tmp_path):
         "/raw/schema/originNames": {"value": [{"id": 0, "name": "Timed Drop"}]},
         "/properties/strangeParts": {"value": [{"id": 64, "name": "Kills"}]},
         "/properties/qualities": {"value": [{"id": 0, "name": "Normal"}]},
+        "/raw/schema/string_lookups": {
+            "value": [{"key": "KillEaterEventType", "value": "Kills"}]
+        },
     }
 
     def fake_get(self, url, timeout=20):
@@ -89,6 +95,7 @@ def test_schema_provider_list_payload(monkeypatch, tmp_path):
     assert provider.get_origins() == {0: "Timed Drop"}
     assert provider.get_parts() == {64: {"id": 64, "name": "Kills"}}
     assert provider.get_qualities() == {"Normal": 0}
+    assert provider.get_string_lookups() == {"KillEaterEventType": "Kills"}
 
 
 def test_refresh_all_resets_attributes_and_creates_files(monkeypatch, tmp_path):
@@ -108,6 +115,7 @@ def test_refresh_all_resets_attributes_and_creates_files(monkeypatch, tmp_path):
     provider.qualities_map = {}
     provider.effects_by_index = {}
     provider.origins_by_index = {}
+    provider.string_lookups = {}
 
     printed: list[str] = []
     monkeypatch.setattr("builtins.print", lambda msg: printed.append(msg))
@@ -125,6 +133,7 @@ def test_refresh_all_resets_attributes_and_creates_files(monkeypatch, tmp_path):
     assert provider.qualities_map is None
     assert provider.effects_by_index is None
     assert provider.origins_by_index is None
+    assert provider.string_lookups is None
 
     for key in provider.ENDPOINTS:
         fname = f"{tmp_path / key}.json"

--- a/utils/schema_provider.py
+++ b/utils/schema_provider.py
@@ -23,6 +23,7 @@ class SchemaProvider:
         "parts": "/properties/strangeParts",
         "qualities": "/properties/qualities",
         "defindexes": "/properties/defindexes",
+        "string_lookups": "/raw/schema/string_lookups",
     }
 
     def __init__(
@@ -43,6 +44,7 @@ class SchemaProvider:
         self.qualities_map: Dict[str, int] | None = None
         self.defindex_names: Dict[int, str] | None = None
         self.origins_by_index: Dict[int, str] | None = None
+        self.string_lookups: Dict[str, str] | None = None
 
     # ------------------------------------------------------------------
     def _fetch(self, endpoint: str) -> Any:
@@ -116,6 +118,7 @@ class SchemaProvider:
         self.qualities_map = None
         self.effects_by_index = None
         self.origins_by_index = None
+        self.string_lookups = None
 
     def _to_int_map(self, data: dict) -> Dict[int, Any]:
         mapping: Dict[int, Any] = {}
@@ -191,6 +194,23 @@ class SchemaProvider:
                 mapping = self._from_name_map(data)
             self.origins_by_index = mapping
         return self.origins_by_index
+
+    def get_string_lookups(self, *, force: bool = False) -> Dict[str, str]:
+        if self.string_lookups is None or force:
+            data = self._load("string_lookups", self.ENDPOINTS["string_lookups"], force)
+            if isinstance(data, dict) and "value" in data:
+                data = data["value"]
+            if isinstance(data, list):
+                self.string_lookups = {
+                    str(e.get("key")): str(e.get("value"))
+                    for e in data
+                    if isinstance(e, dict) and "key" in e and "value" in e
+                }
+            elif isinstance(data, dict):
+                self.string_lookups = {str(k): str(v) for k, v in data.items()}
+            else:
+                self.string_lookups = {}
+        return self.string_lookups
 
     def get_parts(self, *, force: bool = False) -> Dict[int, Any]:
         if self.parts_by_defindex is None or force:


### PR DESCRIPTION
## Summary
- support `string_lookups` schema file in `SchemaProvider`
- test new endpoint and refresh behaviour

## Testing
- `pre-commit run --files utils/schema_provider.py tests/test_schema_provider.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867a300566883269e99d4d11fa2ebc0