### PR TITLE
Add price map support and tests

### DIFF
--- a/tests/test_env_loading.py
+++ b/tests/test_env_loading.py
@@ -1,5 +1,6 @@
 import importlib
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -14,6 +15,12 @@ def test_missing_env_vars_raises(monkeypatch):
 
 def test_env_present_allows_import(monkeypatch):
     monkeypatch.setenv("STEAM_API_KEY", "x")
+    monkeypatch.setenv("BPTF_API_KEY", "x")
+    monkeypatch.setattr(
+        "utils.price_loader.ensure_prices_cached",
+        lambda refresh=False: Path("prices.json"),
+    )
+    monkeypatch.setattr("utils.price_loader.build_price_map", lambda path: {})
     monkeypatch.setattr("utils.local_data.load_files", lambda *a, **k: ({}, {}))
     sys.modules.pop("app", None)
     importlib.import_module("app")

--- a/tests/test_quantity_badge.py
+++ b/tests/test_quantity_badge.py
@@ -1,4 +1,5 @@
 import importlib
+from pathlib import Path
 from flask import render_template_string
 from bs4 import BeautifulSoup
 
@@ -18,6 +19,12 @@ def test_stack_items_collapses_duplicates():
 
 def test_quantity_badge_rendered(monkeypatch):
     monkeypatch.setenv("STEAM_API_KEY", "x")
+    monkeypatch.setenv("BPTF_API_KEY", "x")
+    monkeypatch.setattr(
+        "utils.price_loader.ensure_prices_cached",
+        lambda refresh=False: Path("prices.json"),
+    )
+    monkeypatch.setattr("utils.price_loader.build_price_map", lambda path: {})
     monkeypatch.setattr("utils.local_data.load_files", lambda *a, **k: ({}, {}))
     mod = importlib.import_module("app")
     importlib.reload(mod)


### PR DESCRIPTION
## Summary
- gracefully handle missing `strange_parts.json`
- document new `price_map` parameter in `inventory_processor`
- test price map integration
- ensure tests importing `app` set a dummy Backpack.tf API key

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py tests/test_env_loading.py tests/test_quantity_badge.py`

------
https://chatgpt.com/codex/tasks/task_e_686a08c346448326a698c1bcaec6b7fe