### PR TITLE
Support Unusual taunt effects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 .env
 __pycache__/
 data/
+!data/
+!data/effect_names.json
+!data/effect_names.json
 cache/
 !cache/
 cache/*

--- a/data/effect_names.json
+++ b/data/effect_names.json
@@ -1,0 +1,3 @@
+{
+  "3009": "Silver Cyclone"
+}

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -232,6 +232,26 @@ def test_unusual_effect_attribute_object_2041():
     assert items[0]["unusual_effect"] == {"id": 13, "name": "Burning Flames"}
 
 
+def test_unusual_taunt_effect_badge():
+    data = {
+        "items": [
+            {
+                "defindex": 6001,
+                "quality": 5,
+                "attributes": [{"defindex": 134, "float_value": 3009}],
+            }
+        ]
+    }
+    ld.ITEMS_BY_DEFINDEX = {6001: {"item_name": "Taunt: Conga", "image_url": ""}}
+    ld.QUALITIES_BY_INDEX = {5: "Unusual"}
+    ld.EFFECT_NAMES = {"3009": "Silver Cyclone"}
+    items = ip.enrich_inventory(data)
+    item = items[0]
+    assert item["badges"][0]["icon"] == "★"
+    assert item["unusual_effect_name"] == "Silver Cyclone"
+    assert "Silver Cyclone" in item["name"]
+
+
 def test_get_inventories_adds_user_agent(monkeypatch):
     captured = {}
 

--- a/tests/test_local_data.py
+++ b/tests/test_local_data.py
@@ -221,3 +221,30 @@ def test_load_files_string_lookups_missing(tmp_path, monkeypatch):
 
     assert ld.PAINT_SPELL_MAP == {}
     assert ld.FOOTPRINT_SPELL_MAP == {}
+
+
+def test_effect_names_file_loaded(tmp_path, monkeypatch):
+    attr_file = tmp_path / "attributes.json"
+    particles_file = tmp_path / "particles.json"
+    items_file = tmp_path / "items.json"
+    qual_file = tmp_path / "qualities.json"
+    currencies_file = tmp_path / "currencies.json"
+    effect_file = tmp_path / "effect_names.json"
+
+    for f in (attr_file, particles_file, items_file, qual_file):
+        f.write_text("[]")
+
+    effect_file.write_text(json.dumps({"3009": "Silver Cyclone"}))
+
+    monkeypatch.setattr(ld, "ATTRIBUTES_FILE", attr_file)
+    monkeypatch.setattr(ld, "PARTICLES_FILE", particles_file)
+    monkeypatch.setattr(ld, "ITEMS_FILE", items_file)
+    monkeypatch.setattr(ld, "QUALITIES_FILE", qual_file)
+    monkeypatch.setattr(ld, "CURRENCIES_FILE", currencies_file)
+    monkeypatch.setattr(ld, "EFFECT_NAMES_FILE", effect_file)
+
+    currencies_file.write_text(json.dumps({"metal": {"value_raw": 1.0}}))
+
+    ld.load_files()
+
+    assert ld.EFFECT_NAMES["3009"] == "Silver Cyclone"

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -690,26 +690,29 @@ def _process_item(
         effect_id = effect_info["id"]
         effect_name = effect_info["name"]
         effect = effect_info
-        if effect_name:
-            badges.append(
-                {
-                    "icon": "★",
-                    "title": f"Unusual Effect: {effect_name}",
-                    "color": "#8650AC",
-                    "label": effect_name,
-                    "type": "effect",
-                }
-            )
     else:
         effect = None
         effect_id = effect_name = None
+
+    if effect_id is not None:
+        badges.append(
+            {
+                "icon": "★",
+                "title": f"Unusual Effect: {effect_name or f'#{effect_id}'}",
+                "color": "#8650AC",
+                "label": effect_name or f"#{effect_id}",
+                "type": "effect",
+            }
+        )
     # ----------------------------------------------------------------------
 
     display_name = (
-        f"{display_base}" if not effect_name else f"{effect_name} {display_base}"
+        f"{display_base}"
+        if effect_id is None
+        else f"{effect_name or f'Effect #{effect_id}'} {display_base}"
     )
-    original_name = name if effect_name else None
-    if effect_name:
+    original_name = name if effect_id is not None else None
+    if effect_id is not None:
         name = display_name
     if ks_tier_val:
         tier_id = int(float(ks_tier_val))


### PR DESCRIPTION
## Summary
- allow loading all particle effect names from the Steam API
- display unknown taunt effects with a numeric fallback
- include Silver Cyclone test data
- show effect badges on Unusual taunts
- test taunt effect handling

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files utils/local_data.py utils/inventory_processor.py tests/test_local_data.py tests/test_inventory_processor.py .gitignore data/effect_names.json`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b37c4c3f48326bdded5c914d75373