### PR TITLE
Adjust item titles to display up to three lines

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -235,16 +235,16 @@ button {
 }
 
 .item-title {
-  font-size: 12px;
+  font-size: 11px;
   text-align: center;
   word-break: break-word;
   color: #fff;
   line-height: 1.2em;
   display: -webkit-box;
   -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
+  -webkit-line-clamp: 3;
   overflow: hidden;
-  max-height: 2.4em;
+  max-height: 3.6em;
 }
 
 .item-price {


### PR DESCRIPTION
## Summary
- adjust font size for item titles
- allow up to three lines of text before truncation

## Testing
- `pre-commit run --files static/style.css` *(fails: missing schema and pytest errors)*

------
https://chatgpt.com/codex/tasks/task_e_686ad5cdff58832680f982866570cde7