### PR TITLE
Add paintkits schema caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Additional unit tests for inventory processing and ID conversion.
 - Coverage and CI badges in the README.
 - SchemaProvider class for fetching schema properties.
+- Paintkits endpoint cached as `warpaints.json`.
 
 ### Changed
 - Updated schema caching logic and UI (previous releases).

--- a/tests/test_local_data.py
+++ b/tests/test_local_data.py
@@ -67,6 +67,7 @@ def test_load_files_auto_refetch(tmp_path, monkeypatch, caplog):
         "items": [{"defindex": 1, "name": "One"}],
         "particles": [{"id": 1, "name": "P"}],
         "qualities": {"1": "Unique"},
+        "paintkits": [],
         "string_lookups": {
             "value": [
                 {

--- a/tests/test_schema_provider.py
+++ b/tests/test_schema_provider.py
@@ -20,6 +20,7 @@ def test_schema_provider(monkeypatch, tmp_path):
         "/raw/schema/attributes": {"2025": {"name": "Killstreak Tier"}},
         "/properties/effects": {"Burning Flames": {"id": 13, "name": "Burning Flames"}},
         "/properties/paints": {"A Color Similar to Slate": 3100495},
+        "/properties/paintkits": {"Warhawk": 350},
         "/raw/schema/originNames": {"0": "Timed Drop"},
         "/properties/strangeParts": {"Kills": {"id": 64, "name": "Kills"}},
         "/properties/qualities": {"Normal": 0},
@@ -40,6 +41,7 @@ def test_schema_provider(monkeypatch, tmp_path):
     assert provider.get_attributes() == {2025: {"name": "Killstreak Tier"}}
     assert provider.get_effects() == {13: {"id": 13, "name": "Burning Flames"}}
     assert provider.get_paints() == {"A Color Similar to Slate": 3100495}
+    assert provider.get_paintkits() == {350: "Warhawk"}
     assert provider.get_origins() == {0: "Timed Drop"}
     assert provider.get_parts() == {64: {"id": 64, "name": "Kills"}}
     assert provider.get_qualities() == {"Normal": 0}
@@ -72,6 +74,7 @@ def test_schema_provider_list_payload(monkeypatch, tmp_path):
         "/properties/paints": {
             "value": [{"id": 3100495, "name": "A Color Similar to Slate"}]
         },
+        "/properties/paintkits": {"value": [{"id": 350, "name": "Warhawk"}]},
         "/raw/schema/originNames": {"value": [{"id": 0, "name": "Timed Drop"}]},
         "/properties/strangeParts": {"value": [{"id": 64, "name": "Kills"}]},
         "/properties/qualities": {"value": [{"id": 0, "name": "Normal"}]},
@@ -92,6 +95,7 @@ def test_schema_provider_list_payload(monkeypatch, tmp_path):
     }
     assert provider.get_effects() == {13: {"id": 13, "name": "Burning Flames"}}
     assert provider.get_paints() == {"A Color Similar to Slate": 3100495}
+    assert provider.get_paintkits() == {350: "Warhawk"}
     assert provider.get_origins() == {0: "Timed Drop"}
     assert provider.get_parts() == {64: {"id": 64, "name": "Kills"}}
     assert provider.get_qualities() == {"Normal": 0}
@@ -123,7 +127,7 @@ def test_refresh_all_resets_attributes_and_creates_files(monkeypatch, tmp_path):
     provider.refresh_all(verbose=True)
 
     for key in provider.ENDPOINTS:
-        assert (tmp_path / f"{key}.json").exists()
+        assert provider._cache_file(key).exists()
 
     assert provider.items_by_defindex is None
     assert provider.attributes_by_defindex is None
@@ -136,6 +140,6 @@ def test_refresh_all_resets_attributes_and_creates_files(monkeypatch, tmp_path):
     assert provider.string_lookups is None
 
     for key in provider.ENDPOINTS:
-        fname = f"{tmp_path / key}.json"
+        fname = str(provider._cache_file(key))
         assert f"Fetching {key}..." in printed
         assert f"\N{CHECK MARK} Saved {fname} (0 entries)" in printed

--- a/utils/schema_provider.py
+++ b/utils/schema_provider.py
@@ -21,6 +21,7 @@ class SchemaProvider:
         "paints": "/properties/paints",
         "origins": "/raw/schema/originNames",
         "parts": "/properties/strangeParts",
+        "paintkits": "/properties/paintkits",
         "qualities": "/properties/qualities",
         "defindexes": "/properties/defindexes",
         "string_lookups": "/raw/schema/string_lookups",
@@ -41,6 +42,7 @@ class SchemaProvider:
         self.effects_by_index: Dict[int, Any] | None = None
         self.parts_by_defindex: Dict[int, Any] | None = None
         self.paints_map: Dict[str, int] | None = None
+        self.paintkits_map: Dict[int, str] | None = None
         self.qualities_map: Dict[str, int] | None = None
         self.defindex_names: Dict[int, str] | None = None
         self.origins_by_index: Dict[int, str] | None = None
@@ -54,6 +56,8 @@ class SchemaProvider:
         return resp.json()
 
     def _cache_file(self, key: str) -> Path:
+        if key == "paintkits":
+            return self.cache_dir / "warpaints.json"
         return self.cache_dir / f"{key}.json"
 
     def _load(self, key: str, endpoint: str, force: bool = False) -> Any:
@@ -121,6 +125,7 @@ class SchemaProvider:
         self.items_by_defindex = None
         self.attributes_by_defindex = None
         self.paints_map = None
+        self.paintkits_map = None
         self.parts_by_defindex = None
         self.defindex_names = None
         self.qualities_map = None
@@ -280,7 +285,19 @@ class SchemaProvider:
 
     # Stub helpers kept for backward compatibility --------------------------
     def get_paintkits(self, *, force: bool = False) -> Dict[int, str]:
-        return {}
+        if self.paintkits_map is None or force:
+            data = self._load("paintkits", self.ENDPOINTS["paintkits"], force)
+            if isinstance(data, dict):
+                if all(str(v).isdigit() for v in data.values()):
+                    mapping = {int(v): str(k) for k, v in data.items()}
+                else:
+                    mapping = {
+                        int(k): str(v) for k, v in data.items() if str(k).isdigit()
+                    }
+            else:
+                mapping = {}
+            self.paintkits_map = mapping
+        return self.paintkits_map
 
     def get_killstreaks(self, *, force: bool = False) -> Dict[int, str]:
         return {}


### PR DESCRIPTION
## Summary
- extend schema provider to fetch war paint metadata
- handle special cache path `warpaints.json`
- expose `get_paintkits`
- update tests for new endpoint
- document in CHANGELOG

## Testing
- `pre-commit` *(fails: ModuleNotFoundError: No module named 'vdf')*

------
https://chatgpt.com/codex/tasks/task_e_686c4b15ac0c8326aaf7837b4365db15