### PR TITLE
Refine steam icon classes

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -115,7 +115,7 @@ button {
     resize: vertical;
 }
 
-.steam-icon {
+.input-steam-icon {
     position: absolute;
     left: 10px;
     color: #888;
@@ -460,6 +460,10 @@ a.backpack-link:visited {
   margin-bottom: 10px;
 }
 
+.site-footer .attribution {
+  font-size: 0.9rem;
+}
+
 .site-footer a.bptf-link {
   color: #b0b0b0;
   font-weight: 500;
@@ -481,8 +485,9 @@ a.backpack-link:visited {
 }
 
 .steam-icon {
+  display: inline-block;
   margin-right: 6px;
-  color: #c0c0c0;
-  font-size: 1em;
   vertical-align: middle;
+  font-size: 1em;
+  color: #c0c0c0;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -97,7 +97,7 @@
     <form method="post" class="input-form">
         <label for="steamids" class="visually-hidden">Steam IDs</label>
         <div class="input-wrapper">
-            <i class="fa-brands fa-steam steam-icon"></i>
+            <i class="fa-brands fa-steam input-steam-icon"></i>
             <textarea id="steamids" name="steamids" placeholder="Enter SteamID, vanity URL, or multiple IDs…">{{ steamids|default('') }}</textarea>
         </div>
         <div class="form-actions">


### PR DESCRIPTION
## Summary
- style `.steam-icon` as inline element
- rename input icon class to `.input-steam-icon`
- tweak footer attribution text size
- update markup to use new class

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files static/style.css templates/index.html`

------
https://chatgpt.com/codex/tasks/task_e_686bf1226c1c83268fd0c77802440b51