### PR TITLE
Add currencies option to convert_to_key_ref

### DIFF
--- a/tests/test_convert_price.py
+++ b/tests/test_convert_price.py
@@ -16,3 +16,13 @@ def test_convert_exact_key_price():
 def test_convert_keys_currency():
     out = ps.convert_price_to_keys_ref(2, "keys", currencies)
     assert out == "2 Keys"
+
+
+def test_convert_to_key_ref_custom_exact_key():
+    out = ps.convert_to_key_ref(67.16, currencies)
+    assert out == "1 Key"
+
+
+def test_convert_to_key_ref_custom_keys_and_refined():
+    out = ps.convert_to_key_ref(123.44, currencies)
+    assert out == "1 Key 56.28 Refined"

--- a/tests/test_price_service.py
+++ b/tests/test_price_service.py
@@ -14,8 +14,10 @@ def test_convert_price_to_keys_ref_keys():
 
 
 def test_convert_to_key_ref_only_refined():
-    assert convert_to_key_ref(5.0) == "5.00 Refined"
+    currencies = {"keys": {"price": {"value_raw": 50.0}}}
+    assert convert_to_key_ref(5.0, currencies) == "5.00 Refined"
 
 
 def test_convert_to_key_ref_keys_and_refined():
-    assert convert_to_key_ref(125.5) == "2 Keys 25.50 Refined"
+    currencies = {"keys": {"price": {"value_raw": 50.0}}}
+    assert convert_to_key_ref(125.5, currencies) == "2 Keys 25.50 Refined"

--- a/utils/price_service.py
+++ b/utils/price_service.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
+from . import local_data
+
 
 def convert_price_to_keys_ref(
     value_raw: float, currency: str, currencies: Dict[str, Any]
@@ -30,13 +32,18 @@ def convert_price_to_keys_ref(
         return f"{round(value_raw, 2)} {currency}"
 
 
-def convert_to_key_ref(value_refined: float) -> str:
+def convert_to_key_ref(
+    value_refined: float, currencies: Dict[str, Any] | None = None
+) -> str:
     """Convert a refined metal value into a keys+refined string.
 
     Parameters
     ----------
     value_refined:
         The amount of refined metal to convert.
+    currencies:
+        Mapping of currency data loaded from ``local_data``. If ``None``,
+        ``local_data.CURRENCIES`` will be used.
 
     Returns
     -------
@@ -51,7 +58,14 @@ def convert_to_key_ref(value_refined: float) -> str:
     except (TypeError, ValueError):
         return ""
 
+    if currencies is None:
+        currencies = local_data.CURRENCIES
+
     key_price = 50.0
+    try:
+        key_price = float(currencies["keys"]["price"]["value_raw"])
+    except Exception:
+        pass
 
     keys = int(value // key_price)
     refined = value - keys * key_price


### PR DESCRIPTION
## Summary
- allow passing currencies map to `convert_to_key_ref`
- derive key price from currencies
- update tests

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files utils/price_service.py tests/test_price_service.py tests/test_convert_price.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686a806327848326bea827407579ade4