### PR TITLE
Support killstreak tier pricing

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -482,13 +482,13 @@ def test_price_map_applied(patch_valuation):
     data = {"items": [{"defindex": 42, "quality": 6}]}
     ld.ITEMS_BY_DEFINDEX = {42: {"item_name": "Answer", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {6: "Unique"}
-    price_map = {("Answer", 6, False, 0): {"value_raw": 5.33, "currency": "metal"}}
+    price_map = {("Answer", 6, False, 0, 0): {"value_raw": 5.33, "currency": "metal"}}
     ld.CURRENCIES = {"keys": {"price": {"value_raw": 50.0}}}
 
     patch_valuation(price_map)
     items = ip.enrich_inventory(data)
     item = items[0]
-    assert item["price"] == price_map[("Answer", 6, False, 0)]
+    assert item["price"] == price_map[("Answer", 6, False, 0, 0)]
     assert item["price_string"] == "5.33 ref"
     assert item["formatted_price"] == "5.33 ref"
 
@@ -498,14 +498,14 @@ def test_price_map_strange_lookup(patch_valuation):
     ld.ITEMS_BY_DEFINDEX = {111: {"item_name": "Rocket Launcher", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {11: "Strange"}
     price_map = {
-        ("Rocket Launcher", 11, False, 0): {"value_raw": 5.33, "currency": "metal"}
+        ("Rocket Launcher", 11, False, 0, 0): {"value_raw": 5.33, "currency": "metal"}
     }
     ld.CURRENCIES = {"keys": {"price": {"value_raw": 50.0}}}
 
     patch_valuation(price_map)
     items = ip.enrich_inventory(data)
     item = items[0]
-    assert item["price"] == price_map[("Rocket Launcher", 11, False, 0)]
+    assert item["price"] == price_map[("Rocket Launcher", 11, False, 0, 0)]
     assert item["price_string"] == "5.33 ref"
     assert item["formatted_price"] == "5.33 ref"
 
@@ -514,7 +514,7 @@ def test_price_map_key_conversion_large_value(patch_valuation):
     data = {"items": [{"defindex": 42, "quality": 6}]}
     ld.ITEMS_BY_DEFINDEX = {42: {"item_name": "Answer", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {6: "Unique"}
-    price_map = {("Answer", 6, False, 0): {"value_raw": 367.73, "currency": "metal"}}
+    price_map = {("Answer", 6, False, 0, 0): {"value_raw": 367.73, "currency": "metal"}}
     ld.CURRENCIES = {"keys": {"price": {"value_raw": 70.0}}}
 
     patch_valuation(price_map)
@@ -536,7 +536,9 @@ def test_price_map_unusual_lookup(patch_valuation):
     }
     ld.ITEMS_BY_DEFINDEX = {30998: {"item_name": "Veil", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {5: "Unusual"}
-    price_map = {("Veil", 5, False, 13): {"value_raw": 164554.25, "currency": "keys"}}
+    price_map = {
+        ("Veil", 5, False, 13, 0): {"value_raw": 164554.25, "currency": "keys"}
+    }
     ld.CURRENCIES = {"keys": {"price": {"value_raw": 67.165}}}
 
     patch_valuation(price_map)
@@ -550,7 +552,7 @@ def test_untradable_item_no_price(patch_valuation):
     data = {"items": [{"defindex": 42, "quality": 6, "tradable": 0}]}
     ld.ITEMS_BY_DEFINDEX = {42: {"item_name": "Answer", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {6: "Unique"}
-    price_map = {("Answer", 6, False, 0): {"value_raw": 5.33, "currency": "metal"}}
+    price_map = {("Answer", 6, False, 0, 0): {"value_raw": 5.33, "currency": "metal"}}
     ld.CURRENCIES = {"keys": {"price": {"value_raw": 50.0}}}
 
     patch_valuation(price_map)
@@ -607,12 +609,12 @@ def test_price_map_australium_lookup(patch_valuation):
     ld.ITEMS_BY_DEFINDEX = {205: {"item_name": "Rocket Launcher", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {6: "Unique"}
     price_map = {
-        ("Rocket Launcher", 6, True, 0): {"value_raw": 100.0, "currency": "keys"}
+        ("Rocket Launcher", 6, True, 0, 0): {"value_raw": 100.0, "currency": "keys"}
     }
     ld.CURRENCIES = {"keys": {"price": {"value_raw": 50.0}}}
 
     patch_valuation(price_map)
     items = ip.enrich_inventory(data)
     item = items[0]
-    assert item["price"] == price_map[("Rocket Launcher", 6, True, 0)]
+    assert item["price"] == price_map[("Rocket Launcher", 6, True, 0, 0)]
     assert item["formatted_price"] == "2 Keys"

--- a/tests/test_item_enricher.py
+++ b/tests/test_item_enricher.py
@@ -188,11 +188,13 @@ def test_price_lookup_cosmetic_effect(patch_valuation):
     }
     ld.ITEMS_BY_DEFINDEX = {5001: {"item_name": "Cool Hat", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {5: "Unusual"}
-    price_map = {("Cool Hat", 5, False, 55): {"value_raw": 50.0, "currency": "metal"}}
+    price_map = {
+        ("Cool Hat", 5, False, 55, 0): {"value_raw": 50.0, "currency": "metal"}
+    }
     ld.CURRENCIES = {"keys": {"price": {"value_raw": 50.0}}}
     patch_valuation(price_map)
     item = ip.enrich_inventory({"items": [asset]})[0]
-    assert item["price"] == price_map[("Cool Hat", 5, False, 55)]
+    assert item["price"] == price_map[("Cool Hat", 5, False, 55, 0)]
     assert item["price_string"] == "1 Key"
 
 
@@ -205,10 +207,10 @@ def test_price_lookup_taunt_effect(patch_valuation):
     ld.ITEMS_BY_DEFINDEX = {6001: {"item_name": "Taunt: Conga", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {5: "Unusual"}
     price_map = {
-        ("Taunt: Conga", 5, False, 54): {"value_raw": 100.0, "currency": "metal"}
+        ("Taunt: Conga", 5, False, 54, 0): {"value_raw": 100.0, "currency": "metal"}
     }
     ld.CURRENCIES = {"keys": {"price": {"value_raw": 50.0}}}
     patch_valuation(price_map)
     item = ip.enrich_inventory({"items": [asset]})[0]
-    assert item["price"] == price_map[("Taunt: Conga", 5, False, 54)]
+    assert item["price"] == price_map[("Taunt: Conga", 5, False, 54, 0)]
     assert item["price_string"] == "2 Keys"

--- a/tests/test_price_loader.py
+++ b/tests/test_price_loader.py
@@ -38,7 +38,7 @@ def test_price_map_smoke(tmp_path, monkeypatch):
         p = price_loader.ensure_prices_cached(refresh=True)
 
     mapping = price_loader.build_price_map(p)
-    key = ("Mann Co. Supply Crate Key", 6, False, 0)
+    key = ("Mann Co. Supply Crate Key", 6, False, 0, 0)
     assert key in mapping
     assert mapping[key]["currency"] == "metal"
 
@@ -77,7 +77,7 @@ def test_price_map_non_craftable(tmp_path, monkeypatch):
         p = price_loader.ensure_prices_cached(refresh=True)
 
     mapping = price_loader.build_price_map(p)
-    key = ("Unusual Hat", 5, False, 0)
+    key = ("Unusual Hat", 5, False, 0, 0)
     assert key in mapping
     assert mapping[key]["currency"] == "keys"
 
@@ -116,7 +116,7 @@ def test_price_map_unusual_effect(tmp_path, monkeypatch):
         p = price_loader.ensure_prices_cached(refresh=True)
 
     mapping = price_loader.build_price_map(p)
-    key = ("Villain's Veil", 5, False, 13)
+    key = ("Villain's Veil", 5, False, 13, 0)
     assert key in mapping
     assert mapping[key]["currency"] == "keys"
 
@@ -156,7 +156,44 @@ def test_price_map_australium(tmp_path, monkeypatch):
         p = price_loader.ensure_prices_cached(refresh=True)
 
     mapping = price_loader.build_price_map(p)
-    assert ("Rocket Launcher", 6, True, 0) in mapping
+    assert ("Rocket Launcher", 6, True, 0, 0) in mapping
+
+
+def test_price_map_killstreak(tmp_path, monkeypatch):
+    monkeypatch.setenv("BPTF_API_KEY", "TEST")
+    monkeypatch.setattr(price_loader, "PRICES_FILE", tmp_path / "prices.json")
+    url = "https://backpack.tf/api/IGetPrices/v4?raw=1&key=TEST"
+    payload = {
+        "response": {
+            "success": 1,
+            "items": {
+                "Professional Killstreak Rocket Launcher": {
+                    "defindex": [205],
+                    "prices": {
+                        "6": {
+                            "Tradable": {
+                                "Craftable": [
+                                    {
+                                        "value": 100,
+                                        "value_raw": 100.0,
+                                        "currency": "keys",
+                                        "last_update": 0,
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                }
+            },
+        }
+    }
+
+    with responses.RequestsMock() as rsps:
+        rsps.add(responses.GET, url, json=payload, status=200)
+        p = price_loader.ensure_prices_cached(refresh=True)
+
+    mapping = price_loader.build_price_map(p)
+    assert ("Rocket Launcher", 6, False, 0, 3) in mapping
 
 
 def test_missing_api_key(monkeypatch):

--- a/tests/test_valuation_service.py
+++ b/tests/test_valuation_service.py
@@ -3,13 +3,20 @@ from utils import local_data
 
 
 def test_get_price_info():
-    price_map = {("Item", 6, False, 0): {"value_raw": 5.0, "currency": "metal"}}
+    price_map = {("Item", 6, False, 0, 0): {"value_raw": 5.0, "currency": "metal"}}
     service = ValuationService(price_map=price_map)
     assert service.get_price_info("Item", 6) == {"value_raw": 5.0, "currency": "metal"}
 
 
 def test_format_price(monkeypatch):
-    price_map = {("Item", 6, False, 0): {"value_raw": 50.0, "currency": "metal"}}
+    price_map = {("Item", 6, False, 0, 0): {"value_raw": 50.0, "currency": "metal"}}
     service = ValuationService(price_map=price_map)
     local_data.CURRENCIES = {"keys": {"price": {"value_raw": 50.0}}}
     assert service.format_price("Item", 6) == "1 Key"
+
+
+def test_killstreak_tier_lookup(monkeypatch):
+    price_map = {("Item", 6, False, 0, 2): {"value_raw": 100.0, "currency": "keys"}}
+    service = ValuationService(price_map=price_map)
+    local_data.CURRENCIES = {"keys": {"price": {"value_raw": 50.0}}}
+    assert service.format_price("Item", 6, killstreak_tier=2) == "2 Keys"

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -857,6 +857,7 @@ def _process_item(
                     qid,
                     bool(is_australium),
                     effect_id=effect_id,
+                    killstreak_tier=ks_tier_val,
                     currencies=local_data.CURRENCIES,
                 )
             except Exception:  # pragma: no cover - defensive fallback
@@ -867,6 +868,7 @@ def _process_item(
                     qid,
                     bool(is_australium),
                     effect_id=effect_id,
+                    killstreak_tier=ks_tier_val,
                 )
                 item["price_string"] = formatted
                 item["formatted_price"] = formatted

--- a/utils/valuation_service.py
+++ b/utils/valuation_service.py
@@ -25,7 +25,8 @@ class ValuationService:
     """Wrapper around name-based price lookups."""
 
     def __init__(
-        self, price_map: Dict[Tuple[str, int, bool, int], Dict[str, Any]] | None = None
+        self,
+        price_map: Dict[Tuple[str, int, bool, int, int], Dict[str, Any]] | None = None,
     ) -> None:
         if price_map is None:
             path = ensure_prices_cached()
@@ -38,12 +39,19 @@ class ValuationService:
         quality: int,
         is_australium: bool = False,
         effect_id: int | None = None,
+        killstreak_tier: int | None = None,
     ) -> Dict[str, Any] | None:
         """Return raw price info dict for the item if available."""
-        key = (item_name, quality, is_australium, effect_id or 0)
+        key = (item_name, quality, is_australium, effect_id or 0, killstreak_tier or 0)
         info = self.price_map.get(key)
+        if info is None and killstreak_tier is not None:
+            info = self.price_map.get(
+                (item_name, quality, is_australium, effect_id or 0, 0)
+            )
         if info is None and effect_id is not None:
-            info = self.price_map.get((item_name, quality, is_australium, 0))
+            info = self.price_map.get(
+                (item_name, quality, is_australium, 0, killstreak_tier or 0)
+            )
         return info
 
     def format_price(
@@ -53,10 +61,17 @@ class ValuationService:
         is_australium: bool = False,
         *,
         effect_id: int | None = None,
+        killstreak_tier: int | None = None,
         currencies: Dict[str, Any] | None = None,
     ) -> str:
         """Return formatted price string using Backpack.tf key price."""
-        info = self.get_price_info(item_name, quality, is_australium, effect_id)
+        info = self.get_price_info(
+            item_name,
+            quality,
+            is_australium,
+            effect_id,
+            killstreak_tier,
+        )
         if not info:
             return ""
         value = info.get("value_raw")


### PR DESCRIPTION
## Summary
- extend price map with killstreak tier detection
- lookup prices using killstreak tier
- pass killstreak tier in inventory processing
- update tests for new key structure

## Testing
- `pre-commit run --files utils/price_loader.py utils/valuation_service.py utils/inventory_processor.py tests/test_price_loader.py tests/test_inventory_processor.py tests/test_valuation_service.py tests/test_item_enricher.py`

------
https://chatgpt.com/codex/tasks/task_e_686b977bbf688326accbd28a3ed0ae79