### PR TITLE
Expose warpaint id

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -409,7 +409,30 @@ def test_paintkit_appended_to_name(monkeypatch):
     monkeypatch.setattr(ld, "PAINTKIT_NAMES", {"350": "Warhawk"}, False)
     ld.QUALITIES_BY_INDEX = {15: "Decorated Weapon"}
     items = ip.enrich_inventory(data)
-    assert items[0]["name"] == "Decorated Weapon Flamethrower (Warhawk)"
+    item = items[0]
+    assert item["name"] == "Decorated Weapon Flamethrower (Warhawk)"
+    assert item["warpaint_id"] == 350
+    assert item["warpaint_name"] == "Warhawk"
+    assert item["paintkit_name"] == "Warhawk"
+
+
+def test_warpaint_unknown_defaults_unknown(monkeypatch):
+    data = {
+        "items": [
+            {
+                "defindex": 15141,
+                "quality": 15,
+                "attributes": [{"defindex": 834, "float_value": 999}],
+            }
+        ]
+    }
+    ld.ITEMS_BY_DEFINDEX = {15141: {"item_name": "Flamethrower"}}
+    monkeypatch.setattr(ld, "PAINTKIT_NAMES", {}, False)
+    ld.QUALITIES_BY_INDEX = {15: "Decorated Weapon"}
+    items = ip.enrich_inventory(data)
+    item = items[0]
+    assert item["warpaint_id"] == 999
+    assert item["warpaint_name"] == "Unknown"
 
 
 def test_kill_eater_fields(monkeypatch):

--- a/utils/schema_provider.py
+++ b/utils/schema_provider.py
@@ -287,7 +287,13 @@ class SchemaProvider:
     def get_paintkits(self, *, force: bool = False) -> Dict[int, str]:
         if self.paintkits_map is None or force:
             data = self._load("paintkits", self.ENDPOINTS["paintkits"], force)
-            if isinstance(data, dict):
+            if isinstance(data, list):
+                mapping = {
+                    int(e["id"]): str(e["name"])
+                    for e in data
+                    if isinstance(e, dict) and "id" in e and "name" in e
+                }
+            elif isinstance(data, dict):
                 if all(str(v).isdigit() for v in data.values()):
                     mapping = {int(v): str(k) for k, v in data.items()}
                 else:


### PR DESCRIPTION
## Summary
- return warpaint id and name from `_extract_paintkit`
- expose `warpaint_id` and `warpaint_name` via `_process_item`
- support list payloads in SchemaProvider paintkit caching
- test coverage for decorated weapon warpaint fields

## Testing
- `pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py utils/schema_provider.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c52fe95888326933e900db96ad692