### PR TITLE
Remove extra kill-eater warnings

### DIFF
--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -100,5 +100,3 @@ def test_unknown_values_warn(monkeypatch, caplog):
     assert "Unknown sheen id" in text
     assert "Unknown killstreak effect id" in text
     assert "Wear value out of range" in text
-    assert "Invalid kill-eater value" in text
-    assert "Invalid kill-eater defindex" in text

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -447,7 +447,7 @@ def _extract_kill_eater_info(
         try:
             idx = int(idx_raw)
         except (TypeError, ValueError):
-            logger.warning("Invalid kill-eater defindex: %r", idx_raw)
+            # Ignore non-numeric defindex values
             continue
 
         val_raw = (
@@ -456,7 +456,7 @@ def _extract_kill_eater_info(
         try:
             val = int(float(val_raw))
         except (TypeError, ValueError):
-            logger.warning("Invalid kill-eater value for %s: %r", idx, val_raw)
+            # Ignore non-numeric values
             continue
 
         if idx == 214:


### PR DESCRIPTION
## Summary
- ignore malformed kill-eater defindexes and values instead of logging
- update tests accordingly

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files utils/inventory_processor.py tests/test_enrichment.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68692d662e308326bc7bf398ae332e55