### PR TITLE
Redesign user header layout

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -41,6 +41,31 @@ button,
     border-radius: 8px;
 }
 
+/* ───── New user header layout ────────────────────────────── */
+.user-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+  padding: 0 1rem;
+}
+
+.user-profile {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.profile-details {
+  display: flex;
+  flex-direction: column;
+}
+
+.profile-pic {
+  width: 64px;
+  border-radius: 8px;
+}
+
 .profile-info {
     display: flex;
     flex-direction: column;
@@ -48,7 +73,8 @@ button,
     gap: 0.25rem;
 }
 
-.profile-info .username {
+.profile-info .username,
+.profile-details .username {
     font-weight: bold;
     font-size: 1.2rem;
 }
@@ -337,9 +363,9 @@ button {
   font-size: 0.9em;
 }
 
-.bptf-logo {
-  width: 1em;
-  height: 1em;
+.bp-logo {
+  height: 20px;
+  background: transparent;
   vertical-align: middle;
   margin-left: 4px;
 }
@@ -365,10 +391,10 @@ button {
     width: 80px;
     height: 104px;
   }
-  .profile-header .avatar-link img {
+  .profile-pic {
     width: 48px;
   }
-  .profile-info .username {
+  .profile-details .username {
     font-size: 1rem;
   }
 }

--- a/templates/_user.html
+++ b/templates/_user.html
@@ -1,15 +1,20 @@
 <div id="user-{{ user.steamid }}" class="user-card">
-  <div class="profile-header">
-    <a href="{{ user.profile }}" target="_blank" class="avatar-link">
-      <img src="{{ user.avatar }}" alt="Avatar">
-    </a>
-    <div class="profile-info">
-      <div class="username">{{ user.username }}</div>
-      <div class="profile-link">
-        <a href="https://next.backpack.tf/profiles/{{ user.steamid }}" target="_blank">Backpack.tf</a>
-        <img src="/static/images/logos/bptf_small.PNG" alt="Backpack.tf" class="bptf-logo">
+  <div class="user-header">
+    <div class="user-profile">
+      <a href="{{ user.profile }}" target="_blank" class="avatar-link">
+        <img src="{{ user.avatar }}" alt="Avatar" class="profile-pic" />
+      </a>
+      <div class="profile-details">
+        <div class="username">{{ user.username }}</div>
+        <div class="tf2-hours">TF2 Playtime: {{ user.playtime }} hrs</div>
+        <div class="profile-link">
+          <a href="https://next.backpack.tf/profiles/{{ user.steamid }}" target="_blank">
+            Backpack.tf <img src="/static/images/logos/bptf_small.PNG" alt="Backpack.tf" class="bp-logo" />
+          </a>
+        </div>
       </div>
-      <div class="tf2-hours">TF2 Playtime: {{ user.playtime }} hrs</div>
+    </div>
+    <div class="privacy-status">
       <span class="pill status-pill {{ user.status }}{% if user.status == 'failed' %} retry-pill{% endif %}" {% if user.status == 'failed' %}data-steamid="{{ user.steamid }}" title="Retry scan for this user"{% endif %}>
         {% if user.status == 'parsed' %}
           <i class="fa-solid fa-check"></i> Public


### PR DESCRIPTION
## Summary
- restructure header layout in `_user.html`
- add flex-based `.user-header` CSS
- adjust BP.tf logo style via `.bp-logo`
- ensure responsive sizing for profile pic and username

## Testing
- `pre-commit run --files templates/_user.html static/style.css` *(fails: Missing schema files)*
- `pytest tests/test_user_template.py::test_user_template_does_not_error -q`

------
https://chatgpt.com/codex/tasks/task_e_686bd592c39c832682a874e18da19b48