### PR TITLE
Implement ValuationService wrapper

### DIFF
--- a/tests/test_valuation_service.py
+++ b/tests/test_valuation_service.py
@@ -1,0 +1,15 @@
+from utils.valuation_service import ValuationService
+from utils import local_data
+
+
+def test_get_price_info():
+    price_map = {("Item", 6, False): {"value_raw": 5.0, "currency": "metal"}}
+    service = ValuationService(price_map=price_map)
+    assert service.get_price_info("Item", 6) == {"value_raw": 5.0, "currency": "metal"}
+
+
+def test_format_price(monkeypatch):
+    price_map = {("Item", 6, False): {"value_raw": 50.0, "currency": "metal"}}
+    service = ValuationService(price_map=price_map)
+    local_data.CURRENCIES = {"keys": {"price": {"value_raw": 50.0}}}
+    assert service.format_price("Item", 6) == "1 Key"

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -11,6 +11,7 @@ from .local_data import FOOTPRINT_SPELL_MAP, PAINT_SPELL_MAP
 from .wear_helpers import _wear_tier, _decode_seed_info
 from .item_enricher import ItemEnricher
 from .inventory_provider import InventoryProvider
+from .valuation_service import ValuationService
 
 __all__ = [
     "PAINT_COLORS",
@@ -24,6 +25,7 @@ __all__ = [
     "KILLSTREAK_BADGE_ICONS",
     "ItemEnricher",
     "InventoryProvider",
+    "ValuationService",
     "_wear_tier",
     "_decode_seed_info",
 ]

--- a/utils/valuation_service.py
+++ b/utils/valuation_service.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from . import local_data
+from .price_loader import ensure_prices_cached, build_price_map
+from .price_service import format_price
+
+
+class ValuationService:
+    """Wrapper around name-based price lookups."""
+
+    def __init__(
+        self, price_map: Dict[Tuple[str, int, bool], Dict[str, Any]] | None = None
+    ) -> None:
+        if price_map is None:
+            path = ensure_prices_cached()
+            price_map = build_price_map(path)
+        self.price_map = price_map
+
+    def get_price_info(
+        self, item_name: str, quality: int, is_australium: bool = False
+    ) -> Dict[str, Any] | None:
+        """Return raw price info dict for the item if available."""
+        return self.price_map.get((item_name, quality, is_australium))
+
+    def format_price(
+        self,
+        item_name: str,
+        quality: int,
+        is_australium: bool = False,
+        currencies: Dict[str, Any] | None = None,
+    ) -> str:
+        """Return formatted price string using Backpack.tf key price."""
+        info = self.get_price_info(item_name, quality, is_australium)
+        if not info:
+            return ""
+        value = info.get("value_raw")
+        if value is None:
+            return ""
+        if currencies is None:
+            currencies = local_data.CURRENCIES
+        return format_price(value, currencies)


### PR DESCRIPTION
## Summary
- add `utils/valuation_service.py` to provide name-based price lookups
- expose `ValuationService` via `utils.__init__`
- test price retrieval and formatting in the new service

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files utils/valuation_service.py utils/__init__.py tests/test_valuation_service.py`
- `SKIP_VALIDATE=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b05c0edd08326a52cfa778e9919f5