### PR TITLE
Update README with test setup details

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,19 @@ pytest --cov=utils --cov=app
 ```
 HTML coverage is written to `htmlcov/`.
 
+## Test Suite
+
+Running the full test suite requires the additional packages listed in
+`requirements-test.txt`. Install them alongside the main requirements before
+invoking `pytest`.
+
+Many tests also expect cached schema files under `cache/schema/`. You can refresh
+these files with:
+
+```bash
+python app.py --refresh
+```
+
 ## Docker / Deployment
 
 Build and run the container locally:


### PR DESCRIPTION
## Summary
- document that running tests uses dependencies from `requirements-test.txt`
- note that many tests require cached schema files and how to fetch them

## Testing
- `pre-commit run --files README.md` *(fails: ModuleNotFoundError: No module named 'vdf')*

------
https://chatgpt.com/codex/tasks/task_e_686a0d9342c08326a6c1232a471c1a2d