### PR TITLE
Enable auto refetch of optional schema files

### DIFF
--- a/app.py
+++ b/app.py
@@ -51,7 +51,7 @@ STEAM_API_KEY = os.environ["STEAM_API_KEY"]
 app = Flask(__name__)
 
 MAX_MERGE_MS = 0
-local_data.load_files()
+local_data.load_files(auto_refetch=True)
 
 # --- Utility functions ------------------------------------------------------
 

--- a/main.py
+++ b/main.py
@@ -27,7 +27,7 @@ def main() -> None:
         print("\N{CHECK MARK} Schema refreshed")
         return
 
-    local_data.load_files()
+    local_data.load_files(auto_refetch=True)
 
     schema = SchemaProvider()
     enricher = ItemEnricher(schema)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ def app(monkeypatch):
     """Return Flask app with env and schema mocks."""
 
     monkeypatch.setenv("STEAM_API_KEY", "x")
-    monkeypatch.setattr("utils.local_data.load_files", lambda: ({}, {}))
+    monkeypatch.setattr("utils.local_data.load_files", lambda *a, **k: ({}, {}))
 
     mod = importlib.import_module("app")
     importlib.reload(mod)

--- a/tests/test_app_import.py
+++ b/tests/test_app_import.py
@@ -6,7 +6,7 @@ def test_app_uses_mock_schema(monkeypatch):
         "utils.schema_provider.SchemaProvider.refresh_all", lambda self: None
     )
 
-    def fake_load():
+    def fake_load(*args, **kwargs):
         from utils import local_data as ld
 
         ld.SCHEMA_ATTRIBUTES = {1: {"name": "Attr"}}

--- a/tests/test_env_loading.py
+++ b/tests/test_env_loading.py
@@ -6,7 +6,7 @@ import pytest
 
 def test_missing_env_vars_raises(monkeypatch):
     monkeypatch.delenv("STEAM_API_KEY", raising=False)
-    monkeypatch.setattr("utils.local_data.load_files", lambda: ({}, {}))
+    monkeypatch.setattr("utils.local_data.load_files", lambda *a, **k: ({}, {}))
     sys.modules.pop("app", None)
     with pytest.raises(RuntimeError):
         importlib.import_module("app")
@@ -14,6 +14,6 @@ def test_missing_env_vars_raises(monkeypatch):
 
 def test_env_present_allows_import(monkeypatch):
     monkeypatch.setenv("STEAM_API_KEY", "x")
-    monkeypatch.setattr("utils.local_data.load_files", lambda: ({}, {}))
+    monkeypatch.setattr("utils.local_data.load_files", lambda *a, **k: ({}, {}))
     sys.modules.pop("app", None)
     importlib.import_module("app")

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -201,7 +201,7 @@ def test_fetch_inventory_statuses(monkeypatch, payload, expected):
 @pytest.mark.parametrize("status", ["parsed", "incomplete", "private"])
 def test_user_template_safe(monkeypatch, status):
     monkeypatch.setenv("STEAM_API_KEY", "x")
-    monkeypatch.setattr("utils.local_data.load_files", lambda: ({}, {}))
+    monkeypatch.setattr("utils.local_data.load_files", lambda *a, **k: ({}, {}))
     import importlib
 
     app = importlib.import_module("app")

--- a/tests/test_local_data.py
+++ b/tests/test_local_data.py
@@ -9,6 +9,7 @@ def test_load_files_success(tmp_path, monkeypatch, capsys):
     particles_file = tmp_path / "particles.json"
     items_file = tmp_path / "items.json"
     qual_file = tmp_path / "qualities.json"
+    lookups_file = tmp_path / "string_lookups.json"
 
     attr_file.write_text(json.dumps([{"defindex": 1, "name": "Attr"}]))
     particles_file.write_text(json.dumps([{"id": 1, "name": "P"}]))
@@ -19,6 +20,7 @@ def test_load_files_success(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(ld, "PARTICLES_FILE", particles_file)
     monkeypatch.setattr(ld, "ITEMS_FILE", items_file)
     monkeypatch.setattr(ld, "QUALITIES_FILE", qual_file)
+    monkeypatch.setattr(ld, "STRING_LOOKUPS_FILE", lookups_file)
 
     ld.SCHEMA_ATTRIBUTES = {}
     ld.ITEMS_BY_DEFINDEX = {}
@@ -45,17 +47,27 @@ def test_load_files_auto_refetch(tmp_path, monkeypatch, capsys):
     items_file = tmp_path / "items.json"
     particles_file = tmp_path / "particles.json"
     qual_file = tmp_path / "qualities.json"
+    lookups_file = tmp_path / "string_lookups.json"
 
     monkeypatch.setattr(ld, "ATTRIBUTES_FILE", attr_file)
     monkeypatch.setattr(ld, "PARTICLES_FILE", particles_file)
     monkeypatch.setattr(ld, "ITEMS_FILE", items_file)
     monkeypatch.setattr(ld, "QUALITIES_FILE", qual_file)
+    monkeypatch.setattr(ld, "STRING_LOOKUPS_FILE", lookups_file)
 
     payloads = {
         "attributes": [{"defindex": 1, "name": "Attr"}],
         "items": [{"defindex": 1, "name": "One"}],
         "particles": [{"id": 1, "name": "P"}],
         "qualities": {"1": "Unique"},
+        "string_lookups": {
+            "value": [
+                {
+                    "table_name": "SPELL: set item tint RGB",
+                    "strings": [{"index": 0, "string": "A"}],
+                }
+            ]
+        },
     }
 
     def fake_fetch(self, endpoint):
@@ -70,11 +82,14 @@ def test_load_files_auto_refetch(tmp_path, monkeypatch, capsys):
     ld.ITEMS_BY_DEFINDEX = {}
     ld.PARTICLE_NAMES = {}
     ld.QUALITIES_BY_INDEX = {}
+    ld.PAINT_SPELL_MAP = {}
+    ld.FOOTPRINT_SPELL_MAP = {}
 
     ld.load_files(auto_refetch=True)
     out = capsys.readouterr().out
     assert "Downloaded" in out
     assert ld.SCHEMA_ATTRIBUTES[1]["name"] == "Attr"
+    assert ld.PAINT_SPELL_MAP == {0: "A"}
 
 
 def test_load_files_name_key_quality(tmp_path, monkeypatch):

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -24,7 +24,7 @@ def test_main_passes_steamid_to_inventory_provider(monkeypatch):
     monkeypatch.setattr(main, "InventoryProvider", DummyProvider)
     monkeypatch.setattr(main, "ItemEnricher", DummyEnricher)
     monkeypatch.setattr(main, "SchemaProvider", lambda: None)
-    monkeypatch.setattr(main.local_data, "load_files", lambda: ({}, {}))
+    monkeypatch.setattr(main.local_data, "load_files", lambda *a, **k: ({}, {}))
 
     monkeypatch.setattr(sys, "argv", ["main.py", "123"])
     main.main()

--- a/tests/test_user_badges.py
+++ b/tests/test_user_badges.py
@@ -11,7 +11,7 @@ HTML = '{% include "_user.html" %}'
 @pytest.fixture
 def app(monkeypatch):
     monkeypatch.setenv("STEAM_API_KEY", "x")
-    monkeypatch.setattr("utils.local_data.load_files", lambda: ({}, {}))
+    monkeypatch.setattr("utils.local_data.load_files", lambda *a, **k: ({}, {}))
     mod = importlib.import_module("app")
     importlib.reload(mod)
     return mod.app

--- a/tests/test_user_template.py
+++ b/tests/test_user_template.py
@@ -9,7 +9,7 @@ HTML = '{% include "_user.html" %}'
 @pytest.fixture
 def app(monkeypatch):
     monkeypatch.setenv("STEAM_API_KEY", "x")
-    monkeypatch.setattr("utils.local_data.load_files", lambda: ({}, {}))
+    monkeypatch.setattr("utils.local_data.load_files", lambda *a, **k: ({}, {}))
     mod = importlib.import_module("app")
     importlib.reload(mod)
     return mod.app

--- a/utils/local_data.py
+++ b/utils/local_data.py
@@ -130,6 +130,7 @@ def load_files(*, auto_refetch: bool = False) -> Tuple[Dict[int, Any], Dict[int,
         "qualities": QUALITIES_FILE.resolve(),
         "particles": PARTICLES_FILE.resolve(),
     }
+    optional = {"string_lookups": STRING_LOOKUPS_FILE.resolve()}
 
     missing = {k: p for k, p in required.items() if not p.exists()}
     if missing:
@@ -137,6 +138,13 @@ def load_files(*, auto_refetch: bool = False) -> Tuple[Dict[int, Any], Dict[int,
             raise RuntimeError("Missing " + ", ".join(str(p) for p in missing.values()))
         provider = SchemaProvider(cache_dir=required["attributes"].parent)
         for key, path in missing.items():
+            provider._load(key, provider.ENDPOINTS[key], force=True)
+            print(f"\N{DOWNWARDS ARROW WITH TIP LEFTWARDS} Downloaded {path}")
+
+    optional_missing = {k: p for k, p in optional.items() if not p.exists()}
+    if optional_missing and auto_refetch:
+        provider = SchemaProvider(cache_dir=required["attributes"].parent)
+        for key, path in optional_missing.items():
             provider._load(key, provider.ENDPOINTS[key], force=True)
             print(f"\N{DOWNWARDS ARROW WITH TIP LEFTWARDS} Downloaded {path}")
 


### PR DESCRIPTION
## Summary
- download `string_lookups.json` automatically if missing
- ensure app and CLI fetch schema caches on first run
- adjust tests for new optional arg and verify spell lookup download

## Testing
- `pre-commit run --files app.py main.py utils/local_data.py tests/conftest.py tests/test_app_import.py tests/test_env_loading.py tests/test_inventory_processor.py tests/test_local_data.py tests/test_main_cli.py tests/test_user_badges.py tests/test_user_template.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867bb67bd3c8326b141ac2d645e545d