### PR TITLE
Add unusual effect display

### DIFF
--- a/static/modal.js
+++ b/static/modal.js
@@ -77,6 +77,15 @@
       attrs.push('<div>' + ksHtml + '</div>');
     }
 
+    if (data.unusual_effect) {
+      const name = typeof data.unusual_effect === 'object'
+        ? data.unusual_effect.name
+        : data.unusual_effect;
+      if (name) {
+        attrs.push('<div><strong>Unusual Effect:</strong> ' + esc(name) + '</div>');
+      }
+    }
+
     ;[
       ['Type', data.item_type_name],
       ['Level', data.level],
@@ -139,7 +148,15 @@
     const title = document.getElementById('modal-title');
     const effectBox = document.getElementById('modal-effect');
     if (title) title.textContent = data.custom_name || data.name || '';
-    if (effectBox) effectBox.textContent = data.unusual_effect || '';
+    let effectText = '';
+    if (data.unusual_effect) {
+      if (typeof data.unusual_effect === 'object') {
+        effectText = data.unusual_effect.name || '';
+      } else {
+        effectText = data.unusual_effect;
+      }
+    }
+    if (effectBox) effectBox.textContent = effectText;
   }
 
   function renderBadges(badges) {

--- a/static/style.css
+++ b/static/style.css
@@ -203,6 +203,11 @@ button {
   filter:drop-shadow(0 0 2px #A156D6);
 }
 .ks-effect{color:#ff7e30;font-weight:bold;}
+.unusual-effect {
+  font-weight: bold;
+  color: #8650AC;
+  margin-right: 4px;
+}
 .item-img {
   max-width: 64px;
   max-height: 64px;
@@ -218,6 +223,13 @@ button {
 }
 
 .item-name {
+  font-size: 12px;
+  text-align: center;
+  word-break: break-word;
+  color: #fff;
+}
+
+.item-title {
   font-size: 12px;
   text-align: center;
   word-break: break-word;

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -22,7 +22,12 @@
   {% else %}
     <div class="missing-icon"></div>
   {% endif %}
-  <div class="item-name">{{ item.name }}</div>
+  <div class="item-title">
+    {% if item.unusual_effect %}
+      <span class="unusual-effect">{{ item.unusual_effect.name }}</span>
+    {% endif %}
+    {{ item.name }}
+  </div>
   {% if item.strange_parts %}
     <ul class="text-xs mt-1 text-gray-300">
       {% for part in item.strange_parts %}

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -142,6 +142,23 @@ def test_unusual_effect_quality_filter(monkeypatch):
     assert items[0]["unusual_effect"] is None
 
 
+def test_unusual_effect_attribute_object():
+    data = {
+        "items": [
+            {
+                "defindex": 700,
+                "quality": 5,
+                "attributes": [{"defindex": 134, "float_value": 13}],
+            }
+        ]
+    }
+    ld.ITEMS_BY_DEFINDEX = {700: {"item_name": "Hat", "image_url": ""}}
+    ld.QUALITIES_BY_INDEX = {5: "Unusual"}
+    ld.EFFECT_NAMES = {"13": "Burning Flames"}
+    items = ip.enrich_inventory(data)
+    assert items[0]["unusual_effect"] == {"id": 13, "name": "Burning Flames"}
+
+
 def test_get_inventories_adds_user_agent(monkeypatch):
     captured = {}
 

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -631,6 +631,18 @@ def _process_item(asset: dict) -> dict | None:
 
     badges: List[Dict[str, str]] = []
     effect = _extract_unusual_effect(asset)
+    effect_obj: Dict[str, Any] | None = None
+    for attr in asset.get("attributes", []):
+        if attr.get("defindex") == 134:
+            try:
+                effect_id = int(attr.get("float_value", 0))
+            except (TypeError, ValueError):
+                effect_id = 0
+            effect_name = local_data.EFFECT_NAMES.get(str(effect_id))
+            if effect_name:
+                effect_obj = {"id": effect_id, "name": effect_name}
+                effect = effect_name
+            break
     if effect and quality_id in (5, 11):
         badges.append(
             {
@@ -697,7 +709,11 @@ def _process_item(asset: dict) -> dict | None:
         "origin": ORIGIN_MAP.get(asset.get("origin")),
         "custom_name": asset.get("custom_name"),
         "custom_description": asset.get("custom_desc"),
-        "unusual_effect": effect if quality_id in (5, 11) else None,
+        "unusual_effect": (
+            (effect_obj if effect_obj is not None else effect)
+            if quality_id in (5, 11)
+            else None
+        ),
         "killstreak_tier": ks_tier,
         "sheen": sheen,
         "paint_name": paint_name,


### PR DESCRIPTION
## Summary
- enrich unusual effect details by ID and name
- show effect name on item cards and in modals
- style unusual effect label
- test unusual effect attribute parsing

## Testing
- `pre-commit run --files utils/inventory_processor.py templates/item_card.html static/style.css static/modal.js tests/test_inventory_processor.py`


------
https://chatgpt.com/codex/tasks/task_e_68694649d7088326b0d8148ba88a395d