### PR TITLE
Fix unusual price formatting

### DIFF
--- a/tests/test_convert_price.py
+++ b/tests/test_convert_price.py
@@ -1,28 +1,23 @@
-import utils.price_service as ps
+from utils.price_service import format_price
 
 currencies = {"keys": {"price": {"value_raw": 67.16}}}
 
 
-def test_convert_metal_to_keys_and_ref():
-    out = ps.convert_price_to_keys_ref(123.44, "metal", currencies)
-    assert out == "1 Keys 56.28 Refined"
+def test_format_price_metal_to_keys_and_ref():
+    assert format_price(123.44, currencies) == "1 Key 56.28 Refined"
 
 
-def test_convert_exact_key_price():
-    out = ps.convert_price_to_keys_ref(67.16, "metal", currencies)
-    assert out == "1 Keys"
+def test_format_price_exact_key():
+    assert format_price(67.16, currencies) == "1 Key"
 
 
-def test_convert_keys_currency():
-    out = ps.convert_price_to_keys_ref(2, "keys", currencies)
-    assert out == "2 Keys"
+def test_format_price_keys_currency():
+    assert format_price(134.32, currencies) == "2 Keys"
 
 
-def test_convert_to_key_ref_custom_exact_key():
-    out = ps.convert_to_key_ref(67.16, currencies)
-    assert out == "1 Key"
+def test_format_price_custom_exact_key():
+    assert format_price(67.16, currencies) == "1 Key"
 
 
-def test_convert_to_key_ref_custom_keys_and_refined():
-    out = ps.convert_to_key_ref(123.44, currencies)
-    assert out == "1 Key 56.28 Refined"
+def test_format_price_custom_keys_and_refined():
+    assert format_price(123.44, currencies) == "1 Key 56.28 Refined"

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -439,3 +439,24 @@ def test_price_map_key_conversion_large_value():
     item = items[0]
     assert item["formatted_price"] == "5 Keys 17.73 Refined"
     assert item["price_string"] == "5 Keys 17.73 Refined"
+
+
+def test_price_map_unusual_lookup():
+    data = {
+        "items": [
+            {
+                "defindex": 30998,
+                "quality": 5,
+                "attributes": [{"defindex": 134, "float_value": 13}],
+            }
+        ]
+    }
+    ld.ITEMS_BY_DEFINDEX = {30998: {"item_name": "Veil", "image_url": ""}}
+    ld.QUALITIES_BY_INDEX = {5: "Unusual"}
+    price_map = {(30998, 5, 13): {"value_raw": 164554.25, "currency": "keys"}}
+    ld.CURRENCIES = {"keys": {"price": {"value_raw": 67.165}}}
+
+    items = ip.enrich_inventory(data, price_map=price_map)
+    item = items[0]
+    assert item["formatted_price"] == "2449 Keys 67.16 Refined"
+    assert item["price_string"] == "2449 Keys 67.16 Refined"

--- a/tests/test_price_loader.py
+++ b/tests/test_price_loader.py
@@ -80,6 +80,44 @@ def test_price_map_non_craftable(tmp_path, monkeypatch):
     assert mapping[(123, 5)]["currency"] == "keys"
 
 
+def test_price_map_unusual_effect(tmp_path, monkeypatch):
+    monkeypatch.setenv("BPTF_API_KEY", "TEST")
+    monkeypatch.setattr(price_loader, "PRICES_FILE", tmp_path / "prices.json")
+    url = "https://backpack.tf/api/IGetPrices/v4?raw=1&key=TEST"
+    payload = {
+        "response": {
+            "success": 1,
+            "items": {
+                "Villain's Veil": {
+                    "defindex": [30998],
+                    "prices": {
+                        "5": {
+                            "Tradable": {
+                                "Craftable": {
+                                    "13": {
+                                        "value": 2150,
+                                        "value_raw": 164554.25,
+                                        "currency": "keys",
+                                        "last_update": 0,
+                                    }
+                                }
+                            }
+                        }
+                    },
+                }
+            },
+        }
+    }
+
+    with responses.RequestsMock() as rsps:
+        rsps.add(responses.GET, url, json=payload, status=200)
+        p = price_loader.ensure_prices_cached(refresh=True)
+
+    mapping = price_loader.build_price_map(p)
+    assert (30998, 5, 13) in mapping
+    assert mapping[(30998, 5, 13)]["currency"] == "keys"
+
+
 def test_missing_api_key(monkeypatch):
     monkeypatch.delenv("BPTF_API_KEY", raising=False)
     with pytest.raises(RuntimeError):

--- a/tests/test_price_service.py
+++ b/tests/test_price_service.py
@@ -1,29 +1,27 @@
-from utils.price_service import convert_price_to_keys_ref, convert_to_key_ref
+from utils.price_service import format_price
 
 
-def test_convert_price_to_keys_ref_basic():
+def test_format_price_basic():
     currencies = {"keys": {"price": {"value_raw": 50.0}}}
-    out = convert_price_to_keys_ref(25.0, "metal", currencies)
-    assert out == "25.0 Refined"
+    assert format_price(25.0, currencies) == "25.00 Refined"
 
 
-def test_convert_price_to_keys_ref_keys():
+def test_format_price_keys_only():
     currencies = {"keys": {"price": {"value_raw": 50.0}}}
-    out = convert_price_to_keys_ref(1.5, "keys", currencies)
-    assert out == "1.5 Keys"
+    assert format_price(100.0, currencies) == "2 Keys"
 
 
-def test_convert_price_to_keys_ref_mislabeled_keys():
+def test_format_price_keys_and_ref():
     currencies = {"keys": {"price": {"value_raw": 50.0}}}
-    out = convert_price_to_keys_ref(125.5, "keys", currencies)
-    assert out == "2 Keys 25.5 Refined"
+    assert format_price(125.5, currencies) == "2 Keys 25.50 Refined"
 
 
-def test_convert_to_key_ref_only_refined():
+def test_format_price_only_refined():
     currencies = {"keys": {"price": {"value_raw": 50.0}}}
-    assert convert_to_key_ref(5.0, currencies) == "5.00 Refined"
+    assert format_price(5.0, currencies) == "5.00 Refined"
 
 
-def test_convert_to_key_ref_keys_and_refined():
-    currencies = {"keys": {"price": {"value_raw": 50.0}}}
-    assert convert_to_key_ref(125.5, currencies) == "2 Keys 25.50 Refined"
+def test_format_price_example():
+    currencies = {"keys": {"price": {"value_raw": 67.165}}}
+    val = 164554.25
+    assert format_price(val, currencies) == "2449 Keys 67.16 Refined"

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -7,7 +7,7 @@ import json
 from pathlib import Path
 
 from . import steam_api_client, local_data
-from .price_service import convert_price_to_keys_ref, convert_to_key_ref
+from .price_service import format_price
 from .wear_helpers import _wear_tier, _decode_seed_info
 from .constants import (
     KILLSTREAK_TIERS,
@@ -589,7 +589,8 @@ def _is_plain_craft_weapon(asset: dict, schema_entry: Dict[str, Any]) -> bool:
 
 
 def _process_item(
-    asset: dict, price_map: dict[tuple[int, int], dict] | None = None
+    asset: dict,
+    price_map: dict[tuple[int, int] | tuple[int, int, int], dict] | None = None,
 ) -> dict | None:
     """Return an enriched item dictionary for a single asset.
 
@@ -598,9 +599,9 @@ def _process_item(
     asset:
         Raw inventory item from Steam.
     price_map:
-        Optional mapping of ``(defindex, quality_id)`` to Backpack.tf price
-        data. When provided, price information is added under ``"price"`` and
-        ``"price_string"`` keys.
+        Optional mapping of ``(defindex, quality_id[, effect_id])`` to Backpack.tf
+        price data. When provided, price information is added under ``"price"``
+        and ``"price_string"`` keys.
     """
 
     defindex_raw = asset.get("defindex", 0)
@@ -759,32 +760,25 @@ def _process_item(
         ),
     }
     if price_map is not None:
-        info = price_map.get((defindex_int, int(quality_id)))
+        info = None
+        if effect_id is not None and int(quality_id) == 5:
+            info = price_map.get((defindex_int, int(quality_id), effect_id))
+        if info is None:
+            info = price_map.get((defindex_int, int(quality_id)))
+
         if info:
             item["price"] = info
             value = info.get("value_raw")
-            currency = info.get("currency")
-            if value is not None and currency:
-                c = str(currency).lower()
-                if c == "keys":
-                    formatted = convert_price_to_keys_ref(
-                        value, currency, local_data.CURRENCIES
-                    )
-                elif c in {"metal", "ref", "refined"}:
-                    formatted = convert_to_key_ref(
-                        value, currencies=local_data.CURRENCIES
-                    )
-                else:
-                    formatted = convert_price_to_keys_ref(
-                        value, currency, local_data.CURRENCIES
-                    )
+            if value is not None:
+                formatted = format_price(value, local_data.CURRENCIES)
                 item["price_string"] = formatted
                 item["formatted_price"] = formatted
     return item
 
 
 def enrich_inventory(
-    data: Dict[str, Any], price_map: dict[tuple[int, int], dict] | None = None
+    data: Dict[str, Any],
+    price_map: dict[tuple[int, int] | tuple[int, int, int], dict] | None = None,
 ) -> List[Dict[str, Any]]:
     """Return a list of inventory items enriched with schema info.
 
@@ -793,8 +787,8 @@ def enrich_inventory(
     data:
         Inventory payload from Steam.
     price_map:
-        Optional mapping of ``(defindex, quality_id)`` to Backpack.tf price
-        information. When provided, items will include price metadata.
+        Optional mapping of ``(defindex, quality_id[, effect_id])`` to Backpack.tf
+        price information. When provided, items will include price metadata.
     """
     items_raw = data.get("items")
     if not isinstance(items_raw, list):

--- a/utils/price_service.py
+++ b/utils/price_service.py
@@ -5,96 +5,46 @@ from typing import Any, Dict
 from . import local_data
 
 
-def convert_price_to_keys_ref(
-    value_raw: float, currency: str, currencies: Dict[str, Any]
-) -> str:
-    """Return human-readable price in keys and refined metal.
-
-    ``value_raw`` from the Backpack.tf price dump is always expressed in
-    refined metal, even when the ``currency`` field is ``"keys"``. This
-    helper converts that metal value into a formatted string using the
-    current key price from ``currencies``.
-    """
+def format_price(value_raw: float, currencies: Dict[str, Any]) -> str:
+    """Return a refined metal value formatted in keys and refined metal."""
 
     try:
         value = float(value_raw)
     except (TypeError, ValueError):
         return ""
 
-    curr_lower = str(currency or "").lower()
-
     key_price = 0.0
     try:
         key_price = float(currencies["keys"]["price"]["value_raw"])
-    except Exception:
+    except Exception:  # pragma: no cover - defensive
         pass
 
-    # Determine if ``value_raw`` is actually in refined metal units.
-    in_ref = curr_lower in {"metal", "ref", "refined"} or (
-        curr_lower == "keys" and key_price > 0 and value >= key_price
-    )
+    keys = int(value // key_price) if key_price > 0 else 0
+    refined = value - keys * key_price if key_price > 0 else value
 
-    if in_ref:
-        if key_price > 0:
-            keys = int(value // key_price)
-            refined = round(value - keys * key_price, 2)
-            if keys and refined:
-                return f"{keys} Keys {refined} Refined"
-            if keys:
-                return f"{keys} Keys"
-            return f"{refined} Refined"
-        return f"{round(value, 2)} Refined"
+    parts: list[str] = []
+    if keys:
+        parts.append(f"{keys} Key" + ("s" if keys != 1 else ""))
+    if refined > 0 or not parts:
+        parts.append(f"{refined:.2f} Refined")
 
-    if curr_lower == "keys":
-        if value.is_integer():
-            return f"{int(value)} Keys"
-        return f"{round(value, 2)} Keys"
+    return " ".join(parts)
 
-    return f"{round(value, 2)} {currency}"
+
+def convert_price_to_keys_ref(
+    value_raw: float, currency: str, currencies: Dict[str, Any]
+) -> str:
+    """Backward compatible wrapper calling :func:`format_price`."""
+
+    return format_price(value_raw, currencies)
 
 
 def convert_to_key_ref(
     value_refined: float, currencies: Dict[str, Any] | None = None
 ) -> str:
-    """Convert a refined metal value into a keys+refined string.
-
-    Parameters
-    ----------
-    value_refined:
-        The amount of refined metal to convert.
-    currencies:
-        Mapping of currency data loaded from ``local_data``. If ``None``,
-        ``local_data.CURRENCIES`` will be used.
-
-    Returns
-    -------
-    str
-        A string in the form ``"<N> Keys <M.MM> Refined"``. Keys are computed
-        using integer division and the remainder is formatted with two decimal
-        places.
-    """
-
-    try:
-        value = float(value_refined)
-    except (TypeError, ValueError):
-        return ""
+    """Backward compatible wrapper for :func:`format_price`."""
 
     if currencies is None:
         currencies = local_data.CURRENCIES
 
-    key_price = 50.0
-    try:
-        key_price = float(currencies["keys"]["price"]["value_raw"])
-    except Exception:
-        pass
-
-    keys = int(value // key_price)
-    refined = value - keys * key_price
-
-    parts = []
-    if keys:
-        parts.append(f"{keys} Key" + ("s" if keys != 1 else ""))
-    if refined > 0.0 or not parts:
-        parts.append(f"{refined:.2f} Refined")
-
-    return " ".join(parts)
+    return format_price(value_refined, currencies)


### PR DESCRIPTION
## Summary
- always treat `value_raw` as refined
- simplify price formatting logic
- support effect-based price map keys
- parse unusual effect prices in price loader
- adapt inventory tests for new formatting

## Testing
- `pre-commit run --files utils/price_service.py utils/inventory_processor.py utils/price_loader.py tests/test_price_service.py tests/test_convert_price.py tests/test_price_loader.py tests/test_inventory_processor.py`

------
https://chatgpt.com/codex/tasks/task_e_686a8dfce1908326a81769b6d676f5d6