### PR TITLE
Refine item title rendering with killstreak

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -215,6 +215,11 @@ button {
   filter:drop-shadow(0 0 2px #A156D6);
 }
 .ks-effect{color:#ff7e30;font-weight:bold;}
+.ks-tier{
+  color:#ff7e30;
+  font-weight:bold;
+  margin-right:2px;
+}
 .unusual-effect {
   font-weight: bold;
   color: #8650AC;

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -19,5 +19,22 @@
   {% else %}
     <div class="missing-icon"></div>
   {% endif %}
-  <h2 class="item-title">{{ item.name }}</h2>
+  {% set title_parts = [] %}
+  {% if item.killstreak_name %}
+    {% if item.killstreak_name == 'Killstreak' %}
+      {% set _ = title_parts.append('Killstreak') %}
+    {% else %}
+      {% set _ = title_parts.append(item.killstreak_name) %}
+      {% set _ = title_parts.append('Killstreak') %}
+    {% endif %}
+  {% endif %}
+  {% set quality = item.quality %}
+  {% if item.strange or quality == 'Strange' %}
+    {% set _ = title_parts.append('Strange') %}
+  {% elif quality and quality not in ('Unique', 'Normal') %}
+    {% set _ = title_parts.append(quality) %}
+  {% endif %}
+  {% set base = item.base_name or item.display_name or item.name %}
+  {% set _ = title_parts.append(base) %}
+  <h2 class="item-title">{{ title_parts | join(' ') }}</h2>
 </div>


### PR DESCRIPTION
## Summary
- build item titles from killstreak tier, quality and base name
- add optional styling for killstreak tier

## Testing
- `pre-commit run --files templates/item_card.html static/style.css`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b999147ac8326813a382d6bd5217b