### PR TITLE
Add warpaint mapping and badge

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -368,6 +368,16 @@ button {
   word-wrap: break-word;
 }
 
+.warpaint-badge {
+  background: #282828;
+  color: #f4d03f;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 11px;
+  margin-top: 4px;
+  display: inline-block;
+}
+
 /* ───── Paint colour dot (used in card & modal) ───────────────────── */
 .paint-dot {
   display: inline-block;

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -46,4 +46,7 @@
   {% endif %}
   {% set _ = title_parts.append(base) %}
   <h2 class="item-title">{{ title_parts | join(' ') }}</h2>
+  {% if item.warpaint_name %}
+    <div class="badge warpaint-badge">Warpaint: {{ item.warpaint_name }}</div>
+  {% endif %}
 </div>

--- a/tests/test_local_data.py
+++ b/tests/test_local_data.py
@@ -39,6 +39,30 @@ def test_load_files_success(tmp_path, monkeypatch, caplog):
     assert "Loaded 1 attributes" in out
 
 
+def test_warpaint_map_reversed(tmp_path, monkeypatch):
+    attr_file = tmp_path / "attributes.json"
+    particles_file = tmp_path / "particles.json"
+    items_file = tmp_path / "items.json"
+    qual_file = tmp_path / "qualities.json"
+    curr_file = tmp_path / "currencies.json"
+    paintkit_file = tmp_path / "warpaints.json"
+
+    for f in (attr_file, particles_file, items_file, qual_file):
+        f.write_text("[]")
+    curr_file.write_text(json.dumps({"metal": {"value_raw": 1.0}}))
+    paintkit_file.write_text(json.dumps({"Warhawk": 80}))
+
+    monkeypatch.setattr(ld, "ATTRIBUTES_FILE", attr_file)
+    monkeypatch.setattr(ld, "PARTICLES_FILE", particles_file)
+    monkeypatch.setattr(ld, "ITEMS_FILE", items_file)
+    monkeypatch.setattr(ld, "QUALITIES_FILE", qual_file)
+    monkeypatch.setattr(ld, "PAINTKIT_FILE", paintkit_file)
+    monkeypatch.setattr(ld, "CURRENCIES_FILE", curr_file)
+
+    ld.load_files()
+    assert ld.PAINTKIT_NAMES == {"80": "Warhawk"}
+
+
 def test_load_files_missing(tmp_path, monkeypatch):
     monkeypatch.setattr(ld, "ATTRIBUTES_FILE", tmp_path / "missing.json")
     monkeypatch.setattr(ld, "ITEMS_FILE", tmp_path / "missing2.json")

--- a/tests/test_schema_provider.py
+++ b/tests/test_schema_provider.py
@@ -42,6 +42,8 @@ def test_schema_provider(monkeypatch, tmp_path):
     assert provider.get_effects() == {13: {"id": 13, "name": "Burning Flames"}}
     assert provider.get_paints() == {"A Color Similar to Slate": 3100495}
     assert provider.get_paintkits() == {350: "Warhawk"}
+    assert provider.get_warpaints() == {"Warhawk": 350}
+    assert provider.warpaints_by_id == {350: "Warhawk"}
     assert provider.get_origins() == {0: "Timed Drop"}
     assert provider.get_parts() == {64: {"id": 64, "name": "Kills"}}
     assert provider.get_qualities() == {"Normal": 0}
@@ -96,6 +98,8 @@ def test_schema_provider_list_payload(monkeypatch, tmp_path):
     assert provider.get_effects() == {13: {"id": 13, "name": "Burning Flames"}}
     assert provider.get_paints() == {"A Color Similar to Slate": 3100495}
     assert provider.get_paintkits() == {350: "Warhawk"}
+    assert provider.get_warpaints() == {"Warhawk": 350}
+    assert provider.warpaints_by_id == {350: "Warhawk"}
     assert provider.get_origins() == {0: "Timed Drop"}
     assert provider.get_parts() == {64: {"id": 64, "name": "Kills"}}
     assert provider.get_qualities() == {"Normal": 0}

--- a/utils/local_data.py
+++ b/utils/local_data.py
@@ -306,7 +306,7 @@ def load_files(
     KILLSTREAK_NAMES = _load_json_map(KILLSTREAK_FILE)
     KILLSTREAK_EFFECT_NAMES = _load_json_map(KILLSTREAK_EFFECT_FILE)
     STRANGE_PART_NAMES = _load_json_map(STRANGE_PART_FILE)
-    PAINTKIT_NAMES = _load_json_map(PAINTKIT_FILE)
+    PAINTKIT_NAMES = _load_paint_id_map(PAINTKIT_FILE)
     CRATE_SERIES_NAMES = _load_json_map(CRATE_SERIES_FILE)
 
     FOOTPRINT_SPELL_MAP = {}

--- a/utils/schema_provider.py
+++ b/utils/schema_provider.py
@@ -43,6 +43,8 @@ class SchemaProvider:
         self.parts_by_defindex: Dict[int, Any] | None = None
         self.paints_map: Dict[str, int] | None = None
         self.paintkits_map: Dict[int, str] | None = None
+        self.warpaints: Dict[str, int] | None = None
+        self._warpaints_by_id: Dict[int, str] | None = None
         self.qualities_map: Dict[str, int] | None = None
         self.defindex_names: Dict[int, str] | None = None
         self.origins_by_index: Dict[int, str] | None = None
@@ -126,6 +128,8 @@ class SchemaProvider:
         self.attributes_by_defindex = None
         self.paints_map = None
         self.paintkits_map = None
+        self.warpaints = None
+        self._warpaints_by_id = None
         self.parts_by_defindex = None
         self.defindex_names = None
         self.qualities_map = None
@@ -303,7 +307,24 @@ class SchemaProvider:
             else:
                 mapping = {}
             self.paintkits_map = mapping
+            self._warpaints_by_id = mapping
+            self.warpaints = {v: k for k, v in mapping.items()}
         return self.paintkits_map
+
+    # New helpers -----------------------------------------------------------
+    def get_warpaints(self, *, force: bool = False) -> Dict[str, int]:
+        """Return a mapping of warpaint name -> id."""
+
+        if self.warpaints is None or self._warpaints_by_id is None or force:
+            _ = self.get_paintkits(force=force)
+        assert self.warpaints is not None
+        return self.warpaints
+
+    @property
+    def warpaints_by_id(self) -> Dict[int, str]:
+        if self._warpaints_by_id is None:
+            _ = self.get_paintkits()
+        return self._warpaints_by_id or {}
 
     def get_killstreaks(self, *, force: bool = False) -> Dict[int, str]:
         return {}


### PR DESCRIPTION
## Summary
- expose warpaint mappings from `SchemaProvider`
- load warpaint IDs correctly in `local_data`
- show warpaint names on item cards and style badge
- test warpaint mappings and reversed map

## Testing
- `pre-commit` *(fails: validate attributes requires schema files)*

------
https://chatgpt.com/codex/tasks/task_e_686c5b5caf6c83269dacd08e54676046