### PR TITLE
Fix item card layout for long titles

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -149,9 +149,10 @@ button {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: flex-start;
+  justify-content: space-between;
   width: 96px;
-  height: 112px;
+  height: auto;
+  min-height: 128px;
   padding: 4px;
   margin: 0;
   border: 2px solid #FFDD00;
@@ -236,9 +237,6 @@ button {
 
 .item-title {
   font-size: 0.9rem;
-  text-align: center;
-  word-break: break-word;
-  color: #fff;
   line-height: 1.1rem;
   white-space: normal;
   overflow: visible;

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -23,6 +23,11 @@
     <div class="missing-icon"></div>
   {% endif %}
   <h2 class="item-title">{{ item.name }}</h2>
+  {% if item.price_string %}
+    <div class="item-price">
+      {{ item.price_string | replace("Refined", "ref") | lower }}
+    </div>
+  {% endif %}
   {% if item.strange_parts %}
     <ul class="text-xs mt-1 text-gray-300">
       {% for part in item.strange_parts %}


### PR DESCRIPTION
## Summary
- ensure item cards expand for long names
- let item titles wrap with intact price placement

## Testing
- `pre-commit run --files static/style.css templates/item_card.html` *(fails: ModuleNotFoundError: No module named 'vdf')*

------
https://chatgpt.com/codex/tasks/task_e_686acc65f0488326a09b3e8b4fd2bacd