### PR TITLE
Improve item card title scaling

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -235,18 +235,24 @@ button {
 }
 
 .item-title {
-  font-size: 0.9rem;
-  line-height: 1.1rem;
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 3;
   overflow: hidden;
-  max-height: 3.3rem;
+  text-align: center;
+  word-break: break-word;
+  white-space: normal;
+  color: #fff;
+  font-size: 0.9rem;
+  line-height: 1.1rem;
+  max-height: 3.3rem; /* 3 lines x 1.1rem */
   margin-top: 0.4rem;
 }
 
-.item-title.long {
+.item-title.small-font {
   font-size: 0.8rem;
+  line-height: 1rem;
+  max-height: 3rem;
 }
 
 .item-price {

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -22,7 +22,9 @@
   {% else %}
     <div class="missing-icon"></div>
   {% endif %}
-  <h2 class="item-title {% if item.name|length > 45 %}long{% endif %}" title="{{ item.name }}">{{ item.name }}</h2>
+  <h2 class="item-title {% if item.name|length > 45 %}small-font{% endif %}" title="{{ item.name }}">
+    {{ item.name }}
+  </h2>
   {% if item.price_string %}
     <div class="item-price">
       {{ item.price_string | replace("Refined", "ref") | lower }}


### PR DESCRIPTION
## Summary
- adjust `.item-title` rules for three line clamp and dynamic font size
- use `.item-title.small-font` in HTML when names exceed 45 chars

## Testing
- `pre-commit run --files static/style.css templates/item_card.html` *(fails: Failed to load schema)*
- `STEAM_API_KEY=test pytest`

------
https://chatgpt.com/codex/tasks/task_e_686ad2167a4c8326980a3e82def72db7