### PR TITLE
Refactor profile card header UI

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -21,9 +21,47 @@ button,
     margin-bottom: 16px;
 }
 
-.user-card h2 a.avatar-link {
+.profile-header .avatar-link {
     display: inline-block;
     line-height: 0;
+}
+
+/* ───── Profile header layout ─────────────────────────────── */
+.profile-header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 0.25rem;
+    margin-bottom: 0.5rem;
+}
+
+.profile-header .avatar-link img {
+    width: 64px;
+    border-radius: 8px;
+}
+
+.profile-info {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+.profile-info .username {
+    font-weight: bold;
+    font-size: 1.2rem;
+}
+
+.profile-info .profile-link {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+.profile-info .status-pill {
+    margin-left: 0;
+    margin-top: 0.25rem;
 }
 
 button {
@@ -294,7 +332,10 @@ button {
   vertical-align: middle;
 }
 
-.tf2-hours { margin-left: 6px; font-size: 0.9em; }
+.tf2-hours {
+  margin: 0.25rem 0 0;
+  font-size: 0.9em;
+}
 
 .bptf-logo {
   width: 1em;
@@ -323,5 +364,11 @@ button {
   .item-card {
     width: 80px;
     height: 104px;
+  }
+  .profile-header .avatar-link img {
+    width: 48px;
+  }
+  .profile-info .username {
+    font-size: 1rem;
   }
 }

--- a/templates/_user.html
+++ b/templates/_user.html
@@ -1,23 +1,26 @@
 <div id="user-{{ user.steamid }}" class="user-card">
-  <h2>
+  <div class="profile-header">
     <a href="{{ user.profile }}" target="_blank" class="avatar-link">
-      <img src="{{ user.avatar }}" width="64" style="vertical-align: middle; border-radius: 8px;">
+      <img src="{{ user.avatar }}" alt="Avatar">
     </a>
-    {{ user.username }}
-    <a href="https://next.backpack.tf/profiles/{{ user.steamid }}" target="_blank" class="bptf-link">
-      <img src="/static/images/logos/bptf_small.PNG" alt="Backpack.tf" class="bptf-logo">
-    </a>
-    <span class="tf2-hours">TF2 Playtime: {{ user.playtime }} hrs</span>
-    <span class="pill status-pill {{ user.status }}{% if user.status == 'failed' %} retry-pill{% endif %}" {% if user.status == 'failed' %}data-steamid="{{ user.steamid }}" title="Retry scan for this user"{% endif %}>
-      {% if user.status == 'parsed' %}
-        <i class="fa-solid fa-check"></i> Public
-      {% elif user.status == 'private' %}
-        <i class="fa-solid fa-lock"></i> Private
-      {% else %}
-        <i class="fa-solid fa-arrows-rotate"></i> Failed
-      {% endif %}
-    </span>
-  </h2>
+    <div class="profile-info">
+      <div class="username">{{ user.username }}</div>
+      <div class="profile-link">
+        <a href="https://next.backpack.tf/profiles/{{ user.steamid }}" target="_blank">Backpack.tf</a>
+        <img src="/static/images/logos/bptf_small.PNG" alt="Backpack.tf" class="bptf-logo">
+      </div>
+      <div class="tf2-hours">TF2 Playtime: {{ user.playtime }} hrs</div>
+      <span class="pill status-pill {{ user.status }}{% if user.status == 'failed' %} retry-pill{% endif %}" {% if user.status == 'failed' %}data-steamid="{{ user.steamid }}" title="Retry scan for this user"{% endif %}>
+        {% if user.status == 'parsed' %}
+          <i class="fa-solid fa-check"></i> Public
+        {% elif user.status == 'private' %}
+          <i class="fa-solid fa-lock"></i> Private
+        {% else %}
+          <i class="fa-solid fa-arrows-rotate"></i> Failed
+        {% endif %}
+      </span>
+    </div>
+  </div>
   <div class="card-body">
     {% if user.status == 'incomplete' %}
       <span class="badge bg-warning text-dark">Fetched but unparsed</span>


### PR DESCRIPTION
## Summary
- stack profile info vertically under the avatar
- embed backpack.tf logo alongside the link
- style new profile layout with flexbox
- tweak TF2 hours and responsiveness

## Testing
- `pre-commit run --files static/style.css templates/_user.html` *(fails: Failed to load schema)*

------
https://chatgpt.com/codex/tasks/task_e_686bcebca6c083268f261de1f19257b4