### PR TITLE
Fix item card styling

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -151,8 +151,7 @@ button {
   align-items: center;
   justify-content: space-between;
   width: 96px;
-  height: auto;
-  min-height: 128px;
+  height: 112px;
   padding: 4px;
   margin: 0;
   border: 2px solid #FFDD00;
@@ -238,9 +237,16 @@ button {
 .item-title {
   font-size: 0.9rem;
   line-height: 1.1rem;
-  white-space: normal;
-  overflow: visible;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  overflow: hidden;
+  max-height: 3.3rem;
   margin-top: 0.4rem;
+}
+
+.item-title.long {
+  font-size: 0.8rem;
 }
 
 .item-price {

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -22,7 +22,7 @@
   {% else %}
     <div class="missing-icon"></div>
   {% endif %}
-  <h2 class="item-title">{{ item.name }}</h2>
+  <h2 class="item-title {% if item.name|length > 45 %}long{% endif %}" title="{{ item.name }}">{{ item.name }}</h2>
   {% if item.price_string %}
     <div class="item-price">
       {{ item.price_string | replace("Refined", "ref") | lower }}


### PR DESCRIPTION
## Summary
- tweak card height in CSS
- support long titles with a separate class
- preserve price placement below title
- update item card template for long titles

## Testing
- `pre-commit run --files static/style.css templates/item_card.html`

------
https://chatgpt.com/codex/tasks/task_e_686acf04e45483268ac20af19dbe32b4