### PR TITLE
Handle warpaint ID 0

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -469,24 +469,26 @@ def test_no_warpaint_attribute(monkeypatch):
     assert item["name"] == "Decorated Weapon Flamethrower"
 
 
-def test_warpaint_zero_ignored(monkeypatch):
+def test_warpaint_zero_resolves(monkeypatch):
     data = {
         "items": [
             {
                 "defindex": 15141,
                 "quality": 15,
-                "attributes": [{"defindex": 834, "float_value": 0}],
+                "attributes": [{"defindex": 834, "value": 0}],
             }
         ]
     }
     ld.ITEMS_BY_DEFINDEX = {
         15141: {"item_name": "Flamethrower", "craft_class": "weapon"}
     }
+    monkeypatch.setattr(ld, "PAINTKIT_NAMES", {"Red Rock Roscoe": 0}, False)
+    monkeypatch.setattr(ld, "PAINTKIT_NAMES_BY_ID", {"0": "Red Rock Roscoe"}, False)
     ld.QUALITIES_BY_INDEX = {15: "Decorated Weapon"}
     items = ip.enrich_inventory(data)
     item = items[0]
-    assert item["warpaint_id"] is None
-    assert item["warpaint_name"] is None
+    assert item["warpaint_id"] == 0
+    assert item["warpaint_name"] == "Red Rock Roscoe"
 
 
 def test_warpaint_invalid_value(monkeypatch):

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -328,7 +328,7 @@ def _extract_paintkit(
             except (TypeError, ValueError):
                 logger.warning("Invalid paintkit id: %r", raw)
                 continue
-            if not warpaint_id:
+            if warpaint_id is None:
                 continue
 
             if idx in (834, 749) and attr_class not in PAINTKIT_CLASSES:


### PR DESCRIPTION
## Summary
- fix `_extract_paintkit` so that warpaint ID 0 is treated as valid
- add regression test for warpaint attribute with value `0`

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py`
- `pytest tests/test_inventory_processor.py::test_warpaint_zero_resolves -q`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686d16b0e4a48326b7edbc8619cc0a4a