### PR TITLE
Add Backpack.tf price caching module

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 STEAM_API_KEY=your_steam_key_here
+BPTF_API_KEY=your_backpack_key_here

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A Flask web app that inspects one or more Steam users' Team Fortress 2 inventori
    ```bash
    cp .env.example .env
    # edit .env and set STEAM_API_KEY=<your key>
+   # and BPTF_API_KEY=<your backpack.tf key>
    ```
    The app uses **python-dotenv** to load variables at runtime.
 

--- a/tests/test_price_loader.py
+++ b/tests/test_price_loader.py
@@ -1,0 +1,48 @@
+import responses
+import pytest
+
+from utils import price_loader
+
+
+def test_price_map_smoke(tmp_path, monkeypatch):
+    monkeypatch.setenv("BPTF_API_KEY", "TEST")
+    monkeypatch.setattr(price_loader, "PRICES_FILE", tmp_path / "prices.json")
+    url = "https://backpack.tf/api/IGetPrices/v4?raw=1&key=TEST"
+    payload = {
+        "response": {
+            "success": 1,
+            "items": {
+                "Mann Co. Supply Crate Key": {
+                    "defindex": [5021],
+                    "prices": {
+                        "6": {
+                            "Tradable": {
+                                "Craftable": [
+                                    {
+                                        "value": 57,
+                                        "value_raw": 57.0,
+                                        "currency": "metal",
+                                        "last_update": 0,
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                }
+            },
+        }
+    }
+
+    with responses.RequestsMock() as rsps:
+        rsps.add(responses.GET, url, json=payload, status=200)
+        p = price_loader.ensure_prices_cached(refresh=True)
+
+    mapping = price_loader.build_price_map(p)
+    assert (5021, 6) in mapping
+    assert mapping[(5021, 6)]["currency"] == "metal"
+
+
+def test_missing_api_key(monkeypatch):
+    monkeypatch.delenv("BPTF_API_KEY", raising=False)
+    with pytest.raises(RuntimeError):
+        price_loader.ensure_prices_cached(refresh=True)

--- a/utils/price_loader.py
+++ b/utils/price_loader.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+PRICES_FILE = Path("cache/prices.json")
+
+
+def _require_key() -> str:
+    key = os.getenv("BPTF_API_KEY")
+    if not key:
+        raise RuntimeError(
+            "BPTF_API_KEY is required. Set it in the environment or .env file."
+        )
+    return key
+
+
+def ensure_prices_cached(refresh: bool = False) -> Path:
+    """Download price dump from backpack.tf if needed and return cache path."""
+
+    path = PRICES_FILE
+    if path.exists() and not refresh:
+        return path
+
+    url = f"https://backpack.tf/api/IGetPrices/v4?raw=1&key={_require_key()}"
+    try:
+        resp = requests.get(url, timeout=5, headers={"accept": "application/json"})
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as exc:  # requests or JSON
+        logger.warning("Failed to fetch prices: %s", exc)
+        if path.exists():
+            return path
+        raise RuntimeError("Cannot fetch Backpack.tf prices") from exc
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2))
+    return path
+
+
+def build_price_map(prices_path: Path) -> dict[tuple[int, int], dict]:
+    """Return mapping of (defindex, quality) -> price info."""
+
+    with prices_path.open() as f:
+        data = json.load(f)
+
+    items = data.get("response", {}).get("items", {})
+    mapping: dict[tuple[int, int], dict] = {}
+
+    for item in items.values():
+        defindexes = item.get("defindex") or []
+        prices = item.get("prices", {})
+        for quality, qdata in prices.items():
+            try:
+                qid = int(quality)
+            except (TypeError, ValueError):
+                continue
+            craftable = qdata.get("Tradable", {}).get("Craftable")
+            entry = craftable[0] if isinstance(craftable, list) else None
+            if not isinstance(entry, dict):
+                continue
+            value_raw = entry.get("value_raw")
+            currency = entry.get("currency")
+            if value_raw is None or currency is None:
+                continue
+            for defi in defindexes:
+                try:
+                    idx = int(defi)
+                except (TypeError, ValueError):
+                    continue
+                mapping[(idx, qid)] = {
+                    "value_raw": float(value_raw),
+                    "currency": str(currency),
+                }
+    return mapping


### PR DESCRIPTION
## Summary
- implement price loader with dotenv and requests
- document BPTF_API_KEY in README and .env.example
- include unit tests for price cache logic

## Testing
- `pre-commit run --files utils/price_loader.py tests/test_price_loader.py README.md .env.example` *(fails: pytest errors due to missing schema)*
- `pytest tests/test_price_loader.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6869fb75744083268c222123a97f998f