### PR TITLE
Improve spells rendering

### DIFF
--- a/static/modal.js
+++ b/static/modal.js
@@ -111,7 +111,21 @@
     if (Array.isArray(data.spells) && data.spells.length) {
       spells += '<h4 id="modal-spells">Spells</h4><ul>';
       data.spells.forEach(sp => {
-        spells += '<li>' + esc(sp) + '</li>';
+        let name = '';
+        let count = null;
+        if (typeof sp === 'string') {
+          name = sp;
+        } else if (sp && typeof sp === 'object') {
+          name = sp.name || '';
+          count = sp.count;
+        } else {
+          name = String(sp || '');
+        }
+        let line = esc(name);
+        if (count && count > 1) {
+          line += ' (' + esc(count) + ')';
+        }
+        spells += '<li>' + line + '</li>';
       });
       spells += '</ul>';
     }

--- a/tests/test_modal.js
+++ b/tests/test_modal.js
@@ -45,6 +45,22 @@ modal.renderBadges([{ icon: '🌈', title: 'Weapon color spell' }]);
 if (!window.document.querySelector('#modal-badges').textContent.includes('🌈')) {
   throw new Error('Badge not rendered');
 }
+const html1 = modal.generateModalHTML({ spells: ['A Spell', 'B Spell'] });
+if (!html1.includes('<li>A Spell</li>') || !html1.includes('<li>B Spell</li>')) {
+  throw new Error('String spells not rendered');
+}
+const html2 = modal.generateModalHTML({
+  spells: [
+    { name: 'Ghosts', count: 2 },
+    { name: 'Fire', count: 1 },
+  ],
+});
+if (!html2.includes('<li>Ghosts (2)</li>')) {
+  throw new Error('Spell count not shown');
+}
+if (!html2.includes('<li>Fire</li>')) {
+  throw new Error('Spell object not rendered');
+}
 modal.closeModal();
 modal.showItemModal('<p>Race</p>');
 setTimeout(() => {


### PR DESCRIPTION
## Summary
- allow spells array to contain objects
- render spell name with count if provided
- extend `tests/test_modal.js` to cover spells rendering

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files static/modal.js tests/test_modal.js`
- `npm install && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68681c6dab38832686b68a525097045e