### PR TITLE
Add spells documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ All modal behaviour is centralized in `static/modal.js`. Other scripts use
 its helper functions and should never manipulate the modal DOM directly.
 Use `showItemModal(html)` to populate and display the dialog.
 
+## Spells
+
+Halloween spells are parsed from item attributes using the loaded schema files
+at runtime. The processor decodes attribute values to extract spell names and
+their counts, mapping each spell through schema lookups. When an item has any
+spells, they are listed in the item modal as bullet points; counts greater than
+one appear in parentheses next to the spell name.
+
 ## Testing
 
 Run linting and tests before committing:


### PR DESCRIPTION
## Summary
- document how spells are parsed from the TF2 schema
- explain that spells show up in the item modal with counts

## Testing
- `pre-commit run --files README.md` *(fails: ModuleNotFoundError: No module named 'vdf')*
- `pytest --cov=utils --cov=app`

------
https://chatgpt.com/codex/tasks/task_e_686841bc98b8832694b2f01edf6a2408