### PR TITLE
Add effect-based price lookups

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -462,13 +462,13 @@ def test_price_map_applied(patch_valuation):
     data = {"items": [{"defindex": 42, "quality": 6}]}
     ld.ITEMS_BY_DEFINDEX = {42: {"item_name": "Answer", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {6: "Unique"}
-    price_map = {("Answer", 6, False): {"value_raw": 5.33, "currency": "metal"}}
+    price_map = {("Answer", 6, False, 0): {"value_raw": 5.33, "currency": "metal"}}
     ld.CURRENCIES = {"keys": {"price": {"value_raw": 50.0}}}
 
     patch_valuation(price_map)
     items = ip.enrich_inventory(data)
     item = items[0]
-    assert item["price"] == price_map[("Answer", 6, False)]
+    assert item["price"] == price_map[("Answer", 6, False, 0)]
     assert item["price_string"] == "5.33 ref"
     assert item["formatted_price"] == "5.33 ref"
 
@@ -478,14 +478,14 @@ def test_price_map_strange_lookup(patch_valuation):
     ld.ITEMS_BY_DEFINDEX = {111: {"item_name": "Rocket Launcher", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {11: "Strange"}
     price_map = {
-        ("Rocket Launcher", 11, False): {"value_raw": 5.33, "currency": "metal"}
+        ("Rocket Launcher", 11, False, 0): {"value_raw": 5.33, "currency": "metal"}
     }
     ld.CURRENCIES = {"keys": {"price": {"value_raw": 50.0}}}
 
     patch_valuation(price_map)
     items = ip.enrich_inventory(data)
     item = items[0]
-    assert item["price"] == price_map[("Rocket Launcher", 11, False)]
+    assert item["price"] == price_map[("Rocket Launcher", 11, False, 0)]
     assert item["price_string"] == "5.33 ref"
     assert item["formatted_price"] == "5.33 ref"
 
@@ -494,7 +494,7 @@ def test_price_map_key_conversion_large_value(patch_valuation):
     data = {"items": [{"defindex": 42, "quality": 6}]}
     ld.ITEMS_BY_DEFINDEX = {42: {"item_name": "Answer", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {6: "Unique"}
-    price_map = {("Answer", 6, False): {"value_raw": 367.73, "currency": "metal"}}
+    price_map = {("Answer", 6, False, 0): {"value_raw": 367.73, "currency": "metal"}}
     ld.CURRENCIES = {"keys": {"price": {"value_raw": 70.0}}}
 
     patch_valuation(price_map)
@@ -516,7 +516,7 @@ def test_price_map_unusual_lookup(patch_valuation):
     }
     ld.ITEMS_BY_DEFINDEX = {30998: {"item_name": "Veil", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {5: "Unusual"}
-    price_map = {("Veil", 5, False): {"value_raw": 164554.25, "currency": "keys"}}
+    price_map = {("Veil", 5, False, 13): {"value_raw": 164554.25, "currency": "keys"}}
     ld.CURRENCIES = {"keys": {"price": {"value_raw": 67.165}}}
 
     patch_valuation(price_map)
@@ -530,7 +530,7 @@ def test_untradable_item_no_price(patch_valuation):
     data = {"items": [{"defindex": 42, "quality": 6, "tradable": 0}]}
     ld.ITEMS_BY_DEFINDEX = {42: {"item_name": "Answer", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {6: "Unique"}
-    price_map = {("Answer", 6, False): {"value_raw": 5.33, "currency": "metal"}}
+    price_map = {("Answer", 6, False, 0): {"value_raw": 5.33, "currency": "metal"}}
     ld.CURRENCIES = {"keys": {"price": {"value_raw": 50.0}}}
 
     patch_valuation(price_map)
@@ -586,11 +586,13 @@ def test_price_map_australium_lookup(patch_valuation):
     data = {"items": [{"defindex": 205, "quality": 6, "is_australium": True}]}
     ld.ITEMS_BY_DEFINDEX = {205: {"item_name": "Rocket Launcher", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {6: "Unique"}
-    price_map = {("Rocket Launcher", 6, True): {"value_raw": 100.0, "currency": "keys"}}
+    price_map = {
+        ("Rocket Launcher", 6, True, 0): {"value_raw": 100.0, "currency": "keys"}
+    }
     ld.CURRENCIES = {"keys": {"price": {"value_raw": 50.0}}}
 
     patch_valuation(price_map)
     items = ip.enrich_inventory(data)
     item = items[0]
-    assert item["price"] == price_map[("Rocket Launcher", 6, True)]
+    assert item["price"] == price_map[("Rocket Launcher", 6, True, 0)]
     assert item["formatted_price"] == "2 Keys"

--- a/tests/test_price_loader.py
+++ b/tests/test_price_loader.py
@@ -38,8 +38,9 @@ def test_price_map_smoke(tmp_path, monkeypatch):
         p = price_loader.ensure_prices_cached(refresh=True)
 
     mapping = price_loader.build_price_map(p)
-    assert ("Mann Co. Supply Crate Key", 6, False) in mapping
-    assert mapping[("Mann Co. Supply Crate Key", 6, False)]["currency"] == "metal"
+    key = ("Mann Co. Supply Crate Key", 6, False, 0)
+    assert key in mapping
+    assert mapping[key]["currency"] == "metal"
 
 
 def test_price_map_non_craftable(tmp_path, monkeypatch):
@@ -76,8 +77,9 @@ def test_price_map_non_craftable(tmp_path, monkeypatch):
         p = price_loader.ensure_prices_cached(refresh=True)
 
     mapping = price_loader.build_price_map(p)
-    assert ("Unusual Hat", 5, False) in mapping
-    assert mapping[("Unusual Hat", 5, False)]["currency"] == "keys"
+    key = ("Unusual Hat", 5, False, 0)
+    assert key in mapping
+    assert mapping[key]["currency"] == "keys"
 
 
 def test_price_map_unusual_effect(tmp_path, monkeypatch):
@@ -114,8 +116,9 @@ def test_price_map_unusual_effect(tmp_path, monkeypatch):
         p = price_loader.ensure_prices_cached(refresh=True)
 
     mapping = price_loader.build_price_map(p)
-    assert ("Villain's Veil", 5, False) in mapping
-    assert mapping[("Villain's Veil", 5, False)]["currency"] == "keys"
+    key = ("Villain's Veil", 5, False, 13)
+    assert key in mapping
+    assert mapping[key]["currency"] == "keys"
 
 
 def test_price_map_australium(tmp_path, monkeypatch):
@@ -153,7 +156,7 @@ def test_price_map_australium(tmp_path, monkeypatch):
         p = price_loader.ensure_prices_cached(refresh=True)
 
     mapping = price_loader.build_price_map(p)
-    assert ("Rocket Launcher", 6, True) in mapping
+    assert ("Rocket Launcher", 6, True, 0) in mapping
 
 
 def test_missing_api_key(monkeypatch):

--- a/tests/test_valuation_service.py
+++ b/tests/test_valuation_service.py
@@ -3,13 +3,13 @@ from utils import local_data
 
 
 def test_get_price_info():
-    price_map = {("Item", 6, False): {"value_raw": 5.0, "currency": "metal"}}
+    price_map = {("Item", 6, False, 0): {"value_raw": 5.0, "currency": "metal"}}
     service = ValuationService(price_map=price_map)
     assert service.get_price_info("Item", 6) == {"value_raw": 5.0, "currency": "metal"}
 
 
 def test_format_price(monkeypatch):
-    price_map = {("Item", 6, False): {"value_raw": 50.0, "currency": "metal"}}
+    price_map = {("Item", 6, False, 0): {"value_raw": 50.0, "currency": "metal"}}
     service = ValuationService(price_map=price_map)
     local_data.CURRENCIES = {"keys": {"price": {"value_raw": 50.0}}}
     assert service.format_price("Item", 6) == "1 Key"

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -811,13 +811,17 @@ def _process_item(
                     item.get("base_name", base_name),
                     qid,
                     bool(is_australium),
+                    effect_id=effect_id,
                     currencies=local_data.CURRENCIES,
                 )
             except Exception:  # pragma: no cover - defensive fallback
                 formatted = ""
             if formatted:
                 item["price"] = valuation_service.get_price_info(
-                    item.get("base_name", base_name), qid, bool(is_australium)
+                    item.get("base_name", base_name),
+                    qid,
+                    bool(is_australium),
+                    effect_id=effect_id,
                 )
                 item["price_string"] = formatted
                 item["formatted_price"] = formatted

--- a/utils/valuation_service.py
+++ b/utils/valuation_service.py
@@ -25,7 +25,7 @@ class ValuationService:
     """Wrapper around name-based price lookups."""
 
     def __init__(
-        self, price_map: Dict[Tuple[str, int, bool], Dict[str, Any]] | None = None
+        self, price_map: Dict[Tuple[str, int, bool, int], Dict[str, Any]] | None = None
     ) -> None:
         if price_map is None:
             path = ensure_prices_cached()
@@ -33,20 +33,30 @@ class ValuationService:
         self.price_map = price_map
 
     def get_price_info(
-        self, item_name: str, quality: int, is_australium: bool = False
+        self,
+        item_name: str,
+        quality: int,
+        is_australium: bool = False,
+        effect_id: int | None = None,
     ) -> Dict[str, Any] | None:
         """Return raw price info dict for the item if available."""
-        return self.price_map.get((item_name, quality, is_australium))
+        key = (item_name, quality, is_australium, effect_id or 0)
+        info = self.price_map.get(key)
+        if info is None and effect_id is not None:
+            info = self.price_map.get((item_name, quality, is_australium, 0))
+        return info
 
     def format_price(
         self,
         item_name: str,
         quality: int,
         is_australium: bool = False,
+        *,
+        effect_id: int | None = None,
         currencies: Dict[str, Any] | None = None,
     ) -> str:
         """Return formatted price string using Backpack.tf key price."""
-        info = self.get_price_info(item_name, quality, is_australium)
+        info = self.get_price_info(item_name, quality, is_australium, effect_id)
         if not info:
             return ""
         value = info.get("value_raw")


### PR DESCRIPTION
## Summary
- include unusual effect id in price map
- look up prices with effect id in valuation service and inventory processor
- handle effect prices in tests for taunts and cosmetics

## Testing
- `pre-commit run --files utils/price_loader.py utils/valuation_service.py utils/inventory_processor.py tests/test_price_loader.py tests/test_inventory_processor.py tests/test_item_enricher.py tests/test_valuation_service.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686b34a9ad90832688fed9412edfc71f