### PR TITLE
Fix item title truncation

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -151,12 +151,10 @@ button {
   align-items: center;
   justify-content: flex-start;
   width: 96px;
-  height: 112px;
   padding: 4px;
   margin: 0;
   border: 2px solid #FFDD00;
   border-radius: 8px;
-  overflow: hidden;
   background-color: #1e1e1e;
   position: relative; /* ensure badges overlay */
 }
@@ -240,11 +238,6 @@ button {
   word-break: break-word;
   color: #fff;
   line-height: 1.2em;
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
-  overflow: hidden;
-  max-height: 2.4em;
 }
 
 .item-price {
@@ -286,6 +279,5 @@ button {
   }
   .item-card {
     width: 80px;
-    height: 104px;
   }
 }


### PR DESCRIPTION
## Summary
- let item cards auto-adjust height
- remove text clamping from item names

## Testing
- `pre-commit run --files static/style.css` *(fails: ModuleNotFoundError: No module named 'vdf')*
- `pytest -q` *(fails: error: unrecognized arguments: --cov --cov-config=.coveragerc)*

------
https://chatgpt.com/codex/tasks/task_e_686a9a2357c48326a2eda99500676d8a