### PR TITLE
Support unusual effects via defindex 2041

### DIFF
--- a/scripts/validate_attributes.py
+++ b/scripts/validate_attributes.py
@@ -10,6 +10,7 @@ from utils import local_data
 # attribute defindex -> human readable name
 REQUIRED_ATTRS = {
     134: "Unusual Effect",
+    2041: "Unusual Effect (new)",
     142: "Paint Color",
     261: "Paint Color (legacy)",
     725: "Wear",

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -215,6 +215,23 @@ def test_unusual_effect_attribute_object():
     assert items[0]["unusual_effect"] == {"id": 13, "name": "Burning Flames"}
 
 
+def test_unusual_effect_attribute_object_2041():
+    data = {
+        "items": [
+            {
+                "defindex": 701,
+                "quality": 5,
+                "attributes": [{"defindex": 2041, "value": 13}],
+            }
+        ]
+    }
+    ld.ITEMS_BY_DEFINDEX = {701: {"item_name": "Hat", "image_url": ""}}
+    ld.QUALITIES_BY_INDEX = {5: "Unusual"}
+    ld.EFFECT_NAMES = {"13": "Burning Flames"}
+    items = ip.enrich_inventory(data)
+    assert items[0]["unusual_effect"] == {"id": 13, "name": "Burning Flames"}
+
+
 def test_get_inventories_adds_user_agent(monkeypatch):
     captured = {}
 

--- a/tests/test_item_enricher.py
+++ b/tests/test_item_enricher.py
@@ -96,6 +96,32 @@ def test_enrich_inventory_attribute_class(monkeypatch):
     assert item["unusual_effect"] == "Hot"
 
 
+def test_enrich_inventory_attribute_class_2041(monkeypatch):
+    provider = SchemaProvider(base_url="https://example.com")
+
+    monkeypatch.setattr(
+        provider, "get_items", lambda: {100: {"defindex": 100, "item_name": "Rocket"}}
+    )
+    monkeypatch.setattr(provider, "get_qualities", lambda: {"Unique": 6})
+    monkeypatch.setattr(provider, "get_paints", lambda: {})
+    monkeypatch.setattr(
+        provider,
+        "get_attributes",
+        lambda: {2041: {"defindex": 2041, "attribute_class": "set_attached_particle"}},
+    )
+    monkeypatch.setattr(provider, "get_effects", lambda: {55: "Hot"})
+    monkeypatch.setattr(provider, "get_strange_parts", lambda: {})
+
+    enricher = ItemEnricher(provider)
+
+    raw = [
+        {"defindex": 100, "quality": 6, "attributes": [{"defindex": 2041, "value": 55}]}
+    ]
+
+    item = enricher.enrich_inventory(raw)[0]
+    assert item["unusual_effect"] == "Hot"
+
+
 def test_spell_extraction(monkeypatch):
     provider = SchemaProvider(base_url="https://example.com")
 

--- a/tests/test_unusual_effect_extraction.py
+++ b/tests/test_unusual_effect_extraction.py
@@ -7,10 +7,10 @@ def test_extract_unusual_effect_cosmetic():
     assert _extract_unusual_effect(asset) == {"id": 350, "name": "Spectral Fire"}
 
 
-def test_ignore_defindex_2041():
+def test_extract_unusual_effect_unusual():
     EFFECTS_MAP[510] = "Test Name"
     asset = {"quality": 5, "attributes": [{"defindex": 2041, "value": 510}]}
-    assert _extract_unusual_effect(asset) is None
+    assert _extract_unusual_effect(asset) == {"id": 510, "name": "Test Name"}
 
 
 def test_no_effect():

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -70,7 +70,7 @@ def _refresh_attr_classes() -> None:
     global PATTERN_SEED_LO_CLASSES, PATTERN_SEED_HI_CLASSES
     global PAINTKIT_CLASSES, CRATE_SERIES_CLASSES
 
-    UNUSUAL_CLASSES = {cls(134)} - {None}
+    UNUSUAL_CLASSES = {cls(134), cls(2041)} - {None}
     KILLSTREAK_TIER_CLASSES = {cls(2025)} - {None}
     KILLSTREAK_SHEEN_CLASSES = {cls(2014)} - {None}
     KILLSTREAK_EFFECT_CLASSES = {cls(2013)} - {None}
@@ -137,7 +137,7 @@ def _extract_unusual_effect(asset: Dict[str, Any]) -> dict | None:
         except (TypeError, ValueError):
             continue
 
-        if idx_int != 134:
+        if idx_int not in (134, 2041):
             continue
 
         raw = attr.get("float_value")


### PR DESCRIPTION
## Summary
- recognize new unusual-effect attribute 2041 alongside cosmetic 134
- ensure schema validation checks for attribute 2041
- update effect extraction logic and refresh cached classes
- add coverage for defindex 2041 in unit tests

## Testing
- `pre-commit run --files utils/inventory_processor.py scripts/validate_attributes.py tests/test_unusual_effect_extraction.py tests/test_inventory_processor.py tests/test_item_enricher.py`

------
https://chatgpt.com/codex/tasks/task_e_686b30af35488326a61a5da2076918fd