### PR TITLE
Implement sticky footer layout

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -491,3 +491,25 @@ a.backpack-link:visited {
   font-size: 1em;
   color: #c0c0c0;
 }
+
+html, body {
+  height: 100%;
+  margin: 0;
+}
+
+.page-container {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.content-wrap {
+  flex: 1;
+}
+
+footer {
+  padding: 1rem;
+  text-align: center;
+  font-size: 0.85rem;
+  color: #aaa;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -86,6 +86,8 @@
     </style>
 </head>
 <body>
+    <div class="page-container">
+    <main class="content-wrap">
     <h1>TF2 Inventory Checker</h1>
     {% with msgs = get_flashed_messages() %}
         {% if msgs %}
@@ -125,6 +127,7 @@
       </div>
     </dialog>
 
+    </main>
     <footer class="site-footer">
       <p class="attribution">
         Pricing and particles provided by
@@ -140,6 +143,8 @@
         <em>This project is not affiliated with or endorsed by Valve.</em>
       </p>
     </footer>
+
+    </div>
 
     <script>
       window.initialIds = {{ ids|tojson|safe }};


### PR DESCRIPTION
## Summary
- wrap main content in a new `.page-container` and `.content-wrap`
- add flexbox layout styles to enable sticky footer

## Testing
- `pre-commit run --files templates/index.html static/style.css` *(fails: Failed to load schema & pytest arguments)*
- `pytest -q` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_686bf356dd2c8326814e33336546c348