### PR TITLE
Handle Backpack.tf price cache

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,16 @@ def app(monkeypatch):
     """Return Flask app with env and schema mocks."""
 
     monkeypatch.setenv("STEAM_API_KEY", "x")
+    monkeypatch.setenv("BPTF_API_KEY", "x")
     monkeypatch.setattr("utils.local_data.load_files", lambda *a, **k: ({}, {}))
+    monkeypatch.setattr(
+        "utils.price_loader.ensure_prices_cached",
+        lambda refresh=False: Path("prices.json"),
+    )
+    monkeypatch.setattr(
+        "utils.price_loader.build_price_map",
+        lambda path: {},
+    )
 
     mod = importlib.import_module("app")
     importlib.reload(mod)

--- a/tests/test_app_import.py
+++ b/tests/test_app_import.py
@@ -1,4 +1,5 @@
 import importlib
+from pathlib import Path
 
 
 def test_app_uses_mock_schema(monkeypatch):
@@ -15,5 +16,14 @@ def test_app_uses_mock_schema(monkeypatch):
 
     monkeypatch.setattr("utils.local_data.load_files", fake_load)
     monkeypatch.setenv("STEAM_API_KEY", "x")
+    monkeypatch.setenv("BPTF_API_KEY", "x")
+    monkeypatch.setattr(
+        "utils.price_loader.ensure_prices_cached",
+        lambda refresh=False: Path("prices.json"),
+    )
+    monkeypatch.setattr(
+        "utils.price_loader.build_price_map",
+        lambda path: {},
+    )
     app = importlib.import_module("app")
     assert hasattr(app, "app")

--- a/tests/test_app_refresh.py
+++ b/tests/test_app_refresh.py
@@ -1,13 +1,15 @@
 import importlib
 import sys
+from pathlib import Path
 
 import pytest
 
 
 def test_refresh_flag_triggers_update(monkeypatch, capsys):
-    called = {"schema": None}
+    called = {"schema": None, "prices": False}
 
     monkeypatch.setenv("STEAM_API_KEY", "x")
+    monkeypatch.setenv("BPTF_API_KEY", "x")
     monkeypatch.setattr("pathlib.Path.write_text", lambda self, text: None)
     monkeypatch.setattr(
         "pathlib.Path.mkdir", lambda self, parents=True, exist_ok=True: None
@@ -22,6 +24,10 @@ def test_refresh_flag_triggers_update(monkeypatch, capsys):
     monkeypatch.setattr(
         "utils.schema_provider.SchemaProvider.refresh_all", fake_refresh
     )
+    monkeypatch.setattr(
+        "utils.price_loader.ensure_prices_cached",
+        lambda refresh=True: called.__setitem__("prices", True) or Path("prices.json"),
+    )
     monkeypatch.setattr(sys, "argv", ["app.py", "--refresh", "--verbose"])
     sys.modules.pop("app", None)
     with pytest.raises(SystemExit):
@@ -30,3 +36,4 @@ def test_refresh_flag_triggers_update(monkeypatch, capsys):
     assert "Fetching items..." in out
     assert "✓ Saved cache/schema/items.json (0 entries)" in out
     assert called["schema"] is True
+    assert called["prices"] is True

--- a/tests/test_user_badges.py
+++ b/tests/test_user_badges.py
@@ -1,5 +1,6 @@
 import importlib
 import json
+from pathlib import Path
 
 import pytest
 from flask import render_template_string
@@ -11,7 +12,16 @@ HTML = '{% include "_user.html" %}'
 @pytest.fixture
 def app(monkeypatch):
     monkeypatch.setenv("STEAM_API_KEY", "x")
+    monkeypatch.setenv("BPTF_API_KEY", "x")
     monkeypatch.setattr("utils.local_data.load_files", lambda *a, **k: ({}, {}))
+    monkeypatch.setattr(
+        "utils.price_loader.ensure_prices_cached",
+        lambda refresh=False: Path("prices.json"),
+    )
+    monkeypatch.setattr(
+        "utils.price_loader.build_price_map",
+        lambda path: {},
+    )
     mod = importlib.import_module("app")
     importlib.reload(mod)
     return mod.app

--- a/tests/test_user_template.py
+++ b/tests/test_user_template.py
@@ -1,4 +1,5 @@
 import importlib
+from pathlib import Path
 
 import pytest
 from flask import render_template_string
@@ -10,7 +11,16 @@ HTML = '{% include "_user.html" %}'
 @pytest.fixture
 def app(monkeypatch):
     monkeypatch.setenv("STEAM_API_KEY", "x")
+    monkeypatch.setenv("BPTF_API_KEY", "x")
     monkeypatch.setattr("utils.local_data.load_files", lambda *a, **k: ({}, {}))
+    monkeypatch.setattr(
+        "utils.price_loader.ensure_prices_cached",
+        lambda refresh=False: Path("prices.json"),
+    )
+    monkeypatch.setattr(
+        "utils.price_loader.build_price_map",
+        lambda path: {},
+    )
     mod = importlib.import_module("app")
     importlib.reload(mod)
     return mod.app

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -584,7 +584,9 @@ def _is_plain_craft_weapon(asset: dict, schema_entry: Dict[str, Any]) -> bool:
     return True
 
 
-def _process_item(asset: dict) -> dict | None:
+def _process_item(
+    asset: dict, price_map: dict[tuple[int, int], dict] | None = None
+) -> dict | None:
     """Return an enriched item dictionary for a single asset."""
 
     defindex_raw = asset.get("defindex", 0)
@@ -742,10 +744,16 @@ def _process_item(asset: dict) -> dict | None:
             else None
         ),
     }
+    if price_map is not None:
+        info = price_map.get((defindex_int, int(quality_id)))
+        if info:
+            item["price"] = info
     return item
 
 
-def enrich_inventory(data: Dict[str, Any]) -> List[Dict[str, Any]]:
+def enrich_inventory(
+    data: Dict[str, Any], price_map: dict[tuple[int, int], dict] | None = None
+) -> List[Dict[str, Any]]:
     """Return a list of inventory items enriched with schema info."""
     items_raw = data.get("items")
     if not isinstance(items_raw, list):
@@ -754,7 +762,7 @@ def enrich_inventory(data: Dict[str, Any]) -> List[Dict[str, Any]]:
     items: List[Dict[str, Any]] = []
 
     for asset in items_raw:
-        item = _process_item(asset)
+        item = _process_item(asset, price_map)
         if not item:
             continue
 
@@ -804,9 +812,11 @@ def enrich_inventory(data: Dict[str, Any]) -> List[Dict[str, Any]]:
     return items
 
 
-def process_inventory(data: Dict[str, Any]) -> List[Dict[str, Any]]:
+def process_inventory(
+    data: Dict[str, Any], price_map: dict[tuple[int, int], dict] | None = None
+) -> List[Dict[str, Any]]:
     """Public wrapper that sorts items by name."""
-    items = enrich_inventory(data)
+    items = enrich_inventory(data, price_map)
     return sorted(items, key=lambda i: i["name"])
 
 


### PR DESCRIPTION
## Summary
- import price loader utilities in `app.py`
- refresh Backpack.tf prices via `--refresh`
- load `prices.json` at startup and enrich inventories with `price_map`
- expose `price_map` support in `inventory_processor`
- update tests with price loader stubs

## Testing
- `pre-commit run --files app.py utils/inventory_processor.py tests/conftest.py tests/test_user_template.py tests/test_user_badges.py tests/test_app_refresh.py tests/test_app_import.py` *(fails: Missing schema files and pytest args)*

------
https://chatgpt.com/codex/tasks/task_e_686a0531455883268f7c146e42575590