### PR TITLE
Add verbose option to schema loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Before enriching inventories, load the cached schema to populate
 ```python
 from utils import local_data
 
-local_data.load_files()
+local_data.load_files(verbose=True)
 ```
 You can also enrich raw inventory items using `ItemEnricher`:
 ```python

--- a/app.py
+++ b/app.py
@@ -51,7 +51,7 @@ STEAM_API_KEY = os.environ["STEAM_API_KEY"]
 app = Flask(__name__)
 
 MAX_MERGE_MS = 0
-local_data.load_files(auto_refetch=True)
+local_data.load_files(auto_refetch=True, verbose=ARGS.verbose)
 
 # --- Utility functions ------------------------------------------------------
 

--- a/main.py
+++ b/main.py
@@ -27,7 +27,7 @@ def main() -> None:
         print("\N{CHECK MARK} Schema refreshed")
         return
 
-    local_data.load_files(auto_refetch=True)
+    local_data.load_files(auto_refetch=True, verbose=args.verbose)
 
     schema = SchemaProvider()
     enricher = ItemEnricher(schema)

--- a/tests/test_local_data.py
+++ b/tests/test_local_data.py
@@ -4,7 +4,7 @@ import pytest
 from utils import local_data as ld
 
 
-def test_load_files_success(tmp_path, monkeypatch, capsys):
+def test_load_files_success(tmp_path, monkeypatch, caplog):
     attr_file = tmp_path / "attributes.json"
     particles_file = tmp_path / "particles.json"
     items_file = tmp_path / "items.json"
@@ -28,8 +28,9 @@ def test_load_files_success(tmp_path, monkeypatch, capsys):
     ld.QUALITIES_BY_INDEX = {}
     ld.EFFECT_NAMES = {}
 
-    ld.load_files()
-    out = capsys.readouterr().out
+    caplog.set_level("INFO")
+    ld.load_files(verbose=True)
+    out = caplog.text
     assert ld.SCHEMA_ATTRIBUTES[1]["name"] == "Attr"
     assert ld.ITEMS_BY_DEFINDEX[1]["name"] == "One"
     assert "Loaded 1 attributes" in out
@@ -42,7 +43,7 @@ def test_load_files_missing(tmp_path, monkeypatch):
         ld.load_files()
 
 
-def test_load_files_auto_refetch(tmp_path, monkeypatch, capsys):
+def test_load_files_auto_refetch(tmp_path, monkeypatch, caplog):
     attr_file = tmp_path / "attributes.json"
     items_file = tmp_path / "items.json"
     particles_file = tmp_path / "particles.json"
@@ -85,8 +86,9 @@ def test_load_files_auto_refetch(tmp_path, monkeypatch, capsys):
     ld.PAINT_SPELL_MAP = {}
     ld.FOOTPRINT_SPELL_MAP = {}
 
-    ld.load_files(auto_refetch=True)
-    out = capsys.readouterr().out
+    caplog.set_level("INFO")
+    ld.load_files(auto_refetch=True, verbose=True)
+    out = caplog.text
     assert "Downloaded" in out
     assert ld.SCHEMA_ATTRIBUTES[1]["name"] == "Attr"
     assert ld.PAINT_SPELL_MAP == {0: "A"}

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -800,7 +800,7 @@ def run_enrichment_test(path: str | None = None) -> None:
         print(f"File not found: {file_path}")
         return
 
-    local_data.load_files()
+    local_data.load_files(verbose=True)
     with file_path.open() as f:
         raw = json.load(f)
 


### PR DESCRIPTION
## Summary
- add `verbose` flag to `load_files()` for optional logging
- switch print statements to `logging.info` when verbose
- propagate flag to app and CLI
- document usage in README
- adjust tests for new logging behavior

## Testing
- `pre-commit run --files utils/local_data.py app.py main.py utils/inventory_processor.py README.md tests/test_local_data.py` *(with SKIP=validate-attributes)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867f47e95548326b898a383c561308e