### PR TITLE
Lazy loading for ValuationService

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,14 +13,13 @@ from flask import Flask, render_template, request, flash, jsonify
 from utils.id_parser import extract_steam_ids
 from utils.inventory_processor import enrich_inventory
 import utils.inventory_processor as ip
-from utils.valuation_service import ValuationService
+
 from utils import steam_api_client as sac
 from utils import local_data
 from utils import constants as consts
 from utils.price_loader import (
     ensure_prices_cached,
     ensure_currencies_cached,
-    build_price_map,
 )
 
 load_dotenv()
@@ -70,8 +69,6 @@ try:
         local_data.CURRENCIES = json.load(f)["response"]["currencies"]
 except Exception:
     local_data.CURRENCIES = {}
-PRICE_MAP = build_price_map(_prices_path)
-ip.valuation_service = ValuationService(PRICE_MAP)
 
 # --- Utility functions ------------------------------------------------------
 

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -18,7 +18,7 @@ def reset_data(monkeypatch):
 def patch_valuation(monkeypatch):
     def _apply(price_map):
         service = ValuationService(price_map=price_map)
-        monkeypatch.setattr(ip, "valuation_service", service)
+        monkeypatch.setattr(ip, "get_valuation_service", lambda: service)
         return service
 
     return _apply

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -11,7 +11,7 @@ from .local_data import FOOTPRINT_SPELL_MAP, PAINT_SPELL_MAP
 from .wear_helpers import _wear_tier, _decode_seed_info
 from .item_enricher import ItemEnricher
 from .inventory_provider import InventoryProvider
-from .valuation_service import ValuationService
+from .valuation_service import ValuationService, get_valuation_service
 
 __all__ = [
     "PAINT_COLORS",
@@ -26,6 +26,7 @@ __all__ = [
     "ItemEnricher",
     "InventoryProvider",
     "ValuationService",
+    "get_valuation_service",
     "_wear_tier",
     "_decode_seed_info",
 ]

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -7,7 +7,7 @@ import json
 from pathlib import Path
 
 from . import steam_api_client, local_data
-from .valuation_service import ValuationService
+from .valuation_service import ValuationService, get_valuation_service
 from .wear_helpers import _wear_tier, _decode_seed_info
 from .constants import (
     KILLSTREAK_TIERS,
@@ -21,12 +21,6 @@ from .constants import (
 
 
 logger = logging.getLogger(__name__)
-
-
-try:  # instantiate default valuation service lazily
-    valuation_service = ValuationService()
-except Exception:  # pragma: no cover - fallback when prices unavailable
-    valuation_service = ValuationService(price_map={})
 
 
 SCHEMA_DIR = Path("cache/schema")
@@ -627,7 +621,7 @@ def _process_item(
     """
 
     if valuation_service is None:
-        valuation_service = globals().get("valuation_service")
+        valuation_service = get_valuation_service()
 
     defindex_raw = asset.get("defindex", 0)
     try:
@@ -846,7 +840,7 @@ def enrich_inventory(
         the module-level instance.
     """
     if valuation_service is None:
-        valuation_service = globals().get("valuation_service")
+        valuation_service = get_valuation_service()
     items_raw = data.get("items")
     if not isinstance(items_raw, list):
         return []
@@ -905,7 +899,7 @@ def process_inventory(
 ) -> List[Dict[str, Any]]:
     """Public wrapper that sorts items by name."""
     if valuation_service is None:
-        valuation_service = globals().get("valuation_service")
+        valuation_service = get_valuation_service()
     items = enrich_inventory(data, valuation_service)
     return sorted(items, key=lambda i: i["name"])
 

--- a/utils/valuation_service.py
+++ b/utils/valuation_service.py
@@ -7,6 +7,20 @@ from .price_loader import ensure_prices_cached, build_price_map
 from .price_service import format_price
 
 
+_default_service: ValuationService | None = None
+
+
+def get_valuation_service() -> "ValuationService":
+    """Return singleton :class:`ValuationService` instance."""
+    global _default_service
+    if _default_service is None:
+        try:
+            _default_service = ValuationService()
+        except Exception:  # pragma: no cover - fallback when prices unavailable
+            _default_service = ValuationService(price_map={})
+    return _default_service
+
+
 class ValuationService:
     """Wrapper around name-based price lookups."""
 


### PR DESCRIPTION
## Summary
- construct `ValuationService` only when needed
- expose `get_valuation_service` helper
- adapt inventory processing and tests to use the helper

## Testing
- `pre-commit run --files utils/valuation_service.py utils/inventory_processor.py tests/test_inventory_processor.py utils/__init__.py app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b0ccd2a68832693ba17c44a2914c0