### PR TITLE
Add Australium weapon images

### DIFF
--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -17,7 +17,9 @@
   {% if item.unusual_effect_id %}
     <img class="particle-bg" src="/static/images/effects/{{ item.unusual_effect_id }}.png" alt="effect">
   {% endif %}
-  {% if item.image_url %}
+  {% if item.display_image_url %}
+    <img class="item-img" src="{{ item.display_image_url }}" alt="{{ item.display_name }}" width="64" height="64" onerror="this.style.display='none';">
+  {% elif item.image_url %}
     <img class="item-img" src="{{ item.image_url }}" alt="{{ item.display_name }}" width="64" height="64" onerror="this.style.display='none';">
   {% else %}
     <div class="missing-icon"></div>

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -772,6 +772,18 @@ def test_australium_attribute_sets_flag():
     assert item["display_name"] == "Australium Rocket Launcher"
 
 
+def test_australium_image_override(monkeypatch):
+    data = {"items": [{"defindex": 111, "quality": 6, "is_australium": True}]}
+    ld.ITEMS_BY_DEFINDEX = {111: {"item_name": "Rocket Launcher", "image_url": ""}}
+    ld.QUALITIES_BY_INDEX = {6: "Unique"}
+    monkeypatch.setitem(
+        ip.AUSTRALIUM_IMAGE_URLS, "Rocket Launcher", "https://example.com/a.png"
+    )
+    items = ip.enrich_inventory(data)
+    item = items[0]
+    assert item["display_image_url"] == "https://example.com/a.png"
+
+
 def test_price_map_australium_lookup(patch_valuation):
     data = {"items": [{"defindex": 205, "quality": 6, "is_australium": True}]}
     ld.ITEMS_BY_DEFINDEX = {205: {"item_name": "Rocket Launcher", "image_url": ""}}

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -6,6 +6,7 @@ from .constants import (
     ORIGIN_MAP,
     KILLSTREAK_BADGE_ICONS,
     SPELL_MAP,
+    AUSTRALIUM_IMAGE_URLS,
 )
 from .local_data import FOOTPRINT_SPELL_MAP, PAINT_SPELL_MAP
 from .wear_helpers import _wear_tier, _decode_seed_info
@@ -17,6 +18,7 @@ __all__ = [
     "KILLSTREAK_TIERS",
     "KILLSTREAK_EFFECTS",
     "SPELL_MAP",
+    "AUSTRALIUM_IMAGE_URLS",
     "FOOTPRINT_SPELL_MAP",
     "PAINT_SPELL_MAP",
     "ORIGIN_MAP",

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -123,3 +123,26 @@ SPELL_MAP = {
     1008: {1: "Halloween Fire"},
     1009: {1: "Exorcism"},
 }
+
+# Map of standard weapon base name -> Australium variant image URL
+AUSTRALIUM_IMAGE_URLS = {
+    "Scattergun": "https://wiki.teamfortress.com/wiki/Special:FilePath/Australium_scattergun.png",
+    "Force-A-Nature": "https://wiki.teamfortress.com/wiki/Special:FilePath/Australium_Force-a-Nature.png",
+    "Rocket Launcher": "https://wiki.teamfortress.com/wiki/Special:FilePath/Australium_rocketlauncher.png",
+    "Black Box": "https://wiki.teamfortress.com/wiki/Special:FilePath/Australium_Black_Box.png",
+    "Flame Thrower": "https://wiki.teamfortress.com/wiki/Special:FilePath/Australium_Flame_Thrower.png",
+    "Axtinguisher": "https://wiki.teamfortress.com/wiki/Special:FilePath/Australium_Axtinguisher.png",
+    "Grenade Launcher": "https://wiki.teamfortress.com/wiki/Special:FilePath/Australium_grenadelauncher.png",
+    "Stickybomb Launcher": "https://wiki.teamfortress.com/wiki/Special:FilePath/Australium_stickybomblauncher.png",
+    "Eyelander": "https://wiki.teamfortress.com/wiki/Special:FilePath/Australium_Eyelander.png",
+    "Minigun": "https://wiki.teamfortress.com/wiki/Special:FilePath/Australium_minigun.png",
+    "Tomislav": "https://wiki.teamfortress.com/wiki/Special:FilePath/Australium_Tomislav.png",
+    "Frontier Justice": "https://wiki.teamfortress.com/wiki/Special:FilePath/Australium_Frontier_Justice.png",
+    "Wrench": "https://wiki.teamfortress.com/wiki/Special:FilePath/Australium_wrench.png",
+    "Blutsauger": "https://wiki.teamfortress.com/wiki/Special:FilePath/Australium_Blutsauger_RED.png",
+    "Medi Gun": "https://wiki.teamfortress.com/wiki/Special:FilePath/Australium_medigun_red.png",
+    "Sniper Rifle": "https://wiki.teamfortress.com/wiki/Special:FilePath/Australium_sniperrife.png",
+    "SMG": "https://wiki.teamfortress.com/wiki/Special:FilePath/Australium_SMG.png",
+    "Ambassador": "https://wiki.teamfortress.com/wiki/Special:FilePath/Australium_Ambassador_RED.png",
+    "Knife": "https://wiki.teamfortress.com/wiki/Special:FilePath/Australium_knife_red.png",
+}

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -18,6 +18,7 @@ from .constants import (
     KILLSTREAK_EFFECTS,
     KILLSTREAK_BADGE_ICONS,
     SPELL_MAP,
+    AUSTRALIUM_IMAGE_URLS,
 )
 
 
@@ -736,6 +737,7 @@ def _process_item(
 
     defindex = str(defindex_int)
     image_url = schema_entry.get("image_url", "")
+    display_image_url = image_url
 
     warpaintable = _is_warpaintable(schema_entry)
     warpaint_id = paintkit_name = None
@@ -760,6 +762,9 @@ def _process_item(
             flags=re.IGNORECASE,
         )
         display_base = f"Australium {clean_base}"
+        override = AUSTRALIUM_IMAGE_URLS.get(base_name)
+        if override:
+            display_image_url = override
 
     quality_id = asset.get("quality", 0)
     q_name = local_data.QUALITIES_BY_INDEX.get(quality_id)
@@ -856,6 +861,7 @@ def _process_item(
         "quality": q_name,
         "quality_color": q_col,
         "image_url": image_url,
+        "display_image_url": display_image_url,
         "item_type_name": schema_entry.get("item_type_name"),
         "item_name": schema_entry.get("name"),
         "craft_class": schema_entry.get("craft_class"),


### PR DESCRIPTION
## Summary
- provide direct links to Australium weapon variants
- expose these images via `AUSTRALIUM_IMAGE_URLS`
- prefer `display_image_url` for Australium items in item card template
- test new override logic

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files utils/constants.py utils/__init__.py utils/inventory_processor.py templates/item_card.html tests/test_inventory_processor.py`
- `pytest -q tests/test_inventory_processor.py::test_australium_image_override`

------
https://chatgpt.com/codex/tasks/task_e_686cd355e20c8326a27063771ab101cf