### PR TITLE
Fix CSS item card width override

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -438,10 +438,6 @@ a.backpack-link:visited {
     gap: 2px;
     overflow-x: auto;
   }
-  .item-card {
-    width: 80px;
-    height: 104px;
-  }
   .profile-pic {
     width: 48px;
   }


### PR DESCRIPTION
## Summary
- remove small screen width/height rules for `.item-card`

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files static/style.css`

------
https://chatgpt.com/codex/tasks/task_e_686c1d673a108326b8850f2f253142e3