### PR TITLE
Fix price display with refined conversion

### DIFF
--- a/tests/test_price_service.py
+++ b/tests/test_price_service.py
@@ -13,6 +13,12 @@ def test_convert_price_to_keys_ref_keys():
     assert out == "1.5 Keys"
 
 
+def test_convert_price_to_keys_ref_mislabeled_keys():
+    currencies = {"keys": {"price": {"value_raw": 50.0}}}
+    out = convert_price_to_keys_ref(125.5, "keys", currencies)
+    assert out == "2 Keys 25.5 Refined"
+
+
 def test_convert_to_key_ref_only_refined():
     currencies = {"keys": {"price": {"value_raw": 50.0}}}
     assert convert_to_key_ref(5.0, currencies) == "5.00 Refined"


### PR DESCRIPTION
## Summary
- handle backpack.tf `value_raw` values that are always in refined metal
- adjust `convert_price_to_keys_ref` logic
- test mislabeled price conversion

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files utils/price_service.py tests/test_price_service.py`

------
https://chatgpt.com/codex/tasks/task_e_686a86f7ad1483268105e62f7609be56