### PR TITLE
Fix optional schema refetch logic

### DIFF
--- a/tests/test_local_data.py
+++ b/tests/test_local_data.py
@@ -90,6 +90,7 @@ def test_load_files_auto_refetch(tmp_path, monkeypatch, capsys):
     assert "Downloaded" in out
     assert ld.SCHEMA_ATTRIBUTES[1]["name"] == "Attr"
     assert ld.PAINT_SPELL_MAP == {0: "A"}
+    assert lookups_file.exists()
 
 
 def test_load_files_name_key_quality(tmp_path, monkeypatch):

--- a/utils/local_data.py
+++ b/utils/local_data.py
@@ -143,8 +143,8 @@ def load_files(*, auto_refetch: bool = False) -> Tuple[Dict[int, Any], Dict[int,
 
     optional_missing = {k: p for k, p in optional.items() if not p.exists()}
     if optional_missing and auto_refetch:
-        provider = SchemaProvider(cache_dir=required["attributes"].parent)
         for key, path in optional_missing.items():
+            provider = SchemaProvider(cache_dir=path.parent)
             provider._load(key, provider.ENDPOINTS[key], force=True)
             print(f"\N{DOWNWARDS ARROW WITH TIP LEFTWARDS} Downloaded {path}")
 


### PR DESCRIPTION
## Summary
- instantiate SchemaProvider per optional file in load_files
- assert optional lookup file creation in tests

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files utils/local_data.py tests/test_local_data.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867c14b07408326baa6ffd1aa6b181b