### PR TITLE
Add australium price lookup

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -528,3 +528,16 @@ def test_australium_attribute_sets_flag():
     item = items[0]
     assert item["is_australium"] is True
     assert item["display_name"] == "Australium Rocket Launcher"
+
+
+def test_price_map_australium_lookup():
+    data = {"items": [{"defindex": 205, "quality": 6, "is_australium": True}]}
+    ld.ITEMS_BY_DEFINDEX = {205: {"item_name": "Rocket Launcher", "image_url": ""}}
+    ld.QUALITIES_BY_INDEX = {6: "Unique"}
+    price_map = {(205, 6, "australium"): {"value_raw": 100.0, "currency": "keys"}}
+    ld.CURRENCIES = {"keys": {"price": {"value_raw": 50.0}}}
+
+    items = ip.enrich_inventory(data, price_map=price_map)
+    item = items[0]
+    assert item["price"] == price_map[(205, 6, "australium")]
+    assert item["formatted_price"] == "2 Keys"

--- a/tests/test_price_loader.py
+++ b/tests/test_price_loader.py
@@ -118,6 +118,44 @@ def test_price_map_unusual_effect(tmp_path, monkeypatch):
     assert mapping[(30998, 5, 13)]["currency"] == "keys"
 
 
+def test_price_map_australium(tmp_path, monkeypatch):
+    monkeypatch.setenv("BPTF_API_KEY", "TEST")
+    monkeypatch.setattr(price_loader, "PRICES_FILE", tmp_path / "prices.json")
+    url = "https://backpack.tf/api/IGetPrices/v4?raw=1&key=TEST"
+    payload = {
+        "response": {
+            "success": 1,
+            "items": {
+                "Rocket Launcher": {
+                    "defindex": [205],
+                    "australium": "1",
+                    "prices": {
+                        "6": {
+                            "Tradable": {
+                                "Craftable": [
+                                    {
+                                        "value": 100,
+                                        "value_raw": 100.0,
+                                        "currency": "keys",
+                                        "last_update": 0,
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                }
+            },
+        }
+    }
+
+    with responses.RequestsMock() as rsps:
+        rsps.add(responses.GET, url, json=payload, status=200)
+        p = price_loader.ensure_prices_cached(refresh=True)
+
+    mapping = price_loader.build_price_map(p)
+    assert (205, 6, "australium") in mapping
+
+
 def test_missing_api_key(monkeypatch):
     monkeypatch.delenv("BPTF_API_KEY", raising=False)
     with pytest.raises(RuntimeError):

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -606,7 +606,13 @@ def _is_plain_craft_weapon(asset: dict, schema_entry: Dict[str, Any]) -> bool:
 
 def _process_item(
     asset: dict,
-    price_map: dict[tuple[int, int] | tuple[int, int, int], dict] | None = None,
+    price_map: (
+        dict[
+            tuple[int, int] | tuple[int, int, int] | tuple[int, int, str],
+            dict,
+        ]
+        | None
+    ) = None,
 ) -> dict | None:
     """Return an enriched item dictionary for a single asset.
 
@@ -615,9 +621,10 @@ def _process_item(
     asset:
         Raw inventory item from Steam.
     price_map:
-        Optional mapping of ``(defindex, quality_id[, effect_id])`` to Backpack.tf
-        price data. When provided, price information is added under ``"price"``
-        and ``"price_string"`` keys.
+        Optional mapping of ``(defindex, quality_id[, effect])`` or
+        ``(defindex, quality, "australium")`` to Backpack.tf price data. When
+        provided, price information is added under ``"price"`` and
+        ``"price_string"`` keys.
     """
 
     defindex_raw = asset.get("defindex", 0)
@@ -798,6 +805,8 @@ def _process_item(
             info = None
             if effect_id is not None and int(quality_id) == 5:
                 info = price_map.get((defindex_int, int(quality_id), effect_id))
+            if info is None and is_australium:
+                info = price_map.get((defindex_int, int(quality_id), "australium"))
             if info is None:
                 info = price_map.get((defindex_int, int(quality_id)))
 


### PR DESCRIPTION
## Summary
- include `(defindex, quality, "australium")` prices when building the price map
- look up australium prices when enriching items
- test australium price map creation and lookup

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files utils/price_loader.py utils/inventory_processor.py tests/test_price_loader.py tests/test_inventory_processor.py`

------
https://chatgpt.com/codex/tasks/task_e_686afb8732a883269b026f3dcd3cf2b1