### PR TITLE
Fix inventory enrichment call

### DIFF
--- a/app.py
+++ b/app.py
@@ -152,7 +152,7 @@ def fetch_inventory(steamid64: str) -> Dict[str, Any]:
     items: List[Dict[str, Any]] = []
     if status == "parsed":
         try:
-            items = enrich_inventory(data, valuation_service=ip.valuation_service)
+            items = enrich_inventory(data, valuation_service=ip.get_valuation_service())
         except Exception:
             app.logger.exception("Failed to enrich inventory for %s", steamid64)
             status = "failed"


### PR DESCRIPTION
## Summary
- call `get_valuation_service()` when enriching inventory

## Testing
- `pre-commit run --files app.py` *(fails: ModuleNotFoundError: No module named 'vdf')*


------
https://chatgpt.com/codex/tasks/task_e_686b196ea65c83269c0c16e15b03f699