### PR TITLE
Add refined metal to key conversion helper

### DIFF
--- a/tests/test_price_service.py
+++ b/tests/test_price_service.py
@@ -1,4 +1,4 @@
-from utils.price_service import convert_price_to_keys_ref
+from utils.price_service import convert_price_to_keys_ref, convert_to_key_ref
 
 
 def test_convert_price_to_keys_ref_basic():
@@ -11,3 +11,11 @@ def test_convert_price_to_keys_ref_keys():
     currencies = {"metal": {"value_raw": 1.0}, "keys": {"value_raw": 50.0}}
     out = convert_price_to_keys_ref(1.5, "keys", currencies)
     assert out == "1 Key 25 Refined"
+
+
+def test_convert_to_key_ref_only_refined():
+    assert convert_to_key_ref(5.0) == "5.00 Refined"
+
+
+def test_convert_to_key_ref_keys_and_refined():
+    assert convert_to_key_ref(125.5) == "2 Keys 25.50 Refined"

--- a/utils/price_service.py
+++ b/utils/price_service.py
@@ -36,3 +36,38 @@ def convert_price_to_keys_ref(
         parts.append(f"{ref_str} Refined")
 
     return " ".join(parts)
+
+
+def convert_to_key_ref(value_refined: float) -> str:
+    """Convert a refined metal value into a keys+refined string.
+
+    Parameters
+    ----------
+    value_refined:
+        The amount of refined metal to convert.
+
+    Returns
+    -------
+    str
+        A string in the form ``"<N> Keys <M.MM> Refined"``. Keys are computed
+        using integer division and the remainder is formatted with two decimal
+        places.
+    """
+
+    try:
+        value = float(value_refined)
+    except (TypeError, ValueError):
+        return ""
+
+    key_price = 50.0
+
+    keys = int(value // key_price)
+    refined = value - keys * key_price
+
+    parts = []
+    if keys:
+        parts.append(f"{keys} Key" + ("s" if keys != 1 else ""))
+    if refined > 0.0 or not parts:
+        parts.append(f"{refined:.2f} Refined")
+
+    return " ".join(parts)


### PR DESCRIPTION
## Summary
- add `convert_to_key_ref` helper for refined-to-key formatting
- test refined metal conversion logic

## Testing
- `pre-commit run --files utils/price_service.py tests/test_price_service.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a5f03b2a88326a16f384122387af0