### PR TITLE
Remove unused item-name style

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -227,13 +227,6 @@ button {
   justify-content: center;
 }
 
-.item-name {
-  font-size: 12px;
-  text-align: center;
-  word-break: break-word;
-  color: #fff;
-}
-
 .item-title {
   font-size: 12px;
   text-align: center;


### PR DESCRIPTION
## Summary
- remove old `.item-name` rule so only `.item-title` remains

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files static/style.css`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a7086712c8326bd870ce2b6dcbf43