### PR TITLE
Handle untradable items gracefully

### DIFF
--- a/templates/_user.html
+++ b/templates/_user.html
@@ -30,7 +30,9 @@
             {# ↑ keep border-color for quality #}
             <div class="item-wrapper">
               {% include "item_card.html" %}
-              <div class="item-price">{{ item.formatted_price or "Unpriced" }}</div>
+              {% if item.price_string %}
+                <div class="item-price">{{ item.formatted_price }}</div>
+              {% endif %}
             </div>
           {% endfor %}
         </div>

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -460,3 +460,28 @@ def test_price_map_unusual_lookup():
     item = items[0]
     assert item["formatted_price"] == "2449 Keys 67.16 ref"
     assert item["price_string"] == "2449 Keys 67.16 ref"
+
+
+def test_untradable_item_no_price():
+    data = {"items": [{"defindex": 42, "quality": 6, "tradable": 0}]}
+    ld.ITEMS_BY_DEFINDEX = {42: {"item_name": "Answer", "image_url": ""}}
+    ld.QUALITIES_BY_INDEX = {6: "Unique"}
+    price_map = {(42, 6): {"value_raw": 5.33, "currency": "metal"}}
+    ld.CURRENCIES = {"keys": {"price": {"value_raw": 50.0}}}
+
+    items = ip.enrich_inventory(data, price_map=price_map)
+    item = items[0]
+    assert "price" not in item
+    assert "price_string" not in item
+
+
+def test_tradable_item_missing_price():
+    data = {"items": [{"defindex": 43, "quality": 6, "tradable": 1}]}
+    ld.ITEMS_BY_DEFINDEX = {43: {"item_name": "Bazooka", "image_url": ""}}
+    ld.QUALITIES_BY_INDEX = {6: "Unique"}
+    ld.CURRENCIES = {"keys": {"price": {"value_raw": 50.0}}}
+
+    items = ip.enrich_inventory(data, price_map={})
+    item = items[0]
+    assert item["price"] is None
+    assert item["price_string"] == ""

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -760,19 +760,29 @@ def _process_item(
         ),
     }
     if price_map is not None:
-        info = None
-        if effect_id is not None and int(quality_id) == 5:
-            info = price_map.get((defindex_int, int(quality_id), effect_id))
-        if info is None:
-            info = price_map.get((defindex_int, int(quality_id)))
+        tradable = asset.get("tradable", 1)
+        try:
+            tradable = int(tradable)
+        except (TypeError, ValueError):  # pragma: no cover - fallback handling
+            tradable = 1
 
-        if info:
-            item["price"] = info
-            value = info.get("value_raw")
-            if value is not None:
-                formatted = format_price(value, local_data.CURRENCIES)
-                item["price_string"] = formatted
-                item["formatted_price"] = formatted
+        if tradable:
+            info = None
+            if effect_id is not None and int(quality_id) == 5:
+                info = price_map.get((defindex_int, int(quality_id), effect_id))
+            if info is None:
+                info = price_map.get((defindex_int, int(quality_id)))
+
+            if info:
+                item["price"] = info
+                value = info.get("value_raw")
+                if value is not None:
+                    formatted = format_price(value, local_data.CURRENCIES)
+                    item["price_string"] = formatted
+                    item["formatted_price"] = formatted
+            else:
+                item["price"] = None
+                item["price_string"] = ""
     return item
 
 


### PR DESCRIPTION
## Summary
- skip price enrichment for untradable assets
- default missing prices to `None`/'' for tradable items
- hide item price in UI when no price string present
- add tests for new pricing behaviour

## Testing
- `pre-commit run --files utils/inventory_processor.py templates/_user.html tests/test_inventory_processor.py`

------
https://chatgpt.com/codex/tasks/task_e_686ae28633e883269a5285617fdebf36