### PR TITLE
Handle metal prices as keys+ref in item processor

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -426,3 +426,16 @@ def test_price_map_applied():
     assert item["price"] == price_map[(42, 6)]
     assert item["price_string"] == "5.33 Refined"
     assert item["formatted_price"] == "5.33 Refined"
+
+
+def test_price_map_key_conversion_large_value():
+    data = {"items": [{"defindex": 42, "quality": 6}]}
+    ld.ITEMS_BY_DEFINDEX = {42: {"item_name": "Answer", "image_url": ""}}
+    ld.QUALITIES_BY_INDEX = {6: "Unique"}
+    price_map = {(42, 6): {"value_raw": 367.73, "currency": "metal"}}
+    ld.CURRENCIES = {"keys": {"price": {"value_raw": 70.0}}}
+
+    items = ip.enrich_inventory(data, price_map=price_map)
+    item = items[0]
+    assert item["formatted_price"] == "5 Keys 17.73 Refined"
+    assert item["price_string"] == "5 Keys 17.73 Refined"

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -7,7 +7,7 @@ import json
 from pathlib import Path
 
 from . import steam_api_client, local_data
-from .price_service import convert_price_to_keys_ref
+from .price_service import convert_price_to_keys_ref, convert_to_key_ref
 from .wear_helpers import _wear_tier, _decode_seed_info
 from .constants import (
     KILLSTREAK_TIERS,
@@ -765,9 +765,19 @@ def _process_item(
             value = info.get("value_raw")
             currency = info.get("currency")
             if value is not None and currency:
-                formatted = convert_price_to_keys_ref(
-                    value, currency, local_data.CURRENCIES
-                )
+                c = str(currency).lower()
+                if c == "keys":
+                    formatted = convert_price_to_keys_ref(
+                        value, currency, local_data.CURRENCIES
+                    )
+                elif c in {"metal", "ref", "refined"}:
+                    formatted = convert_to_key_ref(
+                        value, currencies=local_data.CURRENCIES
+                    )
+                else:
+                    formatted = convert_price_to_keys_ref(
+                        value, currency, local_data.CURRENCIES
+                    )
                 item["price_string"] = formatted
                 item["formatted_price"] = formatted
     return item


### PR DESCRIPTION
## Summary
- convert metal prices to keys+refined using `convert_to_key_ref`
- test that larger refined price uses key conversion

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py`
- `pytest tests/test_inventory_processor.py::test_price_map_key_conversion_large_value -q`

------
https://chatgpt.com/codex/tasks/task_e_686a81b5b9848326b0b300a09483ebf8