### PR TITLE
Update docstring to clarify endianness

### DIFF
--- a/utils/item_enricher.py
+++ b/utils/item_enricher.py
@@ -43,7 +43,10 @@ def _build_spell_map(schema_attributes: Dict[int, Any]) -> Dict[int, Dict[str, s
 
 
 def _decode_float_bits_to_int(value: Any) -> int | None:
-    """Return integer decoded from float bits or None."""
+    """Return integer decoded from float bits or None.
+
+    Values are interpreted in little-endian order.
+    """
     try:
         num = float(value)
     except (TypeError, ValueError):


### PR DESCRIPTION
## Summary
- clarify that float values are decoded using little-endian order

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files utils/item_enricher.py`


------
https://chatgpt.com/codex/tasks/task_e_686843ce4870832682ae0dfc72cdb18a