### PR TITLE
Fix avatar link overlay

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -21,6 +21,11 @@ button,
     margin-bottom: 16px;
 }
 
+.user-card h2 a.avatar-link {
+    display: inline-block;
+    line-height: 0;
+}
+
 button {
     padding: 6px 12px;
     cursor: pointer;

--- a/templates/_user.html
+++ b/templates/_user.html
@@ -1,6 +1,6 @@
 <div id="user-{{ user.steamid }}" class="user-card">
   <h2>
-    <a href="{{ user.profile }}" target="_blank">
+    <a href="{{ user.profile }}" target="_blank" class="avatar-link">
       <img src="{{ user.avatar }}" width="64" style="vertical-align: middle; border-radius: 8px;">
     </a>
     {{ user.username }}


### PR DESCRIPTION
## Summary
- make avatar link class `avatar-link`
- ensure avatar link only covers the image using CSS

## Testing
- `pre-commit run --files templates/_user.html static/style.css`

------
https://chatgpt.com/codex/tasks/task_e_686bbc5b40508326abbde6f59d0e1cd6