### PR TITLE
Filter hidden items in user template

### DIFF
--- a/templates/_user.html
+++ b/templates/_user.html
@@ -26,7 +26,7 @@
         <i class="fa-solid fa-chevron-left"></i>
       </button>
       <div class="inventory-container">
-        {% for item in user.items %}
+        {% for item in user.items if not item._hidden %}
           {# ↑ keep border-color for quality #}
           {% include "item_card.html" %}
         {% endfor %}

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -38,3 +38,28 @@ def test_post_valid_ids_sets_initial_ids(app):
     html = resp.get_data(as_text=True)
     assert steamid in html
     assert "window.initialIds" in html
+
+
+def test_hidden_items_not_rendered(app):
+    mod = importlib.import_module("app")
+    user = mod.normalize_user_payload(
+        {
+            "steamid": "1",
+            "avatar": "",
+            "username": "Test",
+            "playtime": 0,
+            "status": "parsed",
+            "items": [
+                {"name": "Visible", "image_url": ""},
+                {"name": "Hid", "image_url": "", "_hidden": True},
+            ],
+        }
+    )
+    app.config["PRELOADED_USERS"] = [user]
+    app.config["TEST_STEAMID"] = "1"
+    client = app.test_client()
+    resp = client.get("/")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert "Visible" in html
+    assert "Hid" not in html

--- a/tests/test_user_template.py
+++ b/tests/test_user_template.py
@@ -77,3 +77,20 @@ def test_user_template_renders_paint_spell_badge(app):
         context["user"] = app_module.normalize_user_payload(context["user"])
         html = render_template_string(HTML, **context)
     assert "🖌" in html
+
+
+def test_user_template_filters_hidden_items(app):
+    context = {
+        "user": {
+            "items": [
+                {"name": "Vis", "image_url": ""},
+                {"name": "Hidden", "image_url": "", "_hidden": True},
+            ]
+        }
+    }
+    with app.app_context():
+        app_module = importlib.import_module("app")
+        context["user"] = app_module.normalize_user_payload(context["user"])
+        html = render_template_string(HTML, **context)
+    assert "Vis" in html
+    assert "Hidden" not in html


### PR DESCRIPTION
## Summary
- avoid rendering hidden items in `_user.html`
- add tests ensuring hidden items are skipped

## Testing
- `pre-commit run --files templates/_user.html tests/test_user_template.py tests/test_flask_routes.py`
- `pytest tests/test_user_template.py::test_user_template_filters_hidden_items -q`
- `pytest tests/test_flask_routes.py::test_hidden_items_not_rendered -q`


------
https://chatgpt.com/codex/tasks/task_e_68693da968e08326914341d93dd07958