### PR TITLE
Remove unknown kill-eater index warning

### DIFF
--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -101,5 +101,4 @@ def test_unknown_values_warn(monkeypatch, caplog):
     assert "Unknown killstreak effect id" in text
     assert "Wear value out of range" in text
     assert "Invalid kill-eater value" in text
-    assert "Unknown kill-eater index" in text
     assert "Invalid kill-eater defindex" in text

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -473,8 +473,6 @@ def _extract_kill_eater_info(
                 types[(idx - 380) // 2 + 2] = val
         elif idx in (214, 292):
             pass
-        else:
-            logger.warning("Unknown kill-eater index: %s", idx)
 
     return counts, types
 


### PR DESCRIPTION
## Summary
- drop logging for unknown kill-eater attribute IDs
- adjust tests

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files utils/inventory_processor.py tests/test_enrichment.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686928ceba008326b700a19601151f94