### PR TITLE
Handle zero war paint values

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -357,7 +357,9 @@ def test_paint_and_paintkit_badges(monkeypatch):
             }
         ]
     }
-    ld.ITEMS_BY_DEFINDEX = {9000: {"item_name": "Painted", "image_url": ""}}
+    ld.ITEMS_BY_DEFINDEX = {
+        9000: {"item_name": "Painted", "image_url": "", "craft_class": "weapon"}
+    }
     ld.QUALITIES_BY_INDEX = {6: "Unique"}
     monkeypatch.setattr(ld, "PAINT_NAMES", {"3100495": "Test Paint"}, False)
     monkeypatch.setattr(ld, "PAINTKIT_NAMES", {"Test Kit": 350}, False)
@@ -406,7 +408,10 @@ def test_paintkit_appended_to_name(monkeypatch):
             }
         ]
     }
-    ld.ITEMS_BY_DEFINDEX = {15141: {"item_name": "Flamethrower"}}
+    ld.ITEMS_BY_DEFINDEX = {
+        15141: {"item_name": "Flamethrower", "craft_class": "weapon"}
+    }
+    ld.ITEMS_BY_DEFINDEX[15141]["craft_class"] = "weapon"
     monkeypatch.setattr(ld, "PAINTKIT_NAMES", {"Warhawk": 350}, False)
     monkeypatch.setattr(ld, "PAINTKIT_NAMES_BY_ID", {"350": "Warhawk"}, False)
     ld.QUALITIES_BY_INDEX = {15: "Decorated Weapon"}
@@ -428,7 +433,9 @@ def test_warpaint_unknown_defaults_unknown(monkeypatch):
             }
         ]
     }
-    ld.ITEMS_BY_DEFINDEX = {15141: {"item_name": "Flamethrower"}}
+    ld.ITEMS_BY_DEFINDEX = {
+        15141: {"item_name": "Flamethrower", "craft_class": "weapon"}
+    }
     monkeypatch.setattr(ld, "PAINTKIT_NAMES", {}, False)
     monkeypatch.setattr(ld, "PAINTKIT_NAMES_BY_ID", {}, False)
     ld.QUALITIES_BY_INDEX = {15: "Decorated Weapon"}
@@ -448,7 +455,9 @@ def test_no_warpaint_attribute(monkeypatch):
             }
         ]
     }
-    ld.ITEMS_BY_DEFINDEX = {15141: {"item_name": "Flamethrower"}}
+    ld.ITEMS_BY_DEFINDEX = {
+        15141: {"item_name": "Flamethrower", "craft_class": "weapon"}
+    }
     monkeypatch.setattr(ld, "PAINTKIT_NAMES", {"Warhawk": 350}, False)
     monkeypatch.setattr(ld, "PAINTKIT_NAMES_BY_ID", {"350": "Warhawk"}, False)
     ld.QUALITIES_BY_INDEX = {15: "Decorated Weapon"}
@@ -457,6 +466,46 @@ def test_no_warpaint_attribute(monkeypatch):
     assert item["warpaint_id"] is None
     assert item["warpaint_name"] is None
     assert item["name"] == "Decorated Weapon Flamethrower"
+
+
+def test_warpaint_zero_ignored(monkeypatch):
+    data = {
+        "items": [
+            {
+                "defindex": 15141,
+                "quality": 15,
+                "attributes": [{"defindex": 834, "float_value": 0}],
+            }
+        ]
+    }
+    ld.ITEMS_BY_DEFINDEX = {
+        15141: {"item_name": "Flamethrower", "craft_class": "weapon"}
+    }
+    ld.QUALITIES_BY_INDEX = {15: "Decorated Weapon"}
+    items = ip.enrich_inventory(data)
+    item = items[0]
+    assert item["warpaint_id"] is None
+    assert item["warpaint_name"] is None
+
+
+def test_warpaint_invalid_value(monkeypatch):
+    data = {
+        "items": [
+            {
+                "defindex": 15141,
+                "quality": 15,
+                "attributes": [{"defindex": 834, "value": "bad"}],
+            }
+        ]
+    }
+    ld.ITEMS_BY_DEFINDEX = {
+        15141: {"item_name": "Flamethrower", "craft_class": "weapon"}
+    }
+    ld.QUALITIES_BY_INDEX = {15: "Decorated Weapon"}
+    items = ip.enrich_inventory(data)
+    item = items[0]
+    assert item["warpaint_id"] is None
+    assert item["warpaint_name"] is None
 
 
 def test_kill_eater_fields(monkeypatch):


### PR DESCRIPTION
## Summary
- handle warpaint_id 0 as `None`
- add `_is_warpaintable` helper
- apply warpaint data only to weapons
- test warpaint edge cases

## Testing
- `pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py` *(fails: validate-attributes missing schema)*
- `pytest tests/test_inventory_processor.py::test_warpaint_zero_ignored -q`
- `pytest tests/test_inventory_processor.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cc93545548326a56491a18c45a334