### PR TITLE
Improve spell color mapping

### DIFF
--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -114,6 +114,9 @@ def _build_spell_map() -> None:
                 ),
                 None,
             )
+            if pretty is None and idx in PAINT_COLORS:
+                color_name = PAINT_COLORS[idx][0]
+                pretty = color_name if kind == "paint" else f"{color_name} Footprints"
             if pretty:
                 mapping[idx] = (kind, pretty)
     _SPELL_MAP = mapping


### PR DESCRIPTION
## Summary
- expand spell map fallback to use PAINT_COLORS when names aren't in schema
- add regression test for color id spell mapping

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files utils/inventory_processor.py tests/test_spells.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68690e75e41483269387a83f661ed003