### PR TITLE
Add fade-in animation to results

### DIFF
--- a/static/retry.js
+++ b/static/retry.js
@@ -4,6 +4,7 @@ function appendCard(html) {
   const card = wrapper.firstElementChild;
   if (card) {
     document.getElementById('user-container').appendChild(card);
+    showResults();
   }
 }
 
@@ -24,6 +25,7 @@ function refreshCard(id) {
         appendCard(html);
       }
       attachHandlers();
+      showResults();
     });
 }
 
@@ -73,6 +75,15 @@ function loadUsers(ids) {
   });
 }
 
+function showResults() {
+  const results = document.getElementById('results');
+  if (!results) return;
+  results.classList.add('fade-in');
+  setTimeout(() => {
+    results.classList.add('show');
+  }, 10);
+}
+
 function attachItemModal() {
   document.querySelectorAll('.item-card').forEach(card => {
     card.addEventListener('click', () => {
@@ -114,5 +125,8 @@ document.addEventListener('DOMContentLoaded', () => {
   attachItemModal();
   if (window.modal && typeof window.modal.initModal === 'function') {
     window.modal.initModal();
+  }
+  if (document.getElementById('user-container').children.length) {
+    showResults();
   }
 });

--- a/static/style.css
+++ b/static/style.css
@@ -507,6 +507,17 @@ html, body {
   flex: 1;
 }
 
+.fade-in {
+  opacity: 0;
+  transform: translateY(10px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.fade-in.show {
+  opacity: 1;
+  transform: translateY(0);
+}
+
 footer {
   padding: 1rem;
   text-align: center;

--- a/templates/index.html
+++ b/templates/index.html
@@ -108,10 +108,12 @@
         </div>
     </form>
 
-    <div id="user-container">
-        {% for user in users %}
-            {% include "_user.html" %}
-        {% endfor %}
+    <div id="results" class="fade-in">
+        <div id="user-container">
+            {% for user in users %}
+                {% include "_user.html" %}
+            {% endfor %}
+        </div>
     </div>
 
     <dialog id="item-modal">


### PR DESCRIPTION
## Summary
- wrap results in a new `#results` container
- add `.fade-in` CSS class for slide-in animation
- trigger animation in `retry.js` when results load

## Testing
- `pre-commit run --files templates/index.html static/style.css static/retry.js` *(fails: ModuleNotFoundError: No module named 'vdf')*

------
https://chatgpt.com/codex/tasks/task_e_686bfa2427348326958ca9a23c44052c