### PR TITLE
Update warpaint cache path

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Submit any supported SteamID format. Each user panel shows the avatar, TF2 playt
 
 - Templates live under `templates/`; `index.html` includes `_user.html` for each user.
 - Item schema is cached automatically via `SchemaProvider` in
-  `utils/schema_provider.py`. Pass `base_url` to use a mirror. Update it with:
+  `utils/schema_provider.py`. Paintkit names are written to
+  `cache/schema/warpaints.json`. Pass `base_url` to use a mirror. Update it with:
   ```bash
   python app.py --refresh  # fetch latest schema files (shows progress)
   python main.py --refresh

--- a/utils/local_data.py
+++ b/utils/local_data.py
@@ -72,7 +72,8 @@ DEFAULT_WEAR_FILE = BASE_DIR / "cache" / "wear_names.json"
 DEFAULT_KILLSTREAK_FILE = BASE_DIR / "cache" / "killstreak_names.json"
 DEFAULT_KS_EFFECT_FILE = BASE_DIR / "cache" / "killstreak_effect_names.json"
 DEFAULT_STRANGE_PART_FILE = BASE_DIR / "cache" / "strange_part_names.json"
-DEFAULT_PAINTKIT_FILE = BASE_DIR / "cache" / "paintkit_names.json"
+# Cached warpaint names from the paintkits endpoint
+DEFAULT_PAINTKIT_FILE = BASE_DIR / "cache" / "schema" / "warpaints.json"
 DEFAULT_CRATE_SERIES_FILE = BASE_DIR / "cache" / "crate_series_names.json"
 DEFAULT_STRING_LOOKUPS_FILE = BASE_DIR / "cache" / "string_lookups.json"
 EFFECT_FILE = Path(os.getenv("TF2_EFFECT_FILE", DEFAULT_EFFECT_FILE))


### PR DESCRIPTION
## Summary
- adjust `DEFAULT_PAINTKIT_FILE` to use `cache/schema/warpaints.json`
- document the new path in the README

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files utils/local_data.py README.md`
- `STEAM_API_KEY=test pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c5564056c832697d0526d8cb471c1