### PR TITLE
Fix Taunt Effect Value Extraction (2041)

### DIFF
--- a/tests/test_unusual_effect_extraction.py
+++ b/tests/test_unusual_effect_extraction.py
@@ -13,6 +13,22 @@ def test_extract_unusual_effect_unusual():
     assert _extract_unusual_effect(asset) == {"id": 510, "name": "Test Name"}
 
 
+def test_extract_unusual_effect_value_fallback():
+    EFFECTS_MAP[3042] = "Taunt Effect"
+    asset = {
+        "quality": 5,
+        "attributes": [
+            {"defindex": 2041, "float_value": 4.2627499284760935e-42, "value": 3042}
+        ],
+    }
+    assert _extract_unusual_effect(asset) == {"id": 3042, "name": "Taunt Effect"}
+
+
+def test_extract_unusual_effect_zero_skipped():
+    asset = {"quality": 5, "attributes": [{"defindex": 2041, "float_value": 0}]}
+    assert _extract_unusual_effect(asset) is None
+
+
 def test_no_effect():
     asset = {"quality": 5, "attributes": []}
     assert _extract_unusual_effect(asset) is None

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -141,12 +141,21 @@ def _extract_unusual_effect(asset: Dict[str, Any]) -> dict | None:
             continue
 
         raw = attr.get("float_value")
-        if raw is None:
-            raw = attr.get("value")
+        effect_id = None
+        if raw is not None:
+            try:
+                effect_id = int(float(raw))
+            except (TypeError, ValueError):
+                effect_id = None
 
-        try:
-            effect_id = int(float(raw))
-        except (TypeError, ValueError):
+        if not effect_id:
+            raw = attr.get("value")
+            try:
+                effect_id = int(float(raw)) if raw is not None else None
+            except (TypeError, ValueError):
+                continue
+
+        if not effect_id:
             continue
 
         effect_name = local_data.EFFECT_NAMES.get(str(effect_id)) or EFFECTS_MAP.get(


### PR DESCRIPTION
## Summary
- detect unusable `float_value` on unusual taunts and fall back to `value`
- skip effect ID `0`
- test taunt effect fallback cases

## Testing
- `pre-commit run --files utils/inventory_processor.py tests/test_unusual_effect_extraction.py` *(fails: ModuleNotFoundError: No module named 'vdf')*

------
https://chatgpt.com/codex/tasks/task_e_686b8e8b1bc88326aff9d5c2ee8b1bbe