### PR TITLE
Fix unusual effect enrichment

### DIFF
--- a/templates/_modal.html
+++ b/templates/_modal.html
@@ -1,0 +1,5 @@
+<div class="modal-content">
+  {% if item.unusual_effect_name %}
+    <div>Unusual Effect: {{ item.unusual_effect_name }}</div>
+  {% endif %}
+</div>

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -23,8 +23,8 @@
     <div class="missing-icon"></div>
   {% endif %}
   <div class="item-title">
-    {% if item.unusual_effect %}
-      <strong>{{ item.unusual_effect.name }} {{ item.name }}</strong>
+    {% if item.unusual_effect_name %}
+      <strong>{{ item.unusual_effect_name }} {{ item.name }}</strong>
     {% else %}
       {{ item.name }}
     {% endif %}

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -624,7 +624,11 @@ def _process_item(asset: dict) -> dict | None:
 
     badges: List[Dict[str, str]] = []
     effect = _extract_unusual_effect(asset)
-    effect_name = effect.get("name") if isinstance(effect, dict) else None
+    effect_id = None
+    effect_name = None
+    if isinstance(effect, dict):
+        effect_id = effect.get("id")
+        effect_name = effect.get("name")
     display_name = f"{effect_name} {base_name}" if effect_name else base_name
     if effect_name:
         badges.append(
@@ -694,6 +698,8 @@ def _process_item(asset: dict) -> dict | None:
         "custom_name": asset.get("custom_name"),
         "custom_description": asset.get("custom_desc"),
         "unusual_effect": effect,
+        "unusual_effect_id": effect_id,
+        "unusual_effect_name": effect_name,
         "killstreak_tier": ks_tier,
         "sheen": sheen,
         "paint_name": paint_name,


### PR DESCRIPTION
## Summary
- support unusual effect id & name fields in item enrichment
- display unusual effect on item cards
- add partial for modal information

## Testing
- `pre-commit run --files utils/inventory_processor.py templates/item_card.html templates/_modal.html`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686961e0a5108326b079efe7117ade19