### PR TITLE
Fix attribute_class handling in ItemEnricher

### DIFF
--- a/tests/test_item_enricher.py
+++ b/tests/test_item_enricher.py
@@ -59,6 +59,43 @@ def test_enrich_inventory(monkeypatch):
     assert item["strange_parts"] == ["Kills"]
 
 
+def test_enrich_inventory_attribute_class(monkeypatch):
+    provider = SchemaProvider(base_url="https://example.com")
+
+    monkeypatch.setattr(
+        provider, "get_items", lambda: {100: {"defindex": 100, "item_name": "Rocket"}}
+    )
+    monkeypatch.setattr(provider, "get_qualities", lambda: {"Unique": 6})
+    monkeypatch.setattr(provider, "get_paints", lambda: {"Team Spirit": 1})
+    monkeypatch.setattr(
+        provider,
+        "get_attributes",
+        lambda: {
+            142: {"defindex": 142, "attribute_class": "set_item_tint_rgb"},
+            134: {"defindex": 134, "attribute_class": "set_attached_particle"},
+        },
+    )
+    monkeypatch.setattr(provider, "get_effects", lambda: {55: "Hot"})
+    monkeypatch.setattr(provider, "get_strange_parts", lambda: {})
+
+    enricher = ItemEnricher(provider)
+
+    raw = [
+        {
+            "defindex": 100,
+            "quality": 6,
+            "attributes": [
+                {"defindex": 142, "value": 1},
+                {"defindex": 134, "value": 55},
+            ],
+        }
+    ]
+
+    item = enricher.enrich_inventory(raw)[0]
+    assert item["paint"] == "Team Spirit"
+    assert item["unusual_effect"] == "Hot"
+
+
 def test_spell_extraction(monkeypatch):
     provider = SchemaProvider(base_url="https://example.com")
 

--- a/utils/item_enricher.py
+++ b/utils/item_enricher.py
@@ -105,7 +105,7 @@ class ItemEnricher:
             val = attr.get("float_value") or attr.get("value")
 
             info = self.attrs.get(aid, {})
-            cls = info.get("class", "")
+            cls = info.get("class") or info.get("attribute_class", "")
             name = info.get("name", "")
 
             if aid in self.parts:


### PR DESCRIPTION
## Summary
- support `attribute_class` in `utils/item_enricher.ItemEnricher._enrich_attributes`
- add regression test for attributes defined by `attribute_class`

## Testing
- `pre-commit run --files utils/item_enricher.py tests/test_item_enricher.py`

------
https://chatgpt.com/codex/tasks/task_e_68683f20c3e48326af5a5b5d1cb704b4