### PR TITLE
Add toast scan progress display

### DIFF
--- a/static/retry.js
+++ b/static/retry.js
@@ -8,6 +8,21 @@ function appendCard(html) {
   }
 }
 
+function updateScanToast(current, total) {
+  const toast = document.getElementById('scan-toast');
+  if (!toast) return;
+  toast.textContent = `\u{1F504} Scanning ${current} of ${total} inventories...`;
+  toast.classList.remove('hidden');
+  toast.classList.add('show');
+}
+
+function hideScanToast() {
+  const toast = document.getElementById('scan-toast');
+  if (!toast) return;
+  toast.classList.remove('show');
+  setTimeout(() => toast.classList.add('hidden'), 300);
+}
+
 function refreshCard(id) {
   const pill = document.querySelector('#user-' + id + ' .status-pill');
   if (pill) {
@@ -59,20 +74,30 @@ function refreshAll() {
   btn.disabled = true;
   const original = btn.textContent;
   btn.textContent = 'Refreshing…';
-  const promises = Array.from(document.querySelectorAll('.retry-pill')).map(el =>
-    refreshCard(el.dataset.steamid)
+  const ids = Array.from(document.querySelectorAll('.retry-pill')).map(
+    el => el.dataset.steamid
   );
-  Promise.all(promises).finally(() => {
+  (async () => {
+    for (let i = 0; i < ids.length; i++) {
+      updateScanToast(i + 1, ids.length);
+      await refreshCard(ids[i]);
+    }
     btn.disabled = false;
     btn.textContent = original;
     attachHandlers();
-  });
+    hideScanToast();
+  })();
 }
 
 function loadUsers(ids) {
-  ids.forEach(id => {
-    refreshCard(id);
-  });
+  if (!ids || !ids.length) return;
+  (async () => {
+    for (let i = 0; i < ids.length; i++) {
+      updateScanToast(i + 1, ids.length);
+      await refreshCard(ids[i]);
+    }
+    hideScanToast();
+  })();
 }
 
 function showResults() {

--- a/static/style.css
+++ b/static/style.css
@@ -524,3 +524,28 @@ footer {
   font-size: 0.85rem;
   color: #aaa;
 }
+
+.toast {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  background-color: rgba(0, 0, 0, 0.85);
+  color: #f0f0f0;
+  padding: 0.75rem 1.25rem;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  font-size: 0.95rem;
+  z-index: 1000;
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.toast.show {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.toast.hidden {
+  display: none;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -116,6 +116,8 @@
         </div>
     </div>
 
+    <div id="scan-toast" class="toast hidden"></div>
+
     <dialog id="item-modal">
       <div class="modal-header">
         <div id="modal-effect" class="modal-effect"></div>


### PR DESCRIPTION
## Summary
- add scan progress toast container
- style toast in CSS
- update JS scanning logic to show toast

## Testing
- `pre-commit run --files templates/index.html static/style.css static/retry.js` *(fails: ModuleNotFoundError: No module named 'vdf')*
- `pytest -k 'nothing'` *(fails: unrecognized arguments: --cov --cov-config=.coveragerc)*

------
https://chatgpt.com/codex/tasks/task_e_686bfd35f7b88326ba8c5198319c938d