### PR TITLE
Fix paintkit extraction from decorated weapons

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -509,6 +509,53 @@ def test_warpaint_invalid_value(monkeypatch):
     assert item["warpaint_name"] is None
 
 
+def test_warpaint_value_preferred_over_float(monkeypatch):
+    data = {
+        "items": [
+            {
+                "defindex": 15141,
+                "quality": 15,
+                "attributes": [
+                    {"defindex": 834, "value": 350, "float_value": 1},
+                ],
+            }
+        ]
+    }
+    ld.ITEMS_BY_DEFINDEX = {
+        15141: {"item_name": "Flamethrower", "craft_class": "weapon"}
+    }
+    monkeypatch.setattr(ld, "PAINTKIT_NAMES", {"Warhawk": 350}, False)
+    monkeypatch.setattr(ld, "PAINTKIT_NAMES_BY_ID", {"350": "Warhawk"}, False)
+    ld.QUALITIES_BY_INDEX = {15: "Decorated Weapon"}
+    items = ip.enrich_inventory(data)
+    item = items[0]
+    assert item["warpaint_id"] == 350
+    assert item["warpaint_name"] == "Warhawk"
+
+
+def test_warpaint_index_749(monkeypatch):
+    data = {
+        "items": [
+            {
+                "defindex": 15141,
+                "quality": 15,
+                "attributes": [
+                    {"defindex": 749, "value": 350},
+                ],
+            }
+        ]
+    }
+    ld.ITEMS_BY_DEFINDEX = {
+        15141: {"item_name": "Flamethrower", "craft_class": "weapon"}
+    }
+    monkeypatch.setattr(ld, "PAINTKIT_NAMES_BY_ID", {"350": "Warhawk"}, False)
+    ld.QUALITIES_BY_INDEX = {15: "Decorated Weapon"}
+    items = ip.enrich_inventory(data)
+    item = items[0]
+    assert item["warpaint_id"] == 350
+    assert item["warpaint_name"] == "Warhawk"
+
+
 def test_unknown_defindex_preserves_warpaint(monkeypatch):
     data = {
         "items": [

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -52,7 +52,7 @@ CRATE_SERIES_CLASSES: set[str] = set()
 SPECIAL_SPELL_ATTRS: set[int] = set(SPELL_MAP.keys()) | set(range(8900, 8926))
 SPECIAL_KILLSTREAK_ATTRS: set[int] = {2013, 2014, 2025}
 SPECIAL_FESTIVIZER_ATTRS: set[int] = {2053}
-SPECIAL_PAINTKIT_ATTRS: set[int] = {834, 866, 867, 725}
+SPECIAL_PAINTKIT_ATTRS: set[int] = {834, 866, 867, 725, 749}
 
 
 def _refresh_attr_classes() -> None:
@@ -319,25 +319,19 @@ def _extract_paintkit(
     for attr in asset.get("attributes", []):
         idx = attr.get("defindex")
         attr_class = _get_attr_class(idx)
-        if idx in (214, 834) or attr_class in PAINTKIT_CLASSES:
-            raw = attr.get("float_value")
-            warpaint_id = None
-            if raw is not None:
-                try:
-                    warpaint_id = int(float(raw))
-                except (TypeError, ValueError):
-                    return None, None
-            if warpaint_id is None:
-                raw = attr.get("value")
-                try:
-                    warpaint_id = int(float(raw)) if raw is not None else None
-                except (TypeError, ValueError):
-                    return None, None
-
+        if idx in (834, 749) or attr_class in PAINTKIT_CLASSES:
+            raw = attr.get("value")
+            if raw is None:
+                raw = attr.get("float_value")
+            try:
+                warpaint_id = int(float(raw)) if raw is not None else None
+            except (TypeError, ValueError):
+                logger.warning("Invalid paintkit id: %r", raw)
+                continue
             if not warpaint_id:
-                return None, None
+                continue
 
-            if idx == 834 and attr_class not in PAINTKIT_CLASSES:
+            if idx in (834, 749) and attr_class not in PAINTKIT_CLASSES:
                 logger.warning("Using numeric fallback for paintkit index %s", idx)
 
             name = local_data.PAINTKIT_NAMES_BY_ID.get(str(warpaint_id))


### PR DESCRIPTION
## Summary
- treat attribute defindex 749 as paintkit id source
- prefer attribute `value` over `float_value` for paintkit ids
- mark defindex 749 as special so decorated weapons aren't filtered
- test paintkit value parsing and new index support

## Testing
- `pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d1028f6a08326b8c73ce2a3229a43