### PR TITLE
Fix price lookup for non-Unique items

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -456,6 +456,23 @@ def test_price_map_applied(patch_valuation):
     assert item["formatted_price"] == "5.33 ref"
 
 
+def test_price_map_strange_lookup(patch_valuation):
+    data = {"items": [{"defindex": 111, "quality": 11}]}
+    ld.ITEMS_BY_DEFINDEX = {111: {"item_name": "Rocket Launcher", "image_url": ""}}
+    ld.QUALITIES_BY_INDEX = {11: "Strange"}
+    price_map = {
+        ("Rocket Launcher", 11, False): {"value_raw": 5.33, "currency": "metal"}
+    }
+    ld.CURRENCIES = {"keys": {"price": {"value_raw": 50.0}}}
+
+    patch_valuation(price_map)
+    items = ip.enrich_inventory(data)
+    item = items[0]
+    assert item["price"] == price_map[("Rocket Launcher", 11, False)]
+    assert item["price_string"] == "5.33 ref"
+    assert item["formatted_price"] == "5.33 ref"
+
+
 def test_price_map_key_conversion_large_value(patch_valuation):
     data = {"items": [{"defindex": 42, "quality": 6}]}
     ld.ITEMS_BY_DEFINDEX = {42: {"item_name": "Answer", "image_url": ""}}
@@ -482,9 +499,7 @@ def test_price_map_unusual_lookup(patch_valuation):
     }
     ld.ITEMS_BY_DEFINDEX = {30998: {"item_name": "Veil", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {5: "Unusual"}
-    price_map = {
-        ("Burning Flames Veil", 5, False): {"value_raw": 164554.25, "currency": "keys"}
-    }
+    price_map = {("Veil", 5, False): {"value_raw": 164554.25, "currency": "keys"}}
     ld.CURRENCIES = {"keys": {"price": {"value_raw": 67.165}}}
 
     patch_valuation(price_map)
@@ -554,16 +569,11 @@ def test_price_map_australium_lookup(patch_valuation):
     data = {"items": [{"defindex": 205, "quality": 6, "is_australium": True}]}
     ld.ITEMS_BY_DEFINDEX = {205: {"item_name": "Rocket Launcher", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {6: "Unique"}
-    price_map = {
-        ("Australium Rocket Launcher", 6, True): {
-            "value_raw": 100.0,
-            "currency": "keys",
-        }
-    }
+    price_map = {("Rocket Launcher", 6, True): {"value_raw": 100.0, "currency": "keys"}}
     ld.CURRENCIES = {"keys": {"price": {"value_raw": 50.0}}}
 
     patch_valuation(price_map)
     items = ip.enrich_inventory(data)
     item = items[0]
-    assert item["price"] == price_map[("Australium Rocket Launcher", 6, True)]
+    assert item["price"] == price_map[("Rocket Launcher", 6, True)]
     assert item["formatted_price"] == "2 Keys"

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -808,7 +808,7 @@ def _process_item(
                 qid = 0
             try:
                 formatted = valuation_service.format_price(
-                    item.get("name", ""),
+                    item.get("base_name", base_name),
                     qid,
                     bool(is_australium),
                     currencies=local_data.CURRENCIES,
@@ -817,7 +817,7 @@ def _process_item(
                 formatted = ""
             if formatted:
                 item["price"] = valuation_service.get_price_info(
-                    item.get("name", ""), qid, bool(is_australium)
+                    item.get("base_name", base_name), qid, bool(is_australium)
                 )
                 item["price_string"] = formatted
                 item["formatted_price"] = formatted


### PR DESCRIPTION
## Summary
- use `base_name` when requesting prices
- check that a Strange item receives a price
- update price lookups in existing tests

## Testing
- `pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py` *(fails: validate-attributes missing schema)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b1b51c51c8326999e8efeeb14eb67