### PR TITLE
Handle killstreak prefixes after quality adjectives

### DIFF
--- a/tests/test_price_loader.py
+++ b/tests/test_price_loader.py
@@ -196,6 +196,43 @@ def test_price_map_killstreak(tmp_path, monkeypatch):
     assert ("Rocket Launcher", 6, False, 0, 3) in mapping
 
 
+def test_price_map_quality_killstreak(tmp_path, monkeypatch):
+    monkeypatch.setenv("BPTF_API_KEY", "TEST")
+    monkeypatch.setattr(price_loader, "PRICES_FILE", tmp_path / "prices.json")
+    url = "https://backpack.tf/api/IGetPrices/v4?raw=1&key=TEST"
+    payload = {
+        "response": {
+            "success": 1,
+            "items": {
+                "Strange Professional Killstreak Rocket Launcher": {
+                    "defindex": [205],
+                    "prices": {
+                        "11": {
+                            "Tradable": {
+                                "Craftable": [
+                                    {
+                                        "value": 100,
+                                        "value_raw": 100.0,
+                                        "currency": "keys",
+                                        "last_update": 0,
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                }
+            },
+        }
+    }
+
+    with responses.RequestsMock() as rsps:
+        rsps.add(responses.GET, url, json=payload, status=200)
+        p = price_loader.ensure_prices_cached(refresh=True)
+
+    mapping = price_loader.build_price_map(p)
+    assert ("Rocket Launcher", 11, False, 0, 3) in mapping
+
+
 def test_missing_api_key(monkeypatch):
     monkeypatch.delenv("BPTF_API_KEY", raising=False)
     with pytest.raises(RuntimeError):

--- a/utils/price_loader.py
+++ b/utils/price_loader.py
@@ -18,14 +18,41 @@ PRICES_FILE = Path("cache/prices.json")
 CURRENCIES_FILE = Path("cache/currencies.json")
 
 
+QUALITY_PREFIXES = (
+    "Strange ",
+    "Genuine ",
+    "Vintage ",
+    "Collector's ",
+    "Haunted ",
+    "Unusual ",
+    "Decorated ",
+    "Civilian Grade ",
+    "Freelance Grade ",
+    "Mercenary Grade ",
+    "Commando Grade ",
+    "Assassin Grade ",
+    "Elite Grade ",
+)
+
+
+def _strip_quality(name: str) -> str:
+    for q in QUALITY_PREFIXES:
+        if name.startswith(q):
+            return name[len(q) :]
+    return name
+
+
 def _extract_killstreak(name: str) -> tuple[str, int]:
     """Return (base name, killstreak tier) from an item name."""
 
+    name_no_qual = _strip_quality(name)
+
     for tier in (3, 2, 1):
         prefix = f"{KILLSTREAK_TIERS[tier]} "
-        if name.startswith(prefix):
-            return name[len(prefix) :], tier
-    return name, 0
+        if name_no_qual.startswith(prefix):
+            base = name_no_qual[len(prefix) :]
+            return base, tier
+    return name_no_qual, 0
 
 
 def _require_key() -> str:


### PR DESCRIPTION
## Summary
- support quality prefixes when extracting killstreak tiers from price dump
- test killstreak tier parsing with quality adjectives

## Testing
- `pre-commit run --files utils/price_loader.py tests/test_price_loader.py`


------
https://chatgpt.com/codex/tasks/task_e_686b9e211cf4832688b8e181df53b91c