### PR TITLE
Implement item stacking

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -167,6 +167,17 @@ button {
   pointer-events:none;
   font-size:14px;
 }
+.item-qty{
+  position:absolute;
+  left:2px;
+  bottom:2px;
+  background:rgba(0,0,0,0.6);
+  color:#fff;
+  padding:0 3px;
+  border-radius:4px;
+  font-size:12px;
+  pointer-events:none;
+}
 .item-badges .badge{
   filter:drop-shadow(0 0 2px #0008);
 }

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -14,6 +14,9 @@
       <span class="badge bg-indigo-600" title="Contains Strange Parts">🔧</span>
     {% endif %}
   </div>
+  {% if item.quantity and item.quantity > 1 %}
+    <span class="item-qty">x{{ item.quantity }}</span>
+  {% endif %}
   {% if item.image_url %}
     <img class="item-img" src="{{ item.image_url }}" alt="{{ item.name }}" width="64" height="64" onerror="this.style.display='none';">
   {% else %}

--- a/tests/test_quantity_badge.py
+++ b/tests/test_quantity_badge.py
@@ -1,0 +1,39 @@
+import importlib
+from flask import render_template_string
+from bs4 import BeautifulSoup
+
+HTML = '{% include "_user.html" %}'
+
+
+def test_stack_items_collapses_duplicates():
+    mod = importlib.import_module("app")
+    items = [
+        {"name": "Key", "image_url": "", "quality_color": "#fff"},
+        {"name": "Key", "image_url": "", "quality_color": "#fff", "level": 10},
+    ]
+    result = mod.stack_items(items)
+    assert len(result) == 1
+    assert result[0]["quantity"] == 2
+
+
+def test_quantity_badge_rendered(monkeypatch):
+    monkeypatch.setenv("STEAM_API_KEY", "x")
+    monkeypatch.setattr("utils.local_data.load_files", lambda *a, **k: ({}, {}))
+    mod = importlib.import_module("app")
+    importlib.reload(mod)
+    item = {"name": "Key", "image_url": "", "quality_color": "#fff", "quantity": 3}
+    user = {
+        "steamid": "1",
+        "profile": "",
+        "avatar": "",
+        "username": "Test",
+        "playtime": 0,
+        "status": "parsed",
+        "items": [item],
+    }
+    with mod.app.app_context():
+        user_ns = mod.normalize_user_payload(user)
+        html = render_template_string(HTML, user=user_ns)
+    soup = BeautifulSoup(html, "html.parser")
+    badge = soup.find("span", class_="item-qty")
+    assert badge.text.strip() == "x3"


### PR DESCRIPTION
## Summary
- allow stacking duplicate inventory items in the UI
- show quantity badge on item cards
- style badge overlay
- test collapse logic and badge rendering

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files app.py templates/item_card.html static/style.css tests/test_quantity_badge.py`
- `STEAM_API_KEY=test pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68693437dcbc83269d94799134505ef7