### PR TITLE
Remove strange parts badges

### DIFF
--- a/static/modal.js
+++ b/static/modal.js
@@ -112,9 +112,6 @@
 
     if (data.custom_description) attrs.push('<div>Custom Desc: ' + esc(data.custom_description) + '</div>');
 
-    if (Array.isArray(data.strange_parts) && data.strange_parts.length) {
-      attrs.push('<div>Strange Parts: ' + data.strange_parts.map(esc).join(', ') + '</div>');
-    }
 
     let spells = '';
     if (Array.isArray(data.spells) && data.spells.length) {

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -10,9 +10,6 @@
           <span class="badge" data-icon="{{ badge.icon }}"{% if badge.color %} style="color:{{ badge.color }}"{% endif %} title="{{ badge.title }}">{{ badge.icon }}</span>
         {% endif %}
       {% endfor %}
-    {% if "🔧" in item.badges %}
-      <span class="badge bg-indigo-600" title="Contains Strange Parts">🔧</span>
-    {% endif %}
   </div>
   {% if item.quantity and item.quantity > 1 %}
     <span class="item-qty">x{{ item.quantity }}</span>
@@ -23,11 +20,4 @@
     <div class="missing-icon"></div>
   {% endif %}
   <h2 class="item-title">{{ item.name }}</h2>
-  {% if item.strange_parts %}
-    <ul class="text-xs mt-1 text-gray-300">
-      {% for part in item.strange_parts %}
-        <li>🛠️ {{ part }}</li>
-      {% endfor %}
-    </ul>
-  {% endif %}
 </div>

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -821,11 +821,6 @@ def enrich_inventory(
                     if name:
                         parts_found.add(name)
             if parts_found:
-                badges = item.setdefault("badges", [])
-                if "🔧" not in badges and not any(
-                    isinstance(b, dict) and b.get("icon") == "🔧" for b in badges
-                ):
-                    badges.append("🔧")
                 existing = item.get("strange_parts", [])
                 if not isinstance(existing, list):
                     existing = []


### PR DESCRIPTION
## Summary
- drop display of strange part badges from templates and modal logic
- stop appending wrench badge in inventory processing

## Testing
- `SKIP_VALIDATE=1 pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ad9c2d1b0832699b858ab6d04fe39