### PR TITLE
Add Backpack.tf currency exchange support

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,7 +15,11 @@ from utils.inventory_processor import enrich_inventory
 from utils import steam_api_client as sac
 from utils import local_data
 from utils import constants as consts
-from utils.price_loader import ensure_prices_cached, build_price_map
+from utils.price_loader import (
+    ensure_prices_cached,
+    ensure_currencies_cached,
+    build_price_map,
+)
 
 load_dotenv()
 if not os.getenv("STEAM_API_KEY"):
@@ -38,7 +42,9 @@ if ARGS.refresh:
     provider = SchemaProvider(cache_dir="cache/schema")
     provider.refresh_all(verbose=True)
     price_path = ensure_prices_cached(refresh=True)
+    curr_path = ensure_currencies_cached(refresh=True)
     print(f"\N{CHECK MARK} Saved {price_path}")
+    print(f"\N{CHECK MARK} Saved {curr_path}")
     print(
         "\N{CHECK MARK} Refresh complete. Restart app normally without --refresh to start server."
     )
@@ -56,6 +62,7 @@ app = Flask(__name__)
 MAX_MERGE_MS = 0
 local_data.load_files(auto_refetch=True, verbose=ARGS.verbose)
 _prices_path = ensure_prices_cached(refresh=ARGS.refresh)
+_currencies_path = ensure_currencies_cached(refresh=ARGS.refresh)
 PRICE_MAP = build_price_map(_prices_path)
 
 # --- Utility functions ------------------------------------------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,10 @@ def app(monkeypatch):
         lambda refresh=False: Path("prices.json"),
     )
     monkeypatch.setattr(
+        "utils.price_loader.ensure_currencies_cached",
+        lambda refresh=False: Path("currencies.json"),
+    )
+    monkeypatch.setattr(
         "utils.price_loader.build_price_map",
         lambda path: {},
     )

--- a/tests/test_app_import.py
+++ b/tests/test_app_import.py
@@ -22,6 +22,10 @@ def test_app_uses_mock_schema(monkeypatch):
         lambda refresh=False: Path("prices.json"),
     )
     monkeypatch.setattr(
+        "utils.price_loader.ensure_currencies_cached",
+        lambda refresh=False: Path("currencies.json"),
+    )
+    monkeypatch.setattr(
         "utils.price_loader.build_price_map",
         lambda path: {},
     )

--- a/tests/test_app_refresh.py
+++ b/tests/test_app_refresh.py
@@ -28,6 +28,10 @@ def test_refresh_flag_triggers_update(monkeypatch, capsys):
         "utils.price_loader.ensure_prices_cached",
         lambda refresh=True: called.__setitem__("prices", True) or Path("prices.json"),
     )
+    monkeypatch.setattr(
+        "utils.price_loader.ensure_currencies_cached",
+        lambda refresh=True: called.__setitem__("curr", True) or Path("curr.json"),
+    )
     monkeypatch.setattr(sys, "argv", ["app.py", "--refresh", "--verbose"])
     sys.modules.pop("app", None)
     with pytest.raises(SystemExit):
@@ -37,3 +41,4 @@ def test_refresh_flag_triggers_update(monkeypatch, capsys):
     assert "✓ Saved cache/schema/items.json (0 entries)" in out
     assert called["schema"] is True
     assert called["prices"] is True
+    assert called["curr"] is True

--- a/tests/test_env_loading.py
+++ b/tests/test_env_loading.py
@@ -20,6 +20,10 @@ def test_env_present_allows_import(monkeypatch):
         "utils.price_loader.ensure_prices_cached",
         lambda refresh=False: Path("prices.json"),
     )
+    monkeypatch.setattr(
+        "utils.price_loader.ensure_currencies_cached",
+        lambda refresh=False: Path("currencies.json"),
+    )
     monkeypatch.setattr("utils.price_loader.build_price_map", lambda path: {})
     monkeypatch.setattr("utils.local_data.load_files", lambda *a, **k: ({}, {}))
     sys.modules.pop("app", None)

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -269,6 +269,10 @@ def test_user_template_safe(monkeypatch, status):
         "utils.price_loader.ensure_prices_cached",
         lambda refresh=False: Path("prices.json"),
     )
+    monkeypatch.setattr(
+        "utils.price_loader.ensure_currencies_cached",
+        lambda refresh=False: Path("currencies.json"),
+    )
     monkeypatch.setattr("utils.price_loader.build_price_map", lambda path: {})
     monkeypatch.setattr("utils.local_data.load_files", lambda *a, **k: ({}, {}))
     import importlib
@@ -419,4 +423,4 @@ def test_price_map_applied():
     items = ip.enrich_inventory(data, price_map=price_map)
     item = items[0]
     assert item["price"] == price_map[(42, 6)]
-    assert item["price_display"] == "5.33 ref"
+    assert item["price_display"] == "5.33 Refined"

--- a/tests/test_local_data.py
+++ b/tests/test_local_data.py
@@ -10,6 +10,7 @@ def test_load_files_success(tmp_path, monkeypatch, caplog):
     items_file = tmp_path / "items.json"
     qual_file = tmp_path / "qualities.json"
     lookups_file = tmp_path / "string_lookups.json"
+    currencies_file = tmp_path / "currencies.json"
 
     attr_file.write_text(json.dumps([{"defindex": 1, "name": "Attr"}]))
     particles_file.write_text(json.dumps([{"id": 1, "name": "P"}]))
@@ -21,12 +22,14 @@ def test_load_files_success(tmp_path, monkeypatch, caplog):
     monkeypatch.setattr(ld, "ITEMS_FILE", items_file)
     monkeypatch.setattr(ld, "QUALITIES_FILE", qual_file)
     monkeypatch.setattr(ld, "STRING_LOOKUPS_FILE", lookups_file)
+    monkeypatch.setattr(ld, "CURRENCIES_FILE", currencies_file)
 
     ld.SCHEMA_ATTRIBUTES = {}
     ld.ITEMS_BY_DEFINDEX = {}
     ld.PARTICLE_NAMES = {}
     ld.QUALITIES_BY_INDEX = {}
     ld.EFFECT_NAMES = {}
+    currencies_file.write_text(json.dumps({"metal": {"value_raw": 1.0}}))
 
     caplog.set_level("INFO")
     ld.load_files(verbose=True)
@@ -39,6 +42,7 @@ def test_load_files_success(tmp_path, monkeypatch, caplog):
 def test_load_files_missing(tmp_path, monkeypatch):
     monkeypatch.setattr(ld, "ATTRIBUTES_FILE", tmp_path / "missing.json")
     monkeypatch.setattr(ld, "ITEMS_FILE", tmp_path / "missing2.json")
+    monkeypatch.setattr(ld, "CURRENCIES_FILE", tmp_path / "missing3.json")
     with pytest.raises(RuntimeError):
         ld.load_files()
 
@@ -49,12 +53,14 @@ def test_load_files_auto_refetch(tmp_path, monkeypatch, caplog):
     particles_file = tmp_path / "particles.json"
     qual_file = tmp_path / "qualities.json"
     lookups_file = tmp_path / "string_lookups.json"
+    currencies_file = tmp_path / "currencies.json"
 
     monkeypatch.setattr(ld, "ATTRIBUTES_FILE", attr_file)
     monkeypatch.setattr(ld, "PARTICLES_FILE", particles_file)
     monkeypatch.setattr(ld, "ITEMS_FILE", items_file)
     monkeypatch.setattr(ld, "QUALITIES_FILE", qual_file)
     monkeypatch.setattr(ld, "STRING_LOOKUPS_FILE", lookups_file)
+    monkeypatch.setattr(ld, "CURRENCIES_FILE", currencies_file)
 
     payloads = {
         "attributes": [{"defindex": 1, "name": "Attr"}],
@@ -78,6 +84,11 @@ def test_load_files_auto_refetch(tmp_path, monkeypatch, caplog):
         raise KeyError(endpoint)
 
     monkeypatch.setattr(ld.SchemaProvider, "_fetch", fake_fetch)
+    monkeypatch.setattr(
+        "utils.price_loader.ensure_currencies_cached",
+        lambda refresh=True: currencies_file,
+    )
+    currencies_file.write_text(json.dumps({"metal": {"value_raw": 1.0}}))
 
     ld.SCHEMA_ATTRIBUTES = {}
     ld.ITEMS_BY_DEFINDEX = {}
@@ -100,6 +111,7 @@ def test_load_files_name_key_quality(tmp_path, monkeypatch):
     particles_file = tmp_path / "particles.json"
     items_file = tmp_path / "items.json"
     qual_file = tmp_path / "qualities.json"
+    currencies_file = tmp_path / "currencies.json"
 
     attr_file.write_text(json.dumps([{"defindex": 1, "name": "Attr"}]))
     particles_file.write_text(json.dumps([{"id": 1, "name": "P"}]))
@@ -110,11 +122,13 @@ def test_load_files_name_key_quality(tmp_path, monkeypatch):
     monkeypatch.setattr(ld, "PARTICLES_FILE", particles_file)
     monkeypatch.setattr(ld, "ITEMS_FILE", items_file)
     monkeypatch.setattr(ld, "QUALITIES_FILE", qual_file)
+    monkeypatch.setattr(ld, "CURRENCIES_FILE", currencies_file)
 
     ld.SCHEMA_ATTRIBUTES = {}
     ld.ITEMS_BY_DEFINDEX = {}
     ld.PARTICLE_NAMES = {}
     ld.QUALITIES_BY_INDEX = {}
+    currencies_file.write_text(json.dumps({"metal": {"value_raw": 1.0}}))
 
     ld.load_files()
     assert ld.QUALITIES_BY_INDEX == {1: "Unique"}
@@ -140,6 +154,7 @@ def test_load_files_string_lookups(tmp_path, monkeypatch):
     items_file = tmp_path / "items.json"
     qual_file = tmp_path / "qualities.json"
     lookups_file = tmp_path / "string_lookups.json"
+    currencies_file = tmp_path / "currencies.json"
 
     for f in (attr_file, particles_file, items_file, qual_file):
         f.write_text("[]")
@@ -169,9 +184,11 @@ def test_load_files_string_lookups(tmp_path, monkeypatch):
     monkeypatch.setattr(ld, "ITEMS_FILE", items_file)
     monkeypatch.setattr(ld, "QUALITIES_FILE", qual_file)
     monkeypatch.setattr(ld, "STRING_LOOKUPS_FILE", lookups_file)
+    monkeypatch.setattr(ld, "CURRENCIES_FILE", currencies_file)
 
     ld.FOOTPRINT_SPELL_MAP = {}
     ld.PAINT_SPELL_MAP = {}
+    currencies_file.write_text(json.dumps({"metal": {"value_raw": 1.0}}))
 
     ld.load_files()
 
@@ -184,6 +201,7 @@ def test_load_files_string_lookups_missing(tmp_path, monkeypatch):
     particles_file = tmp_path / "particles.json"
     items_file = tmp_path / "items.json"
     qual_file = tmp_path / "qualities.json"
+    currencies_file = tmp_path / "currencies.json"
 
     for f in (attr_file, particles_file, items_file, qual_file):
         f.write_text("[]")
@@ -193,9 +211,11 @@ def test_load_files_string_lookups_missing(tmp_path, monkeypatch):
     monkeypatch.setattr(ld, "ITEMS_FILE", items_file)
     monkeypatch.setattr(ld, "QUALITIES_FILE", qual_file)
     monkeypatch.setattr(ld, "STRING_LOOKUPS_FILE", tmp_path / "missing.json")
+    monkeypatch.setattr(ld, "CURRENCIES_FILE", currencies_file)
 
     ld.FOOTPRINT_SPELL_MAP = {1: "X"}
     ld.PAINT_SPELL_MAP = {1: "Y"}
+    currencies_file.write_text(json.dumps({"metal": {"value_raw": 1.0}}))
 
     ld.load_files()
 

--- a/tests/test_price_service.py
+++ b/tests/test_price_service.py
@@ -1,0 +1,13 @@
+from utils.price_service import convert_price_to_keys_ref
+
+
+def test_convert_price_to_keys_ref_basic():
+    currencies = {"metal": {"value_raw": 1.0}, "keys": {"value_raw": 50.0}}
+    out = convert_price_to_keys_ref(25.0, "metal", currencies)
+    assert out == "25 Refined"
+
+
+def test_convert_price_to_keys_ref_keys():
+    currencies = {"metal": {"value_raw": 1.0}, "keys": {"value_raw": 50.0}}
+    out = convert_price_to_keys_ref(1.5, "keys", currencies)
+    assert out == "1 Key 25 Refined"

--- a/tests/test_quantity_badge.py
+++ b/tests/test_quantity_badge.py
@@ -24,6 +24,10 @@ def test_quantity_badge_rendered(monkeypatch):
         "utils.price_loader.ensure_prices_cached",
         lambda refresh=False: Path("prices.json"),
     )
+    monkeypatch.setattr(
+        "utils.price_loader.ensure_currencies_cached",
+        lambda refresh=False: Path("currencies.json"),
+    )
     monkeypatch.setattr("utils.price_loader.build_price_map", lambda path: {})
     monkeypatch.setattr("utils.local_data.load_files", lambda *a, **k: ({}, {}))
     mod = importlib.import_module("app")

--- a/tests/test_user_badges.py
+++ b/tests/test_user_badges.py
@@ -19,6 +19,10 @@ def app(monkeypatch):
         lambda refresh=False: Path("prices.json"),
     )
     monkeypatch.setattr(
+        "utils.price_loader.ensure_currencies_cached",
+        lambda refresh=False: Path("currencies.json"),
+    )
+    monkeypatch.setattr(
         "utils.price_loader.build_price_map",
         lambda path: {},
     )

--- a/tests/test_user_template.py
+++ b/tests/test_user_template.py
@@ -18,6 +18,10 @@ def app(monkeypatch):
         lambda refresh=False: Path("prices.json"),
     )
     monkeypatch.setattr(
+        "utils.price_loader.ensure_currencies_cached",
+        lambda refresh=False: Path("currencies.json"),
+    )
+    monkeypatch.setattr(
         "utils.price_loader.build_price_map",
         lambda path: {},
     )

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -7,6 +7,7 @@ import json
 from pathlib import Path
 
 from . import steam_api_client, local_data
+from .price_service import convert_price_to_keys_ref
 from .wear_helpers import _wear_tier, _decode_seed_info
 from .constants import (
     KILLSTREAK_TIERS,
@@ -764,12 +765,9 @@ def _process_item(
             value = info.get("value_raw")
             currency = info.get("currency")
             if value is not None and currency:
-                if currency == "metal":
-                    display_val = f"{value:.2f}".rstrip("0").rstrip(".")
-                    item["price_display"] = f"{display_val} ref"
-                else:
-                    display_val = f"{value:.2f}".rstrip("0").rstrip(".")
-                    item["price_display"] = f"{display_val} {currency}"
+                item["price_display"] = convert_price_to_keys_ref(
+                    value, currency, local_data.CURRENCIES
+                )
     return item
 
 

--- a/utils/price_loader.py
+++ b/utils/price_loader.py
@@ -13,6 +13,7 @@ load_dotenv()
 logger = logging.getLogger(__name__)
 
 PRICES_FILE = Path("cache/prices.json")
+CURRENCIES_FILE = Path("cache/currencies.json")
 
 
 def _require_key() -> str:
@@ -41,6 +42,29 @@ def ensure_prices_cached(refresh: bool = False) -> Path:
         if path.exists():
             return path
         raise RuntimeError("Cannot fetch Backpack.tf prices") from exc
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2))
+    return path
+
+
+def ensure_currencies_cached(refresh: bool = False) -> Path:
+    """Download currency exchange rates from backpack.tf."""
+
+    path = CURRENCIES_FILE
+    if path.exists() and not refresh:
+        return path
+
+    url = f"https://backpack.tf/api/IGetCurrencies/v1?raw=1&key={_require_key()}"
+    try:
+        resp = requests.get(url, timeout=5, headers={"accept": "application/json"})
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as exc:  # requests or JSON
+        logger.warning("Failed to fetch currencies: %s", exc)
+        if path.exists():
+            return path
+        raise RuntimeError("Cannot fetch Backpack.tf currencies") from exc
 
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(data, indent=2))

--- a/utils/price_service.py
+++ b/utils/price_service.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def convert_price_to_keys_ref(
+    value_raw: float, currency: str, currencies: Dict[str, Any]
+) -> str:
+    """Return human-readable price in keys and refined metal."""
+    try:
+        value = float(value_raw)
+    except (TypeError, ValueError):
+        return ""
+
+    metal_info = currencies.get("metal") or {}
+    key_info = currencies.get("keys") or {}
+    cur_info = currencies.get(currency, {})
+
+    metal_rate = float(metal_info.get("value_raw", 1.0))
+    key_rate = float(key_info.get("value_raw", 0.0))
+    cur_rate = float(cur_info.get("value_raw", 1.0))
+
+    # Normalize to refined metal
+    value_in_ref = value * cur_rate / metal_rate
+
+    keys = 0
+    if key_rate:
+        keys = int(value_in_ref // key_rate)
+    refined = value_in_ref - keys * key_rate
+
+    parts = []
+    if keys:
+        parts.append(f"{keys} Key" + ("s" if keys != 1 else ""))
+    if refined > 0.01 or not parts:
+        ref_str = f"{refined:.2f}".rstrip("0").rstrip(".")
+        parts.append(f"{ref_str} Refined")
+
+    return " ".join(parts)


### PR DESCRIPTION
## Summary
- fetch Backpack.tf currencies during refresh
- load currencies.json alongside schema
- provide conversion helper to format prices
- integrate conversion in inventory processing
- adjust tests and add new test for price formatter

## Testing
- `pre-commit run --files app.py utils/price_loader.py utils/price_service.py utils/local_data.py utils/inventory_processor.py tests/conftest.py tests/test_app_import.py tests/test_app_refresh.py tests/test_env_loading.py tests/test_inventory_processor.py tests/test_local_data.py tests/test_user_badges.py tests/test_user_template.py tests/test_quantity_badge.py tests/test_price_service.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a1ad49ac0832691d085c1e110a937