### PR TITLE
Add australium attribute detection

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -494,3 +494,21 @@ def test_australium_display_name():
     items = ip.enrich_inventory(data)
     item = items[0]
     assert item["display_name"] == "Australium Rocket Launcher"
+
+
+def test_australium_attribute_sets_flag():
+    data = {
+        "items": [
+            {
+                "defindex": 111,
+                "quality": 6,
+                "attributes": [{"defindex": 2027}],
+            }
+        ]
+    }
+    ld.ITEMS_BY_DEFINDEX = {111: {"item_name": "Rocket Launcher", "image_url": ""}}
+    ld.QUALITIES_BY_INDEX = {6: "Unique"}
+    items = ip.enrich_inventory(data)
+    item = items[0]
+    assert item["is_australium"] is True
+    assert item["display_name"] == "Australium Rocket Launcher"

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -305,6 +305,19 @@ def _extract_crate_series(asset: Dict[str, Any]) -> str | None:
     return None
 
 
+def _extract_australium(asset: Dict[str, Any]) -> bool:
+    """Return True if the asset has an Australium attribute."""
+
+    for attr in asset.get("attributes", []):
+        idx = attr.get("defindex")
+        try:
+            if int(idx) == 2027:
+                return True
+        except (TypeError, ValueError):
+            continue
+    return False
+
+
 def _extract_killstreak_effect(asset: Dict[str, Any]) -> str | None:
     """Return killstreak effect string if present."""
 
@@ -628,7 +641,7 @@ def _process_item(
     if paintkit_name:
         base_name = f"{base_name} ({paintkit_name})"
 
-    is_australium = asset.get("is_australium")
+    is_australium = asset.get("is_australium") or _extract_australium(asset)
 
     quality_id = asset.get("quality", 0)
     q_name = local_data.QUALITIES_BY_INDEX.get(quality_id)


### PR DESCRIPTION
## Summary
- support Australium attribute extraction
- flag items as Australium when the attribute is present
- test australium attribute detection

## Testing
- `pytest`
- `pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py` *(fails: Failed to load schema)*

------
https://chatgpt.com/codex/tasks/task_e_686af7a78e508326862c223af664aba5