### PR TITLE
Fix warpaint name lookup

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -361,6 +361,7 @@ def test_paint_and_paintkit_badges(monkeypatch):
     ld.QUALITIES_BY_INDEX = {6: "Unique"}
     monkeypatch.setattr(ld, "PAINT_NAMES", {"3100495": "Test Paint"}, False)
     monkeypatch.setattr(ld, "PAINTKIT_NAMES", {"Test Kit": 350}, False)
+    monkeypatch.setattr(ld, "PAINTKIT_NAMES_BY_ID", {"350": "Test Kit"}, False)
 
     items = ip.enrich_inventory(data)
     badges = items[0]["badges"]
@@ -407,6 +408,7 @@ def test_paintkit_appended_to_name(monkeypatch):
     }
     ld.ITEMS_BY_DEFINDEX = {15141: {"item_name": "Flamethrower"}}
     monkeypatch.setattr(ld, "PAINTKIT_NAMES", {"Warhawk": 350}, False)
+    monkeypatch.setattr(ld, "PAINTKIT_NAMES_BY_ID", {"350": "Warhawk"}, False)
     ld.QUALITIES_BY_INDEX = {15: "Decorated Weapon"}
     items = ip.enrich_inventory(data)
     item = items[0]
@@ -428,6 +430,7 @@ def test_warpaint_unknown_defaults_unknown(monkeypatch):
     }
     ld.ITEMS_BY_DEFINDEX = {15141: {"item_name": "Flamethrower"}}
     monkeypatch.setattr(ld, "PAINTKIT_NAMES", {}, False)
+    monkeypatch.setattr(ld, "PAINTKIT_NAMES_BY_ID", {}, False)
     ld.QUALITIES_BY_INDEX = {15: "Decorated Weapon"}
     items = ip.enrich_inventory(data)
     item = items[0]

--- a/tests/test_local_data.py
+++ b/tests/test_local_data.py
@@ -47,8 +47,10 @@ def test_warpaint_map_reversed(tmp_path, monkeypatch):
     monkeypatch.setattr(ld, "BASE_DIR", tmp_path)
     warpaints = ld.load_json("schema/warpaints.json")
     ld.PAINTKIT_NAMES = {str(k): v for k, v in warpaints.items()}
+    ld.PAINTKIT_NAMES_BY_ID = {str(v): k for k, v in ld.PAINTKIT_NAMES.items()}
 
     assert ld.PAINTKIT_NAMES == {"Warhawk": 80}
+    assert ld.PAINTKIT_NAMES_BY_ID == {"80": "Warhawk"}
 
 
 def test_load_files_missing(tmp_path, monkeypatch):

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -338,12 +338,8 @@ def _extract_paintkit(asset: Dict[str, Any]) -> tuple[int, str] | None:
             if idx == 834 and attr_class not in PAINTKIT_CLASSES:
                 logger.warning("Using numeric fallback for paintkit index %s", idx)
 
-            name = next(
-                (
-                    n
-                    for n, pid in local_data.PAINTKIT_NAMES.items()
-                    if str(pid) == str(warpaint_id)
-                ),
+            name = local_data.PAINTKIT_NAMES_BY_ID.get(
+                str(warpaint_id),
                 "Unknown",
             )
             return warpaint_id, name

--- a/utils/local_data.py
+++ b/utils/local_data.py
@@ -24,6 +24,7 @@ KILLSTREAK_NAMES: Dict[str, str] = {}
 STRANGE_PART_NAMES: Dict[str, str] = {}
 # will be populated at import time
 PAINTKIT_NAMES: Dict[str, str]
+PAINTKIT_NAMES_BY_ID: Dict[str, str]
 CRATE_SERIES_NAMES: Dict[str, str] = {}
 CURRENCIES: Dict[str, Any] = {}
 FOOTPRINT_SPELL_MAP: Dict[int, str] = {}
@@ -36,7 +37,6 @@ KILLSTREAK_EFFECT_NAMES: Dict[str, str] = {
     "2006": "Singularity",
     "2007": "Incinerator",
     "2008": "Hypno-Beam",
-
 }
 
 # Map of attribute class -> in-game spell name
@@ -109,6 +109,7 @@ warpaints = load_json("schema/warpaints.json")
 PAINTKIT_NAMES = (
     {str(k): v for k, v in warpaints.items()} if isinstance(warpaints, dict) else {}
 )
+PAINTKIT_NAMES_BY_ID = {str(v): k for k, v in PAINTKIT_NAMES.items()}
 
 
 def clean_items_game(raw: dict | str) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- add PAINTKIT_NAMES_BY_ID for reverse warpaint lookup
- use the new mapping in inventory processing
- adjust tests for the new data structure

## Testing
- `pre-commit run --files utils/local_data.py utils/inventory_processor.py tests/test_local_data.py tests/test_inventory_processor.py`
- `pytest -q tests/test_local_data.py::test_warpaint_map_reversed tests/test_inventory_processor.py::test_paintkit_appended_to_name tests/test_inventory_processor.py::test_warpaint_unknown_defaults_unknown tests/test_inventory_processor.py::test_paint_and_paintkit_badges`

------
https://chatgpt.com/codex/tasks/task_e_686c74707bb88326bf4f0f4f6ffbde61