### PR TITLE
Move item prices below card

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -138,15 +138,22 @@ button {
 }
 
 
+.item-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 4px;
+}
+
 .item-card {
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: flex-start;
   width: 96px;
-  height: 128px;
+  height: 112px;
   padding: 4px;
-  margin: 4px;
+  margin: 0;
   border: 2px solid #FFDD00;
   border-radius: 8px;
   overflow: hidden;
@@ -279,6 +286,6 @@ button {
   }
   .item-card {
     width: 80px;
-    height: 120px;
+    height: 104px;
   }
 }

--- a/templates/_user.html
+++ b/templates/_user.html
@@ -25,12 +25,15 @@
       <button class="scroll-arrow left" type="button" aria-label="Scroll left">
         <i class="fa-solid fa-chevron-left"></i>
       </button>
-      <div class="inventory-container">
-        {% for item in user.items if not item._hidden %}
-          {# ↑ keep border-color for quality #}
-          {% include "item_card.html" %}
-        {% endfor %}
-      </div>
+        <div class="inventory-container">
+          {% for item in user.items if not item._hidden %}
+            {# ↑ keep border-color for quality #}
+            <div class="item-wrapper">
+              {% include "item_card.html" %}
+              <div class="item-price">{{ item.formatted_price or "Unpriced" }}</div>
+            </div>
+          {% endfor %}
+        </div>
       <button class="scroll-arrow right" type="button" aria-label="Scroll right">
         <i class="fa-solid fa-chevron-right"></i>
       </button>

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -23,7 +23,6 @@
     <div class="missing-icon"></div>
   {% endif %}
   <h2 class="item-title">{{ item.name }}</h2>
-  <div class="item-price">{{ item.formatted_price or "Unpriced" }}</div>
   {% if item.strange_parts %}
     <ul class="text-xs mt-1 text-gray-300">
       {% for part in item.strange_parts %}


### PR DESCRIPTION
## Summary
- drop item price element from `item_card.html`
- wrap item cards in `.item-wrapper` that displays prices below cards
- adjust `static/style.css` for updated layout

## Testing
- `pre-commit run --files static/style.css templates/item_card.html templates/_user.html` *(fails: ModuleNotFoundError: No module named 'vdf')*
- `pytest -q` *(fails: unrecognized arguments: --cov --cov-config=.coveragerc)*

------
https://chatgpt.com/codex/tasks/task_e_686a9680d4c08326b86dd3abe0ee5664