### PR TITLE
Update README for spell schema requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ their counts, mapping each spell through schema lookups. When an item has any
 spells, they are listed in the item modal as bullet points; counts greater than
 one appear in parentheses next to the spell name.
 
+For proper spell resolution, `string_lookups.json` and `defindexes.json` must be
+present in `cache/schema/`. If spell names show up as generic placeholders, run
+the following to refresh the schema files:
+
+```bash
+python app.py --refresh
+```
+
 ## Testing
 
 Run linting and tests before committing:


### PR DESCRIPTION
## Summary
- clarify that `string_lookups.json` and `defindexes.json` must exist in `cache/schema/`
- instruct how to refresh the schema when placeholders appear

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files README.md`


------
https://chatgpt.com/codex/tasks/task_e_686912530b288326ba1a74e1e278e0b1