### PR TITLE
Improve refresh logic to skip loading inventories

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -21,6 +21,11 @@ button,
     margin-bottom: 16px;
 }
 
+.user-box.loading {
+    opacity: 0.6;
+    filter: grayscale(0.4);
+}
+
 .profile-header .avatar-link {
     display: inline-block;
     line-height: 0;

--- a/templates/_user.html
+++ b/templates/_user.html
@@ -1,4 +1,4 @@
-<div id="user-{{ user.steamid }}" class="user-card">
+<div id="user-{{ user.steamid }}" class="user-card user-box {{ user.status }}" data-steamid="{{ user.steamid }}">
   <div class="user-header">
     <div class="user-profile">
       <a href="{{ user.profile }}" target="_blank" class="avatar-link">


### PR DESCRIPTION
## Summary
- label `user-box` containers with a status class and steamid
- style loading user boxes dimmed
- track failures by `.user-box.failed` in the refresh script
- disable the Refresh Failed button when no failures remain

## Testing
- `pre-commit run --files static/retry.js static/style.css templates/_user.html` *(fails: ModuleNotFoundError: No module named 'vdf')*

------
https://chatgpt.com/codex/tasks/task_e_686bfec295708326bece7f999d1438b0