### PR TITLE
Fix paintkit detection

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -438,6 +438,27 @@ def test_warpaint_unknown_defaults_unknown(monkeypatch):
     assert item["warpaint_name"] == "Unknown"
 
 
+def test_no_warpaint_attribute(monkeypatch):
+    data = {
+        "items": [
+            {
+                "defindex": 15141,
+                "quality": 15,
+                "attributes": [],
+            }
+        ]
+    }
+    ld.ITEMS_BY_DEFINDEX = {15141: {"item_name": "Flamethrower"}}
+    monkeypatch.setattr(ld, "PAINTKIT_NAMES", {"Warhawk": 350}, False)
+    monkeypatch.setattr(ld, "PAINTKIT_NAMES_BY_ID", {"350": "Warhawk"}, False)
+    ld.QUALITIES_BY_INDEX = {15: "Decorated Weapon"}
+    items = ip.enrich_inventory(data)
+    item = items[0]
+    assert item["warpaint_id"] is None
+    assert item["warpaint_name"] is None
+    assert item["name"] == "Decorated Weapon Flamethrower"
+
+
 def test_kill_eater_fields(monkeypatch):
     data = {
         "items": [


### PR DESCRIPTION
## Summary
- correct warpaint extraction logic and support missing attribute
- append warpaint name only when present
- cover case of items without warpaints in unit tests

## Testing
- `pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cc4f8181c8326a0f565de9bb60457