### PR TITLE
Fix key/ref price formatting

### DIFF
--- a/app.py
+++ b/app.py
@@ -63,6 +63,11 @@ MAX_MERGE_MS = 0
 local_data.load_files(auto_refetch=True, verbose=ARGS.verbose)
 _prices_path = ensure_prices_cached(refresh=ARGS.refresh)
 _currencies_path = ensure_currencies_cached(refresh=ARGS.refresh)
+try:
+    with open(_currencies_path) as f:
+        local_data.CURRENCIES = json.load(f)["response"]["currencies"]
+except Exception:
+    local_data.CURRENCIES = {}
 PRICE_MAP = build_price_map(_prices_path)
 
 # --- Utility functions ------------------------------------------------------

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -23,7 +23,7 @@
     <div class="missing-icon"></div>
   {% endif %}
   <h2 class="item-title">{{ item.name }}</h2>
-  <div class="item-price">{{ item.formatted_price or "N/A" }}</div>
+  <div class="item-price">{{ item.formatted_price or "Unpriced" }}</div>
   {% if item.strange_parts %}
     <ul class="text-xs mt-1 text-gray-300">
       {% for part in item.strange_parts %}

--- a/tests/test_convert_price.py
+++ b/tests/test_convert_price.py
@@ -1,0 +1,18 @@
+import utils.price_service as ps
+
+currencies = {"keys": {"price": {"value_raw": 67.16}}}
+
+
+def test_convert_metal_to_keys_and_ref():
+    out = ps.convert_price_to_keys_ref(123.44, "metal", currencies)
+    assert out == "1 Keys 56.28 Refined"
+
+
+def test_convert_exact_key_price():
+    out = ps.convert_price_to_keys_ref(67.16, "metal", currencies)
+    assert out == "1 Keys"
+
+
+def test_convert_keys_currency():
+    out = ps.convert_price_to_keys_ref(2, "keys", currencies)
+    assert out == "2 Keys"

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -419,9 +419,10 @@ def test_price_map_applied():
     ld.ITEMS_BY_DEFINDEX = {42: {"item_name": "Answer", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {6: "Unique"}
     price_map = {(42, 6): {"value_raw": 5.33, "currency": "metal"}}
+    ld.CURRENCIES = {"keys": {"price": {"value_raw": 50.0}}}
 
     items = ip.enrich_inventory(data, price_map=price_map)
     item = items[0]
     assert item["price"] == price_map[(42, 6)]
-    assert item["price_string"] == "5.33 ref"
-    assert item["formatted_price"] == "5.33 ref"
+    assert item["price_string"] == "5.33 Refined"
+    assert item["formatted_price"] == "5.33 Refined"

--- a/tests/test_price_service.py
+++ b/tests/test_price_service.py
@@ -2,15 +2,15 @@ from utils.price_service import convert_price_to_keys_ref, convert_to_key_ref
 
 
 def test_convert_price_to_keys_ref_basic():
-    currencies = {"metal": {"value_raw": 1.0}, "keys": {"value_raw": 50.0}}
+    currencies = {"keys": {"price": {"value_raw": 50.0}}}
     out = convert_price_to_keys_ref(25.0, "metal", currencies)
-    assert out == "25 ref"
+    assert out == "25.0 Refined"
 
 
 def test_convert_price_to_keys_ref_keys():
-    currencies = {"metal": {"value_raw": 1.0}, "keys": {"value_raw": 50.0}}
+    currencies = {"keys": {"price": {"value_raw": 50.0}}}
     out = convert_price_to_keys_ref(1.5, "keys", currencies)
-    assert out == "1 key 25 ref"
+    assert out == "1.5 Keys"
 
 
 def test_convert_to_key_ref_only_refined():

--- a/utils/price_service.py
+++ b/utils/price_service.py
@@ -7,35 +7,27 @@ def convert_price_to_keys_ref(
     value_raw: float, currency: str, currencies: Dict[str, Any]
 ) -> str:
     """Return human-readable price in keys and refined metal."""
+
     try:
-        value = float(value_raw)
-    except (TypeError, ValueError):
-        return ""
+        if currency == "keys":
+            return f"{round(value_raw, 2)} Keys"
 
-    metal_info = currencies.get("metal") or {}
-    key_info = currencies.get("keys") or {}
-    cur_info = currencies.get(currency, {})
+        ref_per_key = currencies["keys"]["price"]["value_raw"]
+        if not ref_per_key or ref_per_key <= 0:
+            return f"{round(value_raw, 2)} Refined"
 
-    metal_rate = float(metal_info.get("value_raw", 1.0))
-    key_rate = float(key_info.get("value_raw", 0.0))
-    cur_rate = float(cur_info.get("value_raw", 1.0))
+        total_ref = value_raw
+        keys = int(total_ref // ref_per_key)
+        refined = round(total_ref - keys * ref_per_key, 2)
 
-    # Normalize to refined metal
-    value_in_ref = value * cur_rate / metal_rate
-
-    keys = 0
-    if key_rate:
-        keys = int(value_in_ref // key_rate)
-    refined = value_in_ref - keys * key_rate
-
-    parts = []
-    if keys:
-        parts.append(f"{keys} key" + ("s" if keys != 1 else ""))
-    if refined > 0.01 or not parts:
-        ref_str = f"{refined:.2f}".rstrip("0").rstrip(".")
-        parts.append(f"{ref_str} ref")
-
-    return " ".join(parts)
+        if keys > 0 and refined > 0:
+            return f"{keys} Keys {refined} Refined"
+        elif keys > 0:
+            return f"{keys} Keys"
+        else:
+            return f"{refined} Refined"
+    except Exception:
+        return f"{round(value_raw, 2)} {currency}"
 
 
 def convert_to_key_ref(value_refined: float) -> str:


### PR DESCRIPTION
## Summary
- load currencies at startup
- fix price conversion helper
- show `Unpriced` in item card
- update price conversion tests
- ensure inventory processor uses global currency map

## Testing
- `black utils/price_service.py app.py tests/test_convert_price.py tests/test_price_service.py tests/test_inventory_processor.py`
- `ruff check utils/price_service.py app.py tests/test_convert_price.py tests/test_price_service.py tests/test_inventory_processor.py`
- `pytest -q -o addopts=''` *(fails: ModuleNotFoundError: No module named 'vdf')*

------
https://chatgpt.com/codex/tasks/task_e_686a77605ff08326875fef97fa9c67ec