### PR TITLE
Display item prices

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -241,6 +241,11 @@ button {
   color: #fff;
 }
 
+.item-price {
+  margin-top: 2px;
+  font-size: 12px;
+}
+
 /* ───── Paint colour dot (used in card & modal) ───────────────────── */
 .paint-dot {
   display: inline-block;

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -23,6 +23,9 @@
     <div class="missing-icon"></div>
   {% endif %}
   <h2 class="item-title">{{ item.name }}</h2>
+  {% if item.price_display %}
+    <div class="item-price">{{ item.price_display }}</div>
+  {% endif %}
   {% if item.strange_parts %}
     <ul class="text-xs mt-1 text-gray-300">
       {% for part in item.strange_parts %}

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -748,6 +748,15 @@ def _process_item(
         info = price_map.get((defindex_int, int(quality_id)))
         if info:
             item["price"] = info
+            value = info.get("value_raw")
+            currency = info.get("currency")
+            if value is not None and currency:
+                if currency == "metal":
+                    display_val = f"{value:.2f}".rstrip("0").rstrip(".")
+                    item["price_display"] = f"{display_val} ref"
+                else:
+                    display_val = f"{value:.2f}".rstrip("0").rstrip(".")
+                    item["price_display"] = f"{display_val} {currency}"
     return item
 
 


### PR DESCRIPTION
## Summary
- show item price in each item card
- style the new `.item-price` element
- compute and expose `price_display` for each item

## Testing
- `pre-commit run --files templates/item_card.html static/style.css utils/inventory_processor.py` *(fails: Missing schema files)*
- `pytest -q` *(fails: FileNotFoundError: cache/schema/strange_parts.json)*

------
https://chatgpt.com/codex/tasks/task_e_686a07a615208326b9348c3771a94316