### PR TITLE
Fix Non-Craftable price lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Updated schema caching logic and UI (previous releases).
 - Security audit using git-secrets and pip-audit.
+- Price loader now reads both Craftable and Non-Craftable price entries.

--- a/tests/test_price_loader.py
+++ b/tests/test_price_loader.py
@@ -42,6 +42,44 @@ def test_price_map_smoke(tmp_path, monkeypatch):
     assert mapping[(5021, 6)]["currency"] == "metal"
 
 
+def test_price_map_non_craftable(tmp_path, monkeypatch):
+    monkeypatch.setenv("BPTF_API_KEY", "TEST")
+    monkeypatch.setattr(price_loader, "PRICES_FILE", tmp_path / "prices.json")
+    url = "https://backpack.tf/api/IGetPrices/v4?raw=1&key=TEST"
+    payload = {
+        "response": {
+            "success": 1,
+            "items": {
+                "Unusual Hat": {
+                    "defindex": [123],
+                    "prices": {
+                        "5": {
+                            "Tradable": {
+                                "Non-Craftable": [
+                                    {
+                                        "value": 1,
+                                        "value_raw": 1.0,
+                                        "currency": "keys",
+                                        "last_update": 0,
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                }
+            },
+        }
+    }
+
+    with responses.RequestsMock() as rsps:
+        rsps.add(responses.GET, url, json=payload, status=200)
+        p = price_loader.ensure_prices_cached(refresh=True)
+
+    mapping = price_loader.build_price_map(p)
+    assert (123, 5) in mapping
+    assert mapping[(123, 5)]["currency"] == "keys"
+
+
 def test_missing_api_key(monkeypatch):
     monkeypatch.delenv("BPTF_API_KEY", raising=False)
     with pytest.raises(RuntimeError):

--- a/utils/price_loader.py
+++ b/utils/price_loader.py
@@ -88,8 +88,13 @@ def build_price_map(prices_path: Path) -> dict[tuple[int, int], dict]:
                 qid = int(quality)
             except (TypeError, ValueError):
                 continue
-            craftable = qdata.get("Tradable", {}).get("Craftable")
-            entry = craftable[0] if isinstance(craftable, list) else None
+
+            tradable = qdata.get("Tradable", {})
+            entries = tradable.get("Craftable")
+            if not isinstance(entries, list):
+                entries = tradable.get("Non-Craftable")
+
+            entry = entries[0] if isinstance(entries, list) else None
             if not isinstance(entry, dict):
                 continue
             value_raw = entry.get("value_raw")


### PR DESCRIPTION
## Summary
- look for both Craftable and Non-Craftable price info
- test non-craftable pricing
- update changelog

## Testing
- `pre-commit run --files utils/price_loader.py tests/test_price_loader.py CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_686a5d2f84748326ab50a0fb673051f5