### PR TITLE
Update item name formatting for Unusuals

### DIFF
--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -22,14 +22,7 @@
   {% else %}
     <div class="missing-icon"></div>
   {% endif %}
-  <div class="item-title">
-    {% if item.unusual_effect_name %}
-      <span class="unusual-effect">{{ item.unusual_effect_name }}</span>
-      {{ item.name }}
-    {% else %}
-      {{ item.name }}
-    {% endif %}
-  </div>
+  <h2 class="item-title">{{ item.name }}</h2>
   {% if item.strange_parts %}
     <ul class="text-xs mt-1 text-gray-300">
       {% for part in item.strange_parts %}

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -45,7 +45,8 @@ def test_enrich_inventory_unusual_effect():
     ld.EFFECT_NAMES = {"13": "Burning Flames"}
     items = ip.enrich_inventory(data)
     item = items[0]
-    assert item["name"] == "Unusual Team Captain"
+    assert item["name"] == "Burning Flames Team Captain"
+    assert item["original_name"] == "Unusual Team Captain"
     assert item["display_name"] == "Burning Flames Team Captain"
     assert item["unusual_effect"] == {"id": 13, "name": "Burning Flames"}
     assert item["quality"] == "Unusual"

--- a/tests/test_user_template.py
+++ b/tests/test_user_template.py
@@ -102,7 +102,8 @@ def test_unusual_effect_rendered(app):
         "user": {
             "items": [
                 {
-                    "name": "Unusual Cap",
+                    "name": "Burning Flames Cap",
+                    "original_name": "Unusual Cap",
                     "display_name": "Burning Flames Cap",
                     "unusual_effect_name": "Burning Flames",
                     "image_url": "",
@@ -117,5 +118,7 @@ def test_unusual_effect_rendered(app):
         html = render_template_string(HTML, **context)
     soup = BeautifulSoup(html, "html.parser")
     span = soup.find("span", class_="unusual-effect")
-    assert span is not None
-    assert "Burning Flames" in span.text
+    assert span is None
+    title = soup.find("h2", class_="item-title")
+    assert title is not None
+    assert title.text.strip().startswith("Burning Flames")

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -656,6 +656,9 @@ def _process_item(asset: dict) -> dict | None:
     # ----------------------------------------------------------------------
 
     display_name = f"{base_name}" if not effect_name else f"{effect_name} {base_name}"
+    original_name = name if effect_name else None
+    if effect_name:
+        name = display_name
     if ks_tier_val:
         tier_id = int(float(ks_tier_val))
         icon = KILLSTREAK_BADGE_ICONS.get(tier_id)
@@ -694,6 +697,8 @@ def _process_item(asset: dict) -> dict | None:
     item = {
         "defindex": defindex,
         "name": name,
+        "original_name": original_name,
+        "base_name": base_name,
         "display_name": display_name,
         "quality": q_name,
         "quality_color": q_col,


### PR DESCRIPTION
## Summary
- prefix Unusual item names with their effect inside `_process_item`
- simplify markup in `item_card.html`
- adjust tests to expect effect-prefixed names

## Testing
- `pre-commit run --files utils/inventory_processor.py templates/item_card.html tests/test_inventory_processor.py tests/test_user_template.py`

------
https://chatgpt.com/codex/tasks/task_e_68698c3543f883269f57c9fadbc83ec0