### PR TITLE
Fix item card title wrapping

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -142,7 +142,7 @@ button {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   width: 96px;
   height: 128px;
   padding: 4px;
@@ -239,10 +239,16 @@ button {
   text-align: center;
   word-break: break-word;
   color: #fff;
+  line-height: 1.2em;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+  max-height: 2.4em;
 }
 
 .item-price {
-  margin-top: 2px;
+  margin-top: auto;
   font-size: 12px;
 }
 


### PR DESCRIPTION
## Summary
- clamp `.item-title` to two lines and tweak line height
- push `.item-price` to the bottom of its card

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files static/style.css`


------
https://chatgpt.com/codex/tasks/task_e_686a6991e2c8832695f11283874d9497