### PR TITLE
Add star effect badge

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -186,6 +186,11 @@ button {
   filter:drop-shadow(0 0 3px #ff7e30);
 }
 
+.badge[data-icon="★"]{
+  color:#8650AC;
+  filter:drop-shadow(0 0 2px #8650AC);
+}
+
 /* Killstreak chevrons */
 .badge[data-icon="›"],
 .badge[data-icon="››"],

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -51,6 +51,31 @@ def test_enrich_inventory_unusual_effect():
     assert item["quality"] == "Unusual"
 
 
+def test_unusual_effect_badge_included():
+    data = {
+        "items": [
+            {
+                "defindex": 7000,
+                "quality": 5,
+                "attributes": [{"defindex": 134, "float_value": 13}],
+            }
+        ]
+    }
+    ld.ITEMS_BY_DEFINDEX = {7000: {"item_name": "Hat", "image_url": ""}}
+    ld.QUALITIES_BY_INDEX = {5: "Unusual"}
+    ld.EFFECT_NAMES = {"13": "Burning Flames"}
+
+    items = ip.enrich_inventory(data)
+    badges = items[0]["badges"]
+    assert {
+        "icon": "★",
+        "title": "Unusual Effect: Burning Flames",
+        "color": "#8650AC",
+        "label": "Burning Flames",
+        "type": "effect",
+    } in badges
+
+
 @pytest.mark.parametrize(
     "quality,expected",
     [

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -640,7 +640,16 @@ def _process_item(asset: dict) -> dict | None:
         effect_id = effect_info["id"]
         effect_name = effect_info["name"]
         effect = effect_info
-        badges.append({"type": "effect", "label": effect_name})
+        if effect_name:
+            badges.append(
+                {
+                    "icon": "★",
+                    "title": f"Unusual Effect: {effect_name}",
+                    "color": "#8650AC",
+                    "label": effect_name,
+                    "type": "effect",
+                }
+            )
     else:
         effect = None
         effect_id = effect_name = None


### PR DESCRIPTION
## Summary
- show a star badge for unusual effect items
- style the star badge in CSS
- test badge generation for unusual effects

## Testing
- `pre-commit run --files utils/inventory_processor.py static/style.css tests/test_inventory_processor.py`

------
https://chatgpt.com/codex/tasks/task_e_6869862b31f48326b2110fc7303d4fea