### PR TITLE
Update warpaintable logic

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -508,6 +508,29 @@ def test_warpaint_invalid_value(monkeypatch):
     assert item["warpaint_name"] is None
 
 
+def test_warpaintable_inferred_from_item_class(monkeypatch):
+    data = {
+        "items": [
+            {
+                "defindex": 16001,
+                "quality": 15,
+                "attributes": [{"defindex": 834, "float_value": 350}],
+            }
+        ]
+    }
+    ld.ITEMS_BY_DEFINDEX = {
+        16001: {"item_name": "Tester", "item_class": "tf_weapon_test"}
+    }
+    monkeypatch.setattr(ld, "PAINTKIT_NAMES", {"Warhawk": 350}, False)
+    monkeypatch.setattr(ld, "PAINTKIT_NAMES_BY_ID", {"350": "Warhawk"}, False)
+    ld.QUALITIES_BY_INDEX = {15: "Decorated Weapon"}
+    items = ip.enrich_inventory(data)
+    item = items[0]
+    assert item["warpaint_id"] == 350
+    assert item["warpaint_name"] == "Warhawk"
+    assert item["name"] == "Decorated Weapon Tester (Warhawk)"
+
+
 def test_kill_eater_fields(monkeypatch):
     data = {
         "items": [

--- a/tests/test_unusual_effect_extraction.py
+++ b/tests/test_unusual_effect_extraction.py
@@ -1,4 +1,5 @@
 from utils.inventory_processor import _extract_unusual_effect, EFFECTS_MAP
+from utils import local_data
 
 
 def test_extract_unusual_effect_cosmetic():
@@ -15,6 +16,7 @@ def test_extract_unusual_effect_unusual():
 
 def test_extract_unusual_effect_value_fallback():
     EFFECTS_MAP[3042] = "Taunt Effect"
+    local_data.EFFECT_NAMES.pop("3042", None)
     asset = {
         "quality": 5,
         "attributes": [

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -622,7 +622,9 @@ def _is_warpaintable(schema_entry: Dict[str, Any]) -> bool:
         schema_entry.get("craft_class") != "weapon"
         and schema_entry.get("craft_material_type") != "weapon"
     ):
-        return False
+        item_class = schema_entry.get("item_class", "")
+        if not item_class.startswith("tf_weapon_"):
+            return False
 
     name = schema_entry.get("item_name") or schema_entry.get("name") or ""
     if _is_placeholder_name(name):


### PR DESCRIPTION
## Summary
- extend `_is_warpaintable` to also accept weapons based on `item_class`
- test warpaint detection with only `item_class`
- fix flaky unusual effect test

## Testing
- `pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py tests/test_unusual_effect_extraction.py`

------
https://chatgpt.com/codex/tasks/task_e_686ccef3a89483268690b0bb6713fef1