### PR TITLE
Add australium display names

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -485,3 +485,12 @@ def test_tradable_item_missing_price():
     item = items[0]
     assert item["price"] is None
     assert item["price_string"] == ""
+
+
+def test_australium_display_name():
+    data = {"items": [{"defindex": 111, "quality": 6, "is_australium": True}]}
+    ld.ITEMS_BY_DEFINDEX = {111: {"item_name": "Rocket Launcher", "image_url": ""}}
+    ld.QUALITIES_BY_INDEX = {6: "Unique"}
+    items = ip.enrich_inventory(data)
+    item = items[0]
+    assert item["display_name"] == "Australium Rocket Launcher"

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -628,6 +628,8 @@ def _process_item(
     if paintkit_name:
         base_name = f"{base_name} ({paintkit_name})"
 
+    is_australium = asset.get("is_australium")
+
     quality_id = asset.get("quality", 0)
     q_name = local_data.QUALITIES_BY_INDEX.get(quality_id)
     if not q_name:
@@ -712,12 +714,22 @@ def _process_item(
             }
         )
 
+    if is_australium:
+        clean_base = re.sub(
+            r"^(Strange|Unique|Vintage|Haunted|Collector's|Genuine|Unusual)\s+",
+            "",
+            base_name,
+            flags=re.IGNORECASE,
+        )
+        display_name = f"Australium {clean_base}"
+
     item = {
         "defindex": defindex,
         "name": name,
         "original_name": original_name,
         "base_name": base_name,
         "display_name": display_name,
+        "is_australium": bool(is_australium),
         "quality": q_name,
         "quality_color": q_col,
         "image_url": image_url,


### PR DESCRIPTION
## Summary
- handle `is_australium` flag in `_process_item`
- expose `is_australium` in returned item dict
- display "Australium" prefix for australium items
- test australium display name formatting

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py`

------
https://chatgpt.com/codex/tasks/task_e_686aeb1eb6ec83268648be0312249d8c