### PR TITLE
Switch price map key to item name

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -434,12 +434,12 @@ def test_price_map_applied():
     data = {"items": [{"defindex": 42, "quality": 6}]}
     ld.ITEMS_BY_DEFINDEX = {42: {"item_name": "Answer", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {6: "Unique"}
-    price_map = {(42, 6): {"value_raw": 5.33, "currency": "metal"}}
+    price_map = {("Answer", 6, False): {"value_raw": 5.33, "currency": "metal"}}
     ld.CURRENCIES = {"keys": {"price": {"value_raw": 50.0}}}
 
     items = ip.enrich_inventory(data, price_map=price_map)
     item = items[0]
-    assert item["price"] == price_map[(42, 6)]
+    assert item["price"] == price_map[("Answer", 6, False)]
     assert item["price_string"] == "5.33 ref"
     assert item["formatted_price"] == "5.33 ref"
 
@@ -448,7 +448,7 @@ def test_price_map_key_conversion_large_value():
     data = {"items": [{"defindex": 42, "quality": 6}]}
     ld.ITEMS_BY_DEFINDEX = {42: {"item_name": "Answer", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {6: "Unique"}
-    price_map = {(42, 6): {"value_raw": 367.73, "currency": "metal"}}
+    price_map = {("Answer", 6, False): {"value_raw": 367.73, "currency": "metal"}}
     ld.CURRENCIES = {"keys": {"price": {"value_raw": 70.0}}}
 
     items = ip.enrich_inventory(data, price_map=price_map)
@@ -469,7 +469,7 @@ def test_price_map_unusual_lookup():
     }
     ld.ITEMS_BY_DEFINDEX = {30998: {"item_name": "Veil", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {5: "Unusual"}
-    price_map = {(30998, 5, 13): {"value_raw": 164554.25, "currency": "keys"}}
+    price_map = {("Veil", 5, False): {"value_raw": 164554.25, "currency": "keys"}}
     ld.CURRENCIES = {"keys": {"price": {"value_raw": 67.165}}}
 
     items = ip.enrich_inventory(data, price_map=price_map)
@@ -482,7 +482,7 @@ def test_untradable_item_no_price():
     data = {"items": [{"defindex": 42, "quality": 6, "tradable": 0}]}
     ld.ITEMS_BY_DEFINDEX = {42: {"item_name": "Answer", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {6: "Unique"}
-    price_map = {(42, 6): {"value_raw": 5.33, "currency": "metal"}}
+    price_map = {("Answer", 6, False): {"value_raw": 5.33, "currency": "metal"}}
     ld.CURRENCIES = {"keys": {"price": {"value_raw": 50.0}}}
 
     items = ip.enrich_inventory(data, price_map=price_map)
@@ -534,10 +534,10 @@ def test_price_map_australium_lookup():
     data = {"items": [{"defindex": 205, "quality": 6, "is_australium": True}]}
     ld.ITEMS_BY_DEFINDEX = {205: {"item_name": "Rocket Launcher", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {6: "Unique"}
-    price_map = {(205, 6, "australium"): {"value_raw": 100.0, "currency": "keys"}}
+    price_map = {("Rocket Launcher", 6, True): {"value_raw": 100.0, "currency": "keys"}}
     ld.CURRENCIES = {"keys": {"price": {"value_raw": 50.0}}}
 
     items = ip.enrich_inventory(data, price_map=price_map)
     item = items[0]
-    assert item["price"] == price_map[(205, 6, "australium")]
+    assert item["price"] == price_map[("Rocket Launcher", 6, True)]
     assert item["formatted_price"] == "2 Keys"

--- a/tests/test_price_loader.py
+++ b/tests/test_price_loader.py
@@ -38,8 +38,8 @@ def test_price_map_smoke(tmp_path, monkeypatch):
         p = price_loader.ensure_prices_cached(refresh=True)
 
     mapping = price_loader.build_price_map(p)
-    assert (5021, 6) in mapping
-    assert mapping[(5021, 6)]["currency"] == "metal"
+    assert ("Mann Co. Supply Crate Key", 6, False) in mapping
+    assert mapping[("Mann Co. Supply Crate Key", 6, False)]["currency"] == "metal"
 
 
 def test_price_map_non_craftable(tmp_path, monkeypatch):
@@ -76,8 +76,8 @@ def test_price_map_non_craftable(tmp_path, monkeypatch):
         p = price_loader.ensure_prices_cached(refresh=True)
 
     mapping = price_loader.build_price_map(p)
-    assert (123, 5) in mapping
-    assert mapping[(123, 5)]["currency"] == "keys"
+    assert ("Unusual Hat", 5, False) in mapping
+    assert mapping[("Unusual Hat", 5, False)]["currency"] == "keys"
 
 
 def test_price_map_unusual_effect(tmp_path, monkeypatch):
@@ -114,8 +114,8 @@ def test_price_map_unusual_effect(tmp_path, monkeypatch):
         p = price_loader.ensure_prices_cached(refresh=True)
 
     mapping = price_loader.build_price_map(p)
-    assert (30998, 5, 13) in mapping
-    assert mapping[(30998, 5, 13)]["currency"] == "keys"
+    assert ("Villain's Veil", 5, False) in mapping
+    assert mapping[("Villain's Veil", 5, False)]["currency"] == "keys"
 
 
 def test_price_map_australium(tmp_path, monkeypatch):
@@ -153,7 +153,7 @@ def test_price_map_australium(tmp_path, monkeypatch):
         p = price_loader.ensure_prices_cached(refresh=True)
 
     mapping = price_loader.build_price_map(p)
-    assert (205, 6, "australium") in mapping
+    assert ("Rocket Launcher", 6, True) in mapping
 
 
 def test_missing_api_key(monkeypatch):


### PR DESCRIPTION
## Summary
- parse backpack price dump using item names
- key price map by `(item_name, quality, is_australium)`
- update inventory processing to use new key
- adjust tests for name-based lookup

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files utils/price_loader.py utils/inventory_processor.py tests/test_price_loader.py tests/test_inventory_processor.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686b0085cd9c83269b6598e02bf4b993