### PR TITLE
Fix paintkit name mapping

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -360,7 +360,7 @@ def test_paint_and_paintkit_badges(monkeypatch):
     ld.ITEMS_BY_DEFINDEX = {9000: {"item_name": "Painted", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {6: "Unique"}
     monkeypatch.setattr(ld, "PAINT_NAMES", {"3100495": "Test Paint"}, False)
-    monkeypatch.setattr(ld, "PAINTKIT_NAMES", {"350": "Test Kit"}, False)
+    monkeypatch.setattr(ld, "PAINTKIT_NAMES", {"Test Kit": 350}, False)
 
     items = ip.enrich_inventory(data)
     badges = items[0]["badges"]
@@ -406,7 +406,7 @@ def test_paintkit_appended_to_name(monkeypatch):
         ]
     }
     ld.ITEMS_BY_DEFINDEX = {15141: {"item_name": "Flamethrower"}}
-    monkeypatch.setattr(ld, "PAINTKIT_NAMES", {"350": "Warhawk"}, False)
+    monkeypatch.setattr(ld, "PAINTKIT_NAMES", {"Warhawk": 350}, False)
     ld.QUALITIES_BY_INDEX = {15: "Decorated Weapon"}
     items = ip.enrich_inventory(data)
     item = items[0]

--- a/tests/test_local_data.py
+++ b/tests/test_local_data.py
@@ -46,9 +46,9 @@ def test_warpaint_map_reversed(tmp_path, monkeypatch):
 
     monkeypatch.setattr(ld, "BASE_DIR", tmp_path)
     warpaints = ld.load_json("schema/warpaints.json")
-    ld.PAINTKIT_NAMES = {str(v): k for k, v in warpaints.items()}
+    ld.PAINTKIT_NAMES = {str(k): v for k, v in warpaints.items()}
 
-    assert ld.PAINTKIT_NAMES == {"80": "Warhawk"}
+    assert ld.PAINTKIT_NAMES == {"Warhawk": 80}
 
 
 def test_load_files_missing(tmp_path, monkeypatch):

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -338,7 +338,14 @@ def _extract_paintkit(asset: Dict[str, Any]) -> tuple[int, str] | None:
             if idx == 834 and attr_class not in PAINTKIT_CLASSES:
                 logger.warning("Using numeric fallback for paintkit index %s", idx)
 
-            name = local_data.PAINTKIT_NAMES.get(str(warpaint_id), "Unknown")
+            name = next(
+                (
+                    n
+                    for n, pid in local_data.PAINTKIT_NAMES.items()
+                    if str(pid) == str(warpaint_id)
+                ),
+                "Unknown",
+            )
             return warpaint_id, name
     return None
 

--- a/utils/local_data.py
+++ b/utils/local_data.py
@@ -109,7 +109,7 @@ def load_json(relative: str) -> Any:
 # Preload cached paintkit names at import time
 warpaints = load_json("schema/warpaints.json")
 PAINTKIT_NAMES = (
-    {str(v): k for k, v in warpaints.items()} if isinstance(warpaints, dict) else {}
+    {str(k): v for k, v in warpaints.items()} if isinstance(warpaints, dict) else {}
 )
 
 


### PR DESCRIPTION
## Summary
- store paintkit names keyed by warpaint name
- adjust paintkit extraction to match new structure
- update related tests

## Testing
- `SKIP_VALIDATE=1 pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c6e8add9483268c574123faa6aa9d