### PR TITLE
Add spell extraction to ItemEnricher

### DIFF
--- a/utils/item_enricher.py
+++ b/utils/item_enricher.py
@@ -2,8 +2,58 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 import logging
+import struct
 
 from .schema_provider import SchemaProvider
+
+
+def _build_spell_map(schema_attributes: Dict[int, Any]) -> Dict[int, Dict[str, str]]:
+    """Return mapping of spell defindex -> {name, type}."""
+    mapping: Dict[int, Dict[str, str]] = {}
+    for idx, info in schema_attributes.items():
+        try:
+            didx = int(idx)
+        except (TypeError, ValueError):
+            continue
+        if not (8900 <= didx <= 8925):
+            continue
+        if not isinstance(info, dict):
+            continue
+        raw_name = info.get("name") or info.get("description_string") or ""
+        name = str(raw_name)
+        name = name.replace("SPELL:", "").strip()
+        if name.startswith("#Attrib_"):
+            token = name[1:].replace("Attrib_", "")
+            token = token.replace("_", " ")
+            name = " ".join(w.capitalize() for w in token.split())
+
+        meta = " ".join(
+            str(info.get(k, ""))
+            for k in ("name", "description_string", "attribute_class")
+        ).lower()
+        kind = "paint"
+        if "foot" in meta:
+            kind = "footprint"
+        elif "voice" in meta:
+            kind = "voices"
+        elif any(t in meta for t in ("tint", "paint", "color")):
+            kind = "paint"
+        mapping[didx] = {"name": name, "type": kind}
+    return mapping
+
+
+def _decode_float_bits_to_int(value: Any) -> int | None:
+    """Return integer decoded from float bits or None."""
+    try:
+        num = float(value)
+    except (TypeError, ValueError):
+        return None
+    if num.is_integer():
+        return int(num)
+    try:
+        return int(struct.unpack("<I", struct.pack("<f", num))[0])
+    except Exception:
+        return None
 
 
 class ItemEnricher:
@@ -17,6 +67,7 @@ class ItemEnricher:
         self.parts = self.provider.get_strange_parts()
         self.paints_val = {v: k for k, v in self.provider.get_paints().items()}
         self.qualities = {v: k for k, v in self.provider.get_qualities().items()}
+        self.spell_map = _build_spell_map(self.attrs)
         self._logger = logging.getLogger(__name__)
 
     # ------------------------------------------------------------------
@@ -42,6 +93,7 @@ class ItemEnricher:
             "sheen": None,
             "killstreaker": None,
             "strange_parts": [],
+            "spells": [],
         }
 
         for attr in attributes or []:
@@ -84,6 +136,19 @@ class ItemEnricher:
                     continue
                 result["wear_float"] = round(w, 3)
                 result["wear_label"] = self._wear_label(w)
+            elif aid in self.spell_map:
+                spell = self.spell_map[aid]
+                raw = attr.get("value")
+                if raw is None:
+                    fv = attr.get("float_value")
+                    raw = _decode_float_bits_to_int(fv) if fv is not None else None
+                try:
+                    count = int(raw) if raw is not None else None
+                except (TypeError, ValueError):
+                    count = None
+                result["spells"].append(
+                    {"name": spell["name"], "type": spell["type"], "count": count}
+                )
 
         return result
 


### PR DESCRIPTION
## Summary
- add `_build_spell_map` and `_decode_float_bits_to_int` helpers
- enrich attributes with spell data
- expose spells in `ItemEnricher`
- unit tests for spell extraction and bit decoding

## Testing
- `pre-commit run --files utils/item_enricher.py tests/test_item_enricher.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68681801a5f483268024b203255435d8