### PR TITLE
Add formatted_price to inventory items

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -424,3 +424,4 @@ def test_price_map_applied():
     item = items[0]
     assert item["price"] == price_map[(42, 6)]
     assert item["price_string"] == "5.33 Refined"
+    assert item["formatted_price"] == "5.33 Refined"

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -765,9 +765,11 @@ def _process_item(
             value = info.get("value_raw")
             currency = info.get("currency")
             if value is not None and currency:
-                item["price_string"] = convert_price_to_keys_ref(
+                formatted = convert_price_to_keys_ref(
                     value, currency, local_data.CURRENCIES
                 )
+                item["price_string"] = formatted
+                item["formatted_price"] = formatted
     return item
 
 


### PR DESCRIPTION
## Summary
- compute `formatted_price` in `_process_item`
- keep `price_string` for backwards compatibility
- update tests for formatted price handling

## Testing
- `pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py` *(fails: Missing schema files)*
- `pytest tests/test_inventory_processor.py::test_price_map_applied -q`

------
https://chatgpt.com/codex/tasks/task_e_686a6bd8b0748326aae1fcbdc1b0945d