### PR TITLE
Fix unusual effect display for strange items

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -54,7 +54,7 @@ def test_enrich_inventory_unusual_effect():
     "quality,expected",
     [
         (5, True),
-        (11, False),
+        (11, True),
         (6, False),
     ],
 )

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -114,14 +114,14 @@ QUALITY_MAP = {
 
 
 def _extract_unusual_effect(asset: Dict[str, Any]) -> str | None:
-    """Return the unusual effect name for an Unusual-quality item."""
+    """Return the unusual effect name for Unusual or Strange Unusual items."""
 
     try:
         quality = int(asset.get("quality", 0))
     except (TypeError, ValueError):
         return None
 
-    if quality != 5:
+    if quality not in (5, 11):
         return None
 
     for attr in asset.get("attributes", []):


### PR DESCRIPTION
## Summary
- ensure `_extract_unusual_effect` handles Strange Unusual items
- update tests for new behaviour

## Testing
- `pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py`
- `pytest -q tests/test_inventory_processor.py::test_unusual_effect_only_for_allowed_qualities -q`

------
https://chatgpt.com/codex/tasks/task_e_686953c005e0832697e9e2695062fd4e