### PR TITLE
Consolidate wear helpers

### DIFF
--- a/tests/test_wear_helpers.py
+++ b/tests/test_wear_helpers.py
@@ -1,0 +1,61 @@
+import struct
+import pytest
+
+from utils.wear_helpers import _wear_tier, _decode_seed_info
+from utils import local_data
+
+
+def test_wear_tier_mapping():
+    assert _wear_tier(0.0) == "Factory New"
+    assert _wear_tier(0.1) == "Minimal Wear"
+    assert _wear_tier(0.2) == "Field-Tested"
+    assert _wear_tier(0.4) == "Well-Worn"
+    assert _wear_tier(0.9) == "Battle Scarred"
+
+
+def test_decode_seed_info_basic():
+    wear_val = 0.25
+    hi = struct.unpack("<I", struct.pack("<f", wear_val))[0]
+    attrs = [
+        {"defindex": 866, "value": 123},
+        {"defindex": 867, "value": hi},
+    ]
+    wear, seed = _decode_seed_info(attrs)
+    assert wear == pytest.approx(wear_val)
+    assert seed == 123
+
+
+def test_decode_seed_info_swapped():
+    wear_val = 0.3
+    lo = struct.unpack("<I", struct.pack("<f", wear_val))[0]
+    attrs = [
+        {"defindex": 866, "value": lo},
+        {"defindex": 867, "value": 456},
+    ]
+    wear, seed = _decode_seed_info(attrs)
+    expected = struct.unpack("<f", struct.pack("<I", 456))[0]
+    assert wear == expected
+    assert seed == lo
+
+
+def test_decode_seed_info_attr_classes(monkeypatch):
+    monkeypatch.setattr(
+        local_data,
+        "SCHEMA_ATTRIBUTES",
+        {
+            866: {"attribute_class": "lo"},
+            867: {"attribute_class": "hi"},
+            1: {"attribute_class": "lo"},
+            2: {"attribute_class": "hi"},
+        },
+        False,
+    )
+    wear_val = 0.1
+    hi = struct.unpack("<I", struct.pack("<f", wear_val))[0]
+    attrs = [
+        {"defindex": 1, "value": 789},
+        {"defindex": 2, "value": hi},
+    ]
+    wear, seed = _decode_seed_info(attrs)
+    assert wear == pytest.approx(wear_val)
+    assert seed == 789

--- a/translate_and_enrich.py
+++ b/translate_and_enrich.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any, Dict, Iterable, List
-import struct
 import argparse
 import json
 
@@ -14,6 +13,7 @@ from utils.constants import (
     SHEEN_NAMES,
     KILLSTREAK_BADGE_ICONS,
 )
+from utils.wear_helpers import _wear_tier, _decode_seed_info
 
 
 QUALITY_MAP = {
@@ -50,42 +50,6 @@ def _attr_value(attrs: Iterable[dict], idx: int) -> Any | None:
                 return attr.get("float_value")
             return attr.get("value")
     return None
-
-
-def _wear_tier(value: float) -> str:
-    """Return human readable wear tier for a 0-1 float."""
-    if value < 0.07:
-        return "Factory New"
-    if value < 0.15:
-        return "Minimal Wear"
-    if value < 0.38:
-        return "Field-Tested"
-    if value < 0.45:
-        return "Well-Worn"
-    return "Battle Scarred"
-
-
-def _decode_seed_info(attrs: Iterable[dict]) -> tuple[float | None, int | None]:
-    """Return ``(wear_float, pattern_seed)`` from custom paintkit seed attrs."""
-
-    lo = hi = None
-    for attr in attrs:
-        idx = int(attr.get("defindex", -1))
-        if idx == 866:
-            lo = int(attr.get("value") or 0)
-        elif idx == 867:
-            hi = int(attr.get("value") or 0)
-    if lo is None or hi is None:
-        return None, None
-
-    wear = struct.unpack("<f", struct.pack("<I", hi))[0]
-    seed = lo
-    if not (0 <= wear <= 1):
-        wear = struct.unpack("<f", struct.pack("<I", lo))[0]
-        seed = hi
-    if not (0 <= wear <= 1):
-        wear = None
-    return wear, seed
 
 
 def _collect_unmapped(attrs: Iterable[dict], known: Iterable[int]) -> dict:

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -7,6 +7,7 @@ from .constants import (
     KILLSTREAK_BADGE_ICONS,
 )
 from .local_data import FOOTPRINT_SPELL_MAP, PAINT_SPELL_MAP
+from .wear_helpers import _wear_tier, _decode_seed_info
 from .item_enricher import ItemEnricher
 from .inventory_provider import InventoryProvider
 
@@ -21,4 +22,6 @@ __all__ = [
     "KILLSTREAK_BADGE_ICONS",
     "ItemEnricher",
     "InventoryProvider",
+    "_wear_tier",
+    "_decode_seed_info",
 ]

--- a/utils/wear_helpers.py
+++ b/utils/wear_helpers.py
@@ -1,0 +1,63 @@
+import struct
+from typing import Iterable, Tuple
+
+from . import local_data
+
+
+def _wear_tier(value: float) -> str:
+    """Return a wear tier name for ``value`` between 0 and 1."""
+
+    if value < 0.07:
+        return "Factory New"
+    if value < 0.15:
+        return "Minimal Wear"
+    if value < 0.38:
+        return "Field-Tested"
+    if value < 0.45:
+        return "Well-Worn"
+    return "Battle Scarred"
+
+
+def _decode_seed_info(attrs: Iterable[dict]) -> Tuple[float | None, int | None]:
+    """Return ``(wear_float, pattern_seed)`` from custom paintkit seed attrs."""
+
+    mapping = local_data.SCHEMA_ATTRIBUTES or {}
+
+    def get_class(idx: int | None) -> str | None:
+        try:
+            key = int(idx) if idx is not None else None
+        except (TypeError, ValueError):
+            return None
+        info = mapping.get(key)
+        if isinstance(info, dict):
+            return info.get("attribute_class")
+        return None
+
+    lo_class = get_class(866)
+    hi_class = get_class(867)
+
+    lo = hi = None
+    for attr in attrs:
+        idx = attr.get("defindex")
+        attr_class = get_class(idx)
+        if (lo_class and attr_class == lo_class) or idx == 866:
+            try:
+                lo = int(attr.get("value") or 0)
+            except (TypeError, ValueError):
+                continue
+        elif (hi_class and attr_class == hi_class) or idx == 867:
+            try:
+                hi = int(attr.get("value") or 0)
+            except (TypeError, ValueError):
+                continue
+    if lo is None or hi is None:
+        return None, None
+
+    wear = struct.unpack("<f", struct.pack("<I", hi))[0]
+    seed = lo
+    if not (0 <= wear <= 1):
+        wear = struct.unpack("<f", struct.pack("<I", lo))[0]
+        seed = hi
+    if not (0 <= wear <= 1):
+        wear = None
+    return wear, seed


### PR DESCRIPTION
## Summary
- share `_wear_tier` and `_decode_seed_info` in new `utils.wear_helpers`
- import these helpers in existing modules
- test helper behaviours

## Testing
- `pre-commit run --files utils/wear_helpers.py utils/__init__.py utils/inventory_processor.py translate_and_enrich.py tests/test_wear_helpers.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867efad7e488326b6202b7b9d09ad52