### PR TITLE
Lowercase price units

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -423,5 +423,5 @@ def test_price_map_applied():
     items = ip.enrich_inventory(data, price_map=price_map)
     item = items[0]
     assert item["price"] == price_map[(42, 6)]
-    assert item["price_string"] == "5.33 Refined"
-    assert item["formatted_price"] == "5.33 Refined"
+    assert item["price_string"] == "5.33 ref"
+    assert item["formatted_price"] == "5.33 ref"

--- a/tests/test_price_service.py
+++ b/tests/test_price_service.py
@@ -4,13 +4,13 @@ from utils.price_service import convert_price_to_keys_ref, convert_to_key_ref
 def test_convert_price_to_keys_ref_basic():
     currencies = {"metal": {"value_raw": 1.0}, "keys": {"value_raw": 50.0}}
     out = convert_price_to_keys_ref(25.0, "metal", currencies)
-    assert out == "25 Refined"
+    assert out == "25 ref"
 
 
 def test_convert_price_to_keys_ref_keys():
     currencies = {"metal": {"value_raw": 1.0}, "keys": {"value_raw": 50.0}}
     out = convert_price_to_keys_ref(1.5, "keys", currencies)
-    assert out == "1 Key 25 Refined"
+    assert out == "1 key 25 ref"
 
 
 def test_convert_to_key_ref_only_refined():

--- a/utils/price_service.py
+++ b/utils/price_service.py
@@ -30,10 +30,10 @@ def convert_price_to_keys_ref(
 
     parts = []
     if keys:
-        parts.append(f"{keys} Key" + ("s" if keys != 1 else ""))
+        parts.append(f"{keys} key" + ("s" if keys != 1 else ""))
     if refined > 0.01 or not parts:
         ref_str = f"{refined:.2f}".rstrip("0").rstrip(".")
-        parts.append(f"{ref_str} Refined")
+        parts.append(f"{ref_str} ref")
 
     return " ".join(parts)
 


### PR DESCRIPTION
## Summary
- make `convert_price_to_keys_ref` output `key(s)` and `ref`
- update tests for new strings

## Testing
- `pre-commit run --files utils/price_service.py tests/test_price_service.py tests/test_inventory_processor.py`
- `STEAM_API_KEY=test pytest`

------
https://chatgpt.com/codex/tasks/task_e_686a6f1f4ec08326a07821432a8a0059