### PR TITLE
Fix backpack link styling

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -369,9 +369,25 @@ button {
   font-size: 0.9em;
 }
 
-.bp-logo {
-  height: 20px;
-  background: transparent;
+
+a.backpack-link {
+  color: #ddd;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+a.backpack-link:hover {
+  color: #fff;
+  text-decoration: underline;
+}
+
+a.backpack-link:visited {
+  color: #ddd;
+}
+
+.inline-icon {
+  height: 1em;
+  width: auto;
   vertical-align: middle;
   margin-left: 4px;
 }

--- a/templates/_user.html
+++ b/templates/_user.html
@@ -8,8 +8,9 @@
         <div class="username">{{ user.username }}</div>
         <div class="tf2-hours">TF2 Playtime: {{ user.playtime }} hrs</div>
         <div class="profile-link">
-          <a href="https://next.backpack.tf/profiles/{{ user.steamid }}" target="_blank">
-            Backpack.tf <img src="/static/images/logos/bptf_small.PNG" alt="Backpack.tf" class="bp-logo" />
+          <a href="https://next.backpack.tf/profiles/{{ user.steamid }}" class="backpack-link" target="_blank" rel="noopener">
+            Backpack.tf
+            <img src="/static/images/logos/bptf_small.PNG" alt="Backpack.tf" class="inline-icon" />
           </a>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- polish backpack.tf link in user card
- tweak CSS to keep link inline and stylish

## Testing
- `pre-commit run --files templates/_user.html static/style.css` *(fails: Missing schema files)*

------
https://chatgpt.com/codex/tasks/task_e_686be17819c88326a3e7ec7e41adcd05