### PR TITLE
Revert item card layout changes

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -151,10 +151,12 @@ button {
   align-items: center;
   justify-content: flex-start;
   width: 96px;
+  height: 112px;
   padding: 4px;
   margin: 0;
   border: 2px solid #FFDD00;
   border-radius: 8px;
+  overflow: hidden;
   background-color: #1e1e1e;
   position: relative; /* ensure badges overlay */
 }
@@ -238,6 +240,11 @@ button {
   word-break: break-word;
   color: #fff;
   line-height: 1.2em;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+  max-height: 2.4em;
 }
 
 .item-price {
@@ -279,5 +286,6 @@ button {
   }
   .item-card {
     width: 80px;
+    height: 104px;
   }
 }


### PR DESCRIPTION
## Summary
- revert the style changes that removed fixed item card height and line-clamp

## Testing
- `pre-commit run --files static/style.css` *(fails: ModuleNotFoundError: No module named 'vdf')*

------
https://chatgpt.com/codex/tasks/task_e_686a9cbccb3483269a586e0846e682d4