### PR TITLE
Improve unusual effect detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ cache/*
 !cache/schema/
 cache/schema/*
 !cache/schema/parts.json
+!cache/schema/effects.json
 .venv/
 .coverage

--- a/cache/schema/effects.json
+++ b/cache/schema/effects.json
@@ -1,0 +1,6 @@
+{
+  "13": "Burning Flames",
+  "14": "Scorching Flames",
+  "350": "Spectral Fire",
+  "510": "Test Name"
+}

--- a/tests/test_unusual_effect_extraction.py
+++ b/tests/test_unusual_effect_extraction.py
@@ -7,10 +7,10 @@ def test_extract_unusual_effect_cosmetic():
     assert _extract_unusual_effect(asset) == {"id": 350, "name": "Spectral Fire"}
 
 
-def test_extract_unusual_effect_taunt():
+def test_ignore_defindex_2041():
     EFFECTS_MAP[510] = "Test Name"
     asset = {"quality": 5, "attributes": [{"defindex": 2041, "value": 510}]}
-    assert _extract_unusual_effect(asset) == {"id": 510, "name": EFFECTS_MAP[510]}
+    assert _extract_unusual_effect(asset) is None
 
 
 def test_no_effect():

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -132,30 +132,21 @@ def _extract_unusual_effect(asset: Dict[str, Any]) -> dict | None:
         except (TypeError, ValueError):
             continue
 
-        effect_id = None
-        if idx_int == 134:
-            raw = attr.get("float_value")
-            if raw is None:
-                continue
-            try:
-                effect_id = int(raw)
-            except (TypeError, ValueError):
-                continue
-        elif idx_int == 2041:
-            raw = attr.get("value")
-            if raw is None:
-                continue
-            try:
-                effect_id = int(raw)
-            except (TypeError, ValueError):
-                continue
-
-        if effect_id is None:
+        if idx_int != 134:
             continue
 
-        effect_name = EFFECTS_MAP.get(effect_id)
-        if effect_name is None:
-            effect_name = getattr(local_data, "EFFECT_NAMES", {}).get(str(effect_id))
+        raw = attr.get("float_value")
+        if raw is None:
+            raw = attr.get("value")
+
+        try:
+            effect_id = int(float(raw))
+        except (TypeError, ValueError):
+            continue
+
+        effect_name = local_data.EFFECT_NAMES.get(str(effect_id)) or EFFECTS_MAP.get(
+            effect_id
+        )
         return {"id": effect_id, "name": effect_name}
 
     return None


### PR DESCRIPTION
## Summary
- allow `cache/schema/effects.json` to be tracked
- use effect ID lookup from `effects.json`
- drop legacy handling for defindex 2041
- update unusual effect unit tests

## Testing
- `ruff check utils/inventory_processor.py tests/test_unusual_effect_extraction.py`
- `pytest -k unusual_effect_extraction -q` *(fails to run full suite due to missing deps)*
- `pre-commit run --files utils/inventory_processor.py tests/test_unusual_effect_extraction.py` *(fails: missing schema data)*

------
https://chatgpt.com/codex/tasks/task_e_68696f12c30883269481d6b7c1e60964