### PR TITLE
Expose killstreak tier int

### DIFF
--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -62,7 +62,8 @@ def test_enrichment_full_attributes(monkeypatch):
     items = ip.enrich_inventory(data)
     item = items[0]
 
-    assert item["killstreak_tier"] == "Professional Killstreak"
+    assert item["killstreak_tier"] == 3
+    assert item["killstreak_name"] == "Professional"
     assert item["sheen"] == "Manndarin"
     assert item["killstreak_effect"] == "Cerebral Discharge"
     assert item["wear_name"] == "Field-Tested"

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -7,6 +7,13 @@ KILLSTREAK_TIERS = {
     3: "Professional Killstreak",
 }
 
+# Map of killstreak tier id -> short name
+KILLSTREAK_LABELS = {
+    1: "Killstreak",
+    2: "Specialized",
+    3: "Professional",
+}
+
 # Map of killstreak tier id -> badge icon
 KILLSTREAK_BADGE_ICONS = {
     1: "›",


### PR DESCRIPTION
## Summary
- add KILLSTREAK_LABELS constants
- add `_extract_killstreak_tier` for getting killstreak tier id
- expose numeric killstreak tier and name during enrichment
- update tests for new structure

## Testing
- `pre-commit run --files utils/inventory_processor.py utils/constants.py tests/test_enrichment.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686b94f9d18c8326a47d47ead416dd08