### PR TITLE
Disable refresh button when no failures

### DIFF
--- a/static/retry.js
+++ b/static/retry.js
@@ -27,20 +27,32 @@ function refreshCard(id) {
     });
 }
 
+function updateRefreshButton() {
+  const btn = document.getElementById('refresh-failed-btn');
+  if (!btn) return;
+  const hasFailures = document.querySelectorAll('.status-pill.failed').length > 0;
+  if (!hasFailures) {
+    btn.disabled = true;
+    btn.textContent = 'Nothing to Refresh';
+    btn.classList.add('btn-disabled');
+  } else {
+    btn.disabled = false;
+    btn.textContent = 'Refresh Failed';
+    btn.classList.remove('btn-disabled');
+  }
+}
+
 function attachHandlers() {
   document.querySelectorAll('.retry-pill').forEach(el => {
     el.addEventListener('click', () => refreshCard(el.dataset.steamid));
   });
-  const btn = document.getElementById('retry-all');
-  if (btn) {
-    btn.disabled = document.querySelectorAll('.retry-pill').length === 0;
-  }
+  updateRefreshButton();
 
   attachItemModal();
 }
 
 function refreshAll() {
-  const btn = document.getElementById('retry-all');
+  const btn = document.getElementById('refresh-failed-btn');
   if (!btn) return;
   btn.disabled = true;
   const original = btn.textContent;
@@ -92,7 +104,7 @@ function attachItemModal() {
 
 document.addEventListener('DOMContentLoaded', () => {
   attachHandlers();
-  const btn = document.getElementById('retry-all');
+  const btn = document.getElementById('refresh-failed-btn');
   if (btn) {
     btn.addEventListener('click', refreshAll);
   }

--- a/static/style.css
+++ b/static/style.css
@@ -157,6 +157,12 @@ button {
     cursor: pointer;
 }
 
+.btn-disabled {
+    background-color: #444;
+    color: #aaa;
+    cursor: not-allowed;
+}
+
 .form-actions {
     display: flex;
     gap: 10px;

--- a/templates/index.html
+++ b/templates/index.html
@@ -108,7 +108,7 @@
         </div>
         <div class="form-actions">
             <button type="submit" class="primary-btn action-button"><i class="fa-solid fa-magnifying-glass"></i> Check Inventories</button>
-            <button id="retry-all" disabled class="refresh-btn action-button"><i class="fa-solid fa-arrows-rotate"></i> Refresh Failed</button>
+            <button id="refresh-failed-btn" disabled class="refresh-btn action-button"><i class="fa-solid fa-arrows-rotate"></i> Refresh Failed</button>
         </div>
     </form>
 


### PR DESCRIPTION
## Summary
- disable the "Refresh Failed" button when no failed users remain
- change button ID to `refresh-failed-btn`
- update retry.js to toggle button state and text dynamically
- add `.btn-disabled` style for disabled state

## Testing
- `pre-commit run --files templates/index.html static/retry.js static/style.css` *(fails: Missing schema files, pytest arguments)*

------
https://chatgpt.com/codex/tasks/task_e_686bd98d4d2083269a27938ede141ef1