### PR TITLE
Add particle effect overlay

### DIFF
--- a/static/modal.js
+++ b/static/modal.js
@@ -170,6 +170,17 @@
     });
   }
 
+  function setParticleBackground(effectId) {
+    const box = document.getElementById('modal-effect-bg');
+    if (!box) return;
+    if (effectId) {
+      const url = '/static/images/effects/' + effectId + '_380x380.png';
+      box.innerHTML = '<img src="' + url + '" alt="">';
+    } else {
+      box.innerHTML = '';
+    }
+  }
+
   function showItemModal(html) {
     if (!html) {
       console.warn('Empty modal HTML!');
@@ -201,5 +212,6 @@
     showItemModal,
     generateModalHTML,
     updateHeader,
+    setParticleBackground,
   };
 })(window);

--- a/static/retry.js
+++ b/static/retry.js
@@ -74,6 +74,9 @@ function attachItemModal() {
       if (window.modal && typeof window.modal.updateHeader === 'function') {
         window.modal.updateHeader(data);
       }
+      if (window.modal && typeof window.modal.setParticleBackground === 'function') {
+        window.modal.setParticleBackground(data.unusual_effect_id);
+      }
       if (window.modal && typeof window.modal.generateModalHTML === 'function') {
         const html = window.modal.generateModalHTML(data);
         if (window.modal.showItemModal) {

--- a/static/style.css
+++ b/static/style.css
@@ -161,6 +161,21 @@ button {
   position: relative; /* ensure badges overlay */
 }
 
+.particle-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  z-index: 0;
+}
+.particle-overlay img {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+}
+
 .item-card:hover {
   transform: translateY(-2px) scale(1.03);
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.5);
@@ -229,6 +244,8 @@ button {
   max-width: 64px;
   max-height: 64px;
   margin-bottom: 6px;
+  position: relative;
+  z-index: 1;
 }
 .missing-icon {
   width: 100%;
@@ -250,6 +267,8 @@ button {
   -webkit-line-clamp: 3;
   overflow: hidden;
   max-height: 3.6em;
+  position: relative;
+  z-index: 2;
 }
 
 .item-price {

--- a/templates/index.html
+++ b/templates/index.html
@@ -80,6 +80,8 @@
             align-items: flex-start;
             position: relative;
         }
+        #item-modal .modal-body { position: relative; }
+        #item-modal .particle-overlay img { max-width: 64px; max-height: 64px; }
         .modal-effect {
             font-weight: bold;
             color: #8650AC;
@@ -123,6 +125,7 @@
         <div id="modal-badges" class="item-badges"></div>
       </div>
       <div class="modal-body">
+        <div id="modal-effect-bg" class="particle-overlay"></div>
         <img id="modal-img" src="" width="64" height="64" alt="">
         <div id="modal-details"></div>
       </div>

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -14,6 +14,11 @@
   {% if item.quantity and item.quantity > 1 %}
     <span class="item-qty">x{{ item.quantity }}</span>
   {% endif %}
+  {% if item.unusual_effect_id %}
+    <div class="particle-overlay">
+      <img src="{{ url_for('static', filename='images/effects/%d_380x380.png' % item.unusual_effect_id) }}" alt="" />
+    </div>
+  {% endif %}
   {% if item.image_url %}
     <img class="item-img" src="{{ item.image_url }}" alt="{{ item.display_name }}" width="64" height="64" onerror="this.style.display='none';">
   {% else %}


### PR DESCRIPTION
## Summary
- overlay unusual particle images behind item icons
- add overlay to modal view as well
- update JS to display particle images
- item name displays over particle effects

## Testing
- `pre-commit run --files static/style.css templates/item_card.html templates/index.html static/modal.js static/retry.js`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bada4e2948326b6c671633519b308