### PR TITLE
Fix Unusual effect detection and templates

### DIFF
--- a/templates/_modal.html
+++ b/templates/_modal.html
@@ -1,5 +1,5 @@
 <div class="modal-content">
   {% if item.unusual_effect_name %}
-    <div>Unusual Effect: {{ item.unusual_effect_name }}</div>
+    <p><strong>Unusual Effect:</strong> {{ item.unusual_effect_name }}</p>
   {% endif %}
 </div>

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -24,9 +24,9 @@
   {% endif %}
   <div class="item-title">
     {% if item.unusual_effect_name %}
-      <strong>{{ item.unusual_effect_name }} {{ item.name }}</strong>
+        {{ item.unusual_effect_name }} {{ item.display_name }}
     {% else %}
-      {{ item.name }}
+        {{ item.display_name }}
     {% endif %}
   </div>
   {% if item.strange_parts %}

--- a/tests/test_unusual_effect_extraction.py
+++ b/tests/test_unusual_effect_extraction.py
@@ -1,0 +1,18 @@
+from utils.inventory_processor import _extract_unusual_effect, EFFECTS_MAP
+
+
+def test_extract_unusual_effect_cosmetic():
+    EFFECTS_MAP[350] = "Spectral Fire"
+    asset = {"quality": 5, "attributes": [{"defindex": 134, "float_value": 350}]}
+    assert _extract_unusual_effect(asset) == {"id": 350, "name": "Spectral Fire"}
+
+
+def test_extract_unusual_effect_taunt():
+    EFFECTS_MAP[510] = "Test Name"
+    asset = {"quality": 5, "attributes": [{"defindex": 2041, "value": 510}]}
+    assert _extract_unusual_effect(asset) == {"id": 510, "name": EFFECTS_MAP[510]}
+
+
+def test_no_effect():
+    asset = {"quality": 5, "attributes": []}
+    assert _extract_unusual_effect(asset) is None


### PR DESCRIPTION
## Summary
- refresh unusual effect lookup to cover cosmetics and taunts
- display effect name separately in item card and modal
- add regression tests for unusual effect extraction

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files utils/inventory_processor.py templates/item_card.html templates/_modal.html tests/test_unusual_effect_extraction.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68696500363883268f84ced946b7dafa