### PR TITLE
Display unusual effects

### DIFF
--- a/templates/_modal.html
+++ b/templates/_modal.html
@@ -1,5 +1,7 @@
 <div class="modal-content">
   {% if item.unusual_effect_name %}
-    <p><strong>Unusual Effect:</strong> {{ item.unusual_effect_name }}</p>
+    <p><strong>Unusual Effect:</strong>
+      <span class="unusual-effect">{{ item.unusual_effect_name }}</span>
+    </p>
   {% endif %}
 </div>

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -24,9 +24,10 @@
   {% endif %}
   <div class="item-title">
     {% if item.unusual_effect_name %}
-        {{ item.unusual_effect_name }} {{ item.display_name }}
+      <span class="unusual-effect">{{ item.unusual_effect_name }}</span>
+      {{ item.name }}
     {% else %}
-        {{ item.display_name }}
+      {{ item.name }}
     {% endif %}
   </div>
   {% if item.strange_parts %}

--- a/tests/test_user_template.py
+++ b/tests/test_user_template.py
@@ -2,6 +2,7 @@ import importlib
 
 import pytest
 from flask import render_template_string
+from bs4 import BeautifulSoup
 
 HTML = '{% include "_user.html" %}'
 
@@ -94,3 +95,27 @@ def test_user_template_filters_hidden_items(app):
         html = render_template_string(HTML, **context)
     assert "Vis" in html
     assert "Hidden" not in html
+
+
+def test_unusual_effect_rendered(app):
+    context = {
+        "user": {
+            "items": [
+                {
+                    "name": "Unusual Cap",
+                    "display_name": "Burning Flames Cap",
+                    "unusual_effect_name": "Burning Flames",
+                    "image_url": "",
+                    "quality_color": "#fff",
+                }
+            ]
+        }
+    }
+    with app.app_context():
+        app_module = importlib.import_module("app")
+        context["user"] = app_module.normalize_user_payload(context["user"])
+        html = render_template_string(HTML, **context)
+    soup = BeautifulSoup(html, "html.parser")
+    span = soup.find("span", class_="unusual-effect")
+    assert span is not None
+    assert "Burning Flames" in span.text


### PR DESCRIPTION
## Summary
- display unusual effects with a purple label in item cards and modals
- add test verifying effect label is rendered in user template

## Testing
- `pre-commit run --files templates/item_card.html templates/_modal.html tests/test_user_template.py` *(fails: Missing schema)*
- `pytest -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68697302bd4c8326830f73ee5595cea7