### PR TITLE
Fix australium filtering

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -414,6 +414,22 @@ def test_special_craft_weapon_kept():
     assert len(items) == 1
 
 
+def test_australium_only_attribute_kept():
+    data = {
+        "items": [
+            {
+                "defindex": 12,
+                "quality": 6,
+                "attributes": [{"defindex": 2027}],
+            }
+        ]
+    }
+    ld.ITEMS_BY_DEFINDEX = {12: {"item_name": "C", "craft_class": "weapon"}}
+    ld.QUALITIES_BY_INDEX = {6: "Unique"}
+    items = ip.enrich_inventory(data)
+    assert len(items) == 1
+
+
 def test_price_map_applied():
     data = {"items": [{"defindex": 42, "quality": 6}]}
     ld.ITEMS_BY_DEFINDEX = {42: {"item_name": "Answer", "image_url": ""}}

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -580,6 +580,9 @@ def _is_plain_craft_weapon(asset: dict, schema_entry: Dict[str, Any]) -> bool:
     ):
         return False
 
+    if _extract_australium(asset):
+        return False
+
     for attr in asset.get("attributes", []) or []:
         idx = attr.get("defindex")
         try:


### PR DESCRIPTION
## Summary
- ensure plain craft weapon detection skips australium attribute
- add regression test for australium-only craft weapons

## Testing
- `pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py`
- `pytest tests/test_inventory_processor.py::test_australium_only_attribute_kept -q`

------
https://chatgpt.com/codex/tasks/task_e_686af91ca1248326b5dce3500f2bff95