### PR TITLE
Update price map lookup key

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -469,7 +469,9 @@ def test_price_map_unusual_lookup():
     }
     ld.ITEMS_BY_DEFINDEX = {30998: {"item_name": "Veil", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {5: "Unusual"}
-    price_map = {("Veil", 5, False): {"value_raw": 164554.25, "currency": "keys"}}
+    price_map = {
+        ("Burning Flames Veil", 5, False): {"value_raw": 164554.25, "currency": "keys"}
+    }
     ld.CURRENCIES = {"keys": {"price": {"value_raw": 67.165}}}
 
     items = ip.enrich_inventory(data, price_map=price_map)
@@ -536,10 +538,15 @@ def test_price_map_australium_lookup():
     data = {"items": [{"defindex": 205, "quality": 6, "is_australium": True}]}
     ld.ITEMS_BY_DEFINDEX = {205: {"item_name": "Rocket Launcher", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {6: "Unique"}
-    price_map = {("Rocket Launcher", 6, True): {"value_raw": 100.0, "currency": "keys"}}
+    price_map = {
+        ("Australium Rocket Launcher", 6, True): {
+            "value_raw": 100.0,
+            "currency": "keys",
+        }
+    }
     ld.CURRENCIES = {"keys": {"price": {"value_raw": 50.0}}}
 
     items = ip.enrich_inventory(data, price_map=price_map)
     item = items[0]
-    assert item["price"] == price_map[("Rocket Launcher", 6, True)]
+    assert item["price"] == price_map[("Australium Rocket Launcher", 6, True)]
     assert item["formatted_price"] == "2 Keys"

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -616,8 +616,9 @@ def _process_item(
         Raw inventory item from Steam.
     price_map:
         Optional mapping of ``(item_name, quality, is_australium)`` to
-        Backpack.tf price data. When provided, price information is added under
-        ``"price"`` and ``"price_string"`` keys.
+        Backpack.tf price data. The ``item_name`` key should match the full
+        display name used in the inventory output. When provided, price
+        information is added under ``"price"`` and ``"price_string"`` keys.
     """
 
     defindex_raw = asset.get("defindex", 0)
@@ -797,7 +798,7 @@ def _process_item(
             tradable = 1
 
         if tradable:
-            info = price_map.get((base_name, int(quality_id), bool(is_australium)))
+            info = price_map.get((name, int(quality_id), bool(is_australium)))
 
             if info:
                 item["price"] = info


### PR DESCRIPTION
## Summary
- use the display name when looking up prices
- adjust unusual and australium test keys to match
- clarify docs for `_process_item`

## Testing
- `pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686b045426e48326bfd0f1bee9988770