### PR TITLE
Move price below item and use lowercase ref

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -241,8 +241,10 @@ button {
 }
 
 .item-price {
-  margin-top: auto;
-  font-size: 12px;
+  margin-top: 2px;
+  font-size: 11px;
+  text-align: center;
+  word-wrap: break-word;
 }
 
 /* ───── Paint colour dot (used in card & modal) ───────────────────── */

--- a/tests/test_convert_price.py
+++ b/tests/test_convert_price.py
@@ -4,7 +4,7 @@ currencies = {"keys": {"price": {"value_raw": 67.16}}}
 
 
 def test_format_price_metal_to_keys_and_ref():
-    assert format_price(123.44, currencies) == "1 Key 56.28 Refined"
+    assert format_price(123.44, currencies) == "1 Key 56.28 ref"
 
 
 def test_format_price_exact_key():
@@ -20,4 +20,4 @@ def test_format_price_custom_exact_key():
 
 
 def test_format_price_custom_keys_and_refined():
-    assert format_price(123.44, currencies) == "1 Key 56.28 Refined"
+    assert format_price(123.44, currencies) == "1 Key 56.28 ref"

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -424,8 +424,8 @@ def test_price_map_applied():
     items = ip.enrich_inventory(data, price_map=price_map)
     item = items[0]
     assert item["price"] == price_map[(42, 6)]
-    assert item["price_string"] == "5.33 Refined"
-    assert item["formatted_price"] == "5.33 Refined"
+    assert item["price_string"] == "5.33 ref"
+    assert item["formatted_price"] == "5.33 ref"
 
 
 def test_price_map_key_conversion_large_value():
@@ -437,8 +437,8 @@ def test_price_map_key_conversion_large_value():
 
     items = ip.enrich_inventory(data, price_map=price_map)
     item = items[0]
-    assert item["formatted_price"] == "5 Keys 17.73 Refined"
-    assert item["price_string"] == "5 Keys 17.73 Refined"
+    assert item["formatted_price"] == "5 Keys 17.73 ref"
+    assert item["price_string"] == "5 Keys 17.73 ref"
 
 
 def test_price_map_unusual_lookup():
@@ -458,5 +458,5 @@ def test_price_map_unusual_lookup():
 
     items = ip.enrich_inventory(data, price_map=price_map)
     item = items[0]
-    assert item["formatted_price"] == "2449 Keys 67.16 Refined"
-    assert item["price_string"] == "2449 Keys 67.16 Refined"
+    assert item["formatted_price"] == "2449 Keys 67.16 ref"
+    assert item["price_string"] == "2449 Keys 67.16 ref"

--- a/tests/test_price_service.py
+++ b/tests/test_price_service.py
@@ -3,7 +3,7 @@ from utils.price_service import format_price
 
 def test_format_price_basic():
     currencies = {"keys": {"price": {"value_raw": 50.0}}}
-    assert format_price(25.0, currencies) == "25.00 Refined"
+    assert format_price(25.0, currencies) == "25.00 ref"
 
 
 def test_format_price_keys_only():
@@ -13,15 +13,15 @@ def test_format_price_keys_only():
 
 def test_format_price_keys_and_ref():
     currencies = {"keys": {"price": {"value_raw": 50.0}}}
-    assert format_price(125.5, currencies) == "2 Keys 25.50 Refined"
+    assert format_price(125.5, currencies) == "2 Keys 25.50 ref"
 
 
 def test_format_price_only_refined():
     currencies = {"keys": {"price": {"value_raw": 50.0}}}
-    assert format_price(5.0, currencies) == "5.00 Refined"
+    assert format_price(5.0, currencies) == "5.00 ref"
 
 
 def test_format_price_example():
     currencies = {"keys": {"price": {"value_raw": 67.165}}}
     val = 164554.25
-    assert format_price(val, currencies) == "2449 Keys 67.16 Refined"
+    assert format_price(val, currencies) == "2449 Keys 67.16 ref"

--- a/utils/price_service.py
+++ b/utils/price_service.py
@@ -26,7 +26,7 @@ def format_price(value_raw: float, currencies: Dict[str, Any]) -> str:
     if keys:
         parts.append(f"{keys} Key" + ("s" if keys != 1 else ""))
     if refined > 0 or not parts:
-        parts.append(f"{refined:.2f} Refined")
+        parts.append(f"{refined:.2f} ref")
 
     return " ".join(parts)
 
@@ -34,7 +34,7 @@ def format_price(value_raw: float, currencies: Dict[str, Any]) -> str:
 def convert_price_to_keys_ref(
     value_raw: float, currency: str, currencies: Dict[str, Any]
 ) -> str:
-    """Backward compatible wrapper calling :func:`format_price`."""
+    """Return a price string like ``"1 Key 0.11 ref"``."""
 
     return format_price(value_raw, currencies)
 
@@ -42,7 +42,7 @@ def convert_price_to_keys_ref(
 def convert_to_key_ref(
     value_refined: float, currencies: Dict[str, Any] | None = None
 ) -> str:
-    """Backward compatible wrapper for :func:`format_price`."""
+    """Return a price string formatted using key price and refined metal."""
 
     if currencies is None:
         currencies = local_data.CURRENCIES


### PR DESCRIPTION
## Summary
- show refined metal prices in lowercase `ref`
- tweak item card price styling
- update unit tests for new price format

## Testing
- `pre-commit run --files utils/price_service.py static/style.css tests/test_convert_price.py tests/test_price_service.py tests/test_inventory_processor.py`

------
https://chatgpt.com/codex/tasks/task_e_686a93c8bea48326bcb17103c67294fe