### PR TITLE
Fix layout for price display

### DIFF
--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -23,9 +23,7 @@
     <div class="missing-icon"></div>
   {% endif %}
   <h2 class="item-title">{{ item.name }}</h2>
-  {% if item.price_string %}
-    <div class="item-price">{{ item.price_string }}</div>
-  {% endif %}
+  <div class="item-price">{{ item.formatted_price or "N/A" }}</div>
   {% if item.strange_parts %}
     <ul class="text-xs mt-1 text-gray-300">
       {% for part in item.strange_parts %}


### PR DESCRIPTION
## Summary
- ensure item cards always show a price placeholder

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files templates/item_card.html`


------
https://chatgpt.com/codex/tasks/task_e_686a6d3f383c8326bf829267d04195cb