### PR TITLE
Add Backpack.tf footer attribution

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -392,6 +392,30 @@ a.backpack-link:visited {
   margin-left: 4px;
 }
 
+.footer {
+  text-align: center;
+  color: #aaa;
+  padding: 10px;
+  font-size: 0.9rem;
+}
+
+.bptf-link {
+  color: #ccc;
+  text-decoration: none;
+}
+
+.bptf-link:hover {
+  text-decoration: underline;
+  color: #fff;
+}
+
+.bptf-logo {
+  height: 1em;
+  width: auto;
+  vertical-align: middle;
+  margin-left: 4px;
+}
+
 .page-footer {
   margin-top: 2rem;
   text-align: center;

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,12 +10,6 @@
         .retry-pill:hover {
             background: rgba(255, 0, 0, 0.1);
         }
-        .footer {
-            margin-top: 2rem;
-            text-align: center;
-            font-size: 0.8rem;
-            color: #aaa;
-        }
         .inventory-scroll {
             display: flex;
             align-items: center;
@@ -132,13 +126,20 @@
     </dialog>
 
     <footer class="footer">
-        <i class="fa-brands fa-steam"></i>
-        <span>
-            Team Fortress 2 © Valve Corporation. Steam and the Steam logo are trademarks of Valve Corporation.
-        </span>
-        {% if debug_ms %}
-          <div>Longest merge: {{ debug_ms }} ms</div>
-        {% endif %}
+      <p>
+        Pricing and particles provided by
+        <a href="https://backpack.tf" target="_blank" rel="noopener" class="bptf-link">
+          Backpack.tf
+          <img src="/static/images/logos/bptf_small.PNG" alt="Backpack.tf logo" class="bptf-logo" />
+        </a>
+      </p>
+      <i class="fa-brands fa-steam"></i>
+      <span>
+          Team Fortress 2 © Valve Corporation. Steam and the Steam logo are trademarks of Valve Corporation.
+      </span>
+      {% if debug_ms %}
+        <div>Longest merge: {{ debug_ms }} ms</div>
+      {% endif %}
     </footer>
 
     <script>


### PR DESCRIPTION
## Summary
- add Backpack.tf attribution in footer with logo and link
- style new footer section and link icons

## Testing
- `pre-commit run --files templates/index.html static/style.css` *(fails: ModuleNotFoundError: No module named 'vdf')*


------
https://chatgpt.com/codex/tasks/task_e_686be5ec2b708326b9d2914b9ec5711e