### PR TITLE
Fix price layout on item cards

### DIFF
--- a/templates/_user.html
+++ b/templates/_user.html
@@ -30,7 +30,6 @@
             {# ↑ keep border-color for quality #}
             <div class="item-wrapper">
               {% include "item_card.html" %}
-              <div class="item-price">{{ item.formatted_price or "Unpriced" }}</div>
             </div>
           {% endfor %}
         </div>

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -23,6 +23,9 @@
     <div class="missing-icon"></div>
   {% endif %}
   <h2 class="item-title">{{ item.name }}</h2>
+  {% if item.price_string %}
+    <div class="item-price">{{ item.price_string|replace("Refined", "ref") }}</div>
+  {% endif %}
   {% if item.strange_parts %}
     <ul class="text-xs mt-1 text-gray-300">
       {% for part in item.strange_parts %}


### PR DESCRIPTION
## Summary
- update item card to render item price on its own line
- remove duplicate price markup from `_user.html`

## Testing
- `pre-commit run --files templates/item_card.html templates/_user.html` *(fails: ModuleNotFoundError: No module named 'vdf')*

------
https://chatgpt.com/codex/tasks/task_e_686a9e666a108326b3daea101cdba339