### PR TITLE
Update spell handling and badge metadata

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -244,8 +244,18 @@ def test_paint_and_paintkit_badges(monkeypatch):
     items = ip.enrich_inventory(data)
     badges = items[0]["badges"]
 
-    assert {"icon": "\U0001f3a8", "title": "Paint: Test Paint"} in badges
-    assert {"icon": "\U0001f58c", "title": "Warpaint: Test Kit"} in badges
+    assert {
+        "icon": "\U0001f3a8",
+        "title": "Paint: Test Paint",
+        "label": "Test Paint",
+        "type": "paint",
+    } in badges
+    assert {
+        "icon": "\U0001f58c",
+        "title": "Warpaint: Test Kit",
+        "label": "Test Kit",
+        "type": "warpaint",
+    } in badges
 
 
 def test_schema_name_used_for_key():

--- a/tests/test_spells.py
+++ b/tests/test_spells.py
@@ -118,21 +118,35 @@ def test_paint_and_footprints(monkeypatch):
     }
     monkeypatch.setattr(ld, "SPELL_DISPLAY_NAMES", display, False)
     monkeypatch.setattr(ip, "SPELL_DISPLAY_NAMES", display, False)
+    monkeypatch.setattr(ld, "FOOTPRINT_SPELL_MAP", {3: "Gangreen Footprints"}, False)
+    monkeypatch.setattr(ip, "FOOTPRINT_SPELL_MAP", {3: "Gangreen Footprints"}, False)
+    monkeypatch.setattr(
+        ld,
+        "PAINT_SPELL_MAP",
+        {1: "Paint A", 2: "Paint B", 3: "Paint C", 4: "Paint D"},
+        False,
+    )
+    monkeypatch.setattr(
+        ip,
+        "PAINT_SPELL_MAP",
+        {1: "Paint A", 2: "Paint B", 3: "Paint C", 4: "Paint D"},
+        False,
+    )
 
     dummy = {
         "attributes": [
-            {"defindex": 4001},
-            {"defindex": 4002},
-            {"defindex": 4003},
-            {"defindex": 4004},
+            {"defindex": 4001, "value": 1},
+            {"defindex": 4002, "value": 2},
+            {"defindex": 4003, "value": 3},
+            {"defindex": 4004, "value": 4},
             {"defindex": 2000, "value": 3},
         ]
     }
     _, names = _extract_spells(dummy)
     assert {
-        "Die Job",
-        "Sinister Staining",
-        "Chromatic Corruption",
-        "Spectral Spectrum",
+        "Paint A",
+        "Paint B",
+        "Paint C",
+        "Paint D",
         "Gangreen Footprints",
     } <= set(names)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -7,6 +7,7 @@ from .constants import (
     ORIGIN_MAP,
     KILLSTREAK_BADGE_ICONS,
 )
+from .local_data import FOOTPRINT_SPELL_MAP, PAINT_SPELL_MAP
 from .item_enricher import ItemEnricher
 from .inventory_provider import InventoryProvider
 
@@ -16,6 +17,8 @@ __all__ = [
     "KILLSTREAK_TIERS",
     "KILLSTREAK_EFFECTS",
     "FOOTPRINT_SPELLS",
+    "FOOTPRINT_SPELL_MAP",
+    "PAINT_SPELL_MAP",
     "ORIGIN_MAP",
     "KILLSTREAK_BADGE_ICONS",
     "ItemEnricher",


### PR DESCRIPTION
## Summary
- expose new spell maps from `local_data`
- map spell values to `FOOTPRINT_SPELL_MAP` and `PAINT_SPELL_MAP`
- attach `label` and `type` fields to item badges
- adjust tests for new badge structure and spell mapping

## Testing
- `pre-commit run --files tests/test_inventory_processor.py tests/test_spells.py utils/__init__.py utils/inventory_processor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867b37242448326817d7cc2cb7231cc