### PR TITLE
Remove leftover sample code

### DIFF
--- a/translate_and_enrich.py
+++ b/translate_and_enrich.py
@@ -227,30 +227,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-
-    sample = {
-        "assets": [
-            {
-                "classid": "1",
-                "instanceid": "0",
-                "attributes": [{"defindex": 134, "float_value": 15}],
-            }
-        ],
-        "descriptions": [
-            {
-                "classid": "1",
-                "instanceid": "0",
-                "app_data": {"def_index": "1"},
-                "tradable": 1,
-                "marketable": 1,
-            }
-        ],
-    }
-    maps = {"effect_names": {"15": "Burning Flames"}}
-    enriched = enrich_inventory(
-        sample,
-        {"1": {"item_name": "Test Item"}},
-        {"1": {"name": "Test Item"}},
-        maps,
-    )
-    assert enriched[0]["unusual_effect"] == "Burning Flames"


### PR DESCRIPTION
## Summary
- clean up `translate_and_enrich.py`
- remove sample code so normal CLI usage stops after `main()`

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files translate_and_enrich.py`
- `STEAM_API_KEY=test pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867f334aa588326b552c9744d008221