### PR TITLE
Remove kill-eater warnings

### DIFF
--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -100,6 +100,3 @@ def test_unknown_values_warn(monkeypatch, caplog):
     assert "Unknown sheen id" in text
     assert "Unknown killstreak effect id" in text
     assert "Wear value out of range" in text
-    assert "Invalid kill-eater value" in text
-    assert "Unknown kill-eater index" in text
-    assert "Invalid kill-eater defindex" in text

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -447,7 +447,6 @@ def _extract_kill_eater_info(
         try:
             idx = int(idx_raw)
         except (TypeError, ValueError):
-            logger.warning("Invalid kill-eater defindex: %r", idx_raw)
             continue
 
         val_raw = (
@@ -456,7 +455,6 @@ def _extract_kill_eater_info(
         try:
             val = int(float(val_raw))
         except (TypeError, ValueError):
-            logger.warning("Invalid kill-eater value for %s: %r", idx, val_raw)
             continue
 
         if idx == 214:
@@ -473,8 +471,6 @@ def _extract_kill_eater_info(
                 types[(idx - 380) // 2 + 2] = val
         elif idx in (214, 292):
             pass
-        else:
-            logger.warning("Unknown kill-eater index: %s", idx)
 
     return counts, types
 


### PR DESCRIPTION
## Summary
- drop logging of invalid kill-eater values and defindexes
- update tests

## Testing
- `pre-commit` *(fails: environment lacks dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686928ceba008326b700a19601151f94