### PR TITLE
Improve paintkit name extraction

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -629,6 +629,35 @@ def test_warpaint_resolved_from_schema_name(monkeypatch):
     assert item["name"] == "Decorated Weapon Sniper Rifle (Airwolf)"
 
 
+def test_warpaint_resolved_from_schema_name_mk_ii(monkeypatch):
+    data = {
+        "items": [
+            {
+                "defindex": 15155,
+                "quality": 15,
+                "attributes": [],
+            }
+        ]
+    }
+    ld.ITEMS_BY_DEFINDEX = {
+        15155: {
+            "name": "warbird_shotgun_carpet_bomber_mk_ii",
+            "item_name": "Boomstick",
+            "craft_class": "weapon",
+        }
+    }
+    monkeypatch.setattr(ld, "PAINTKIT_NAMES", {"Carpet Bomber Mk.II": 104}, False)
+    monkeypatch.setattr(
+        ld, "PAINTKIT_NAMES_BY_ID", {"104": "Carpet Bomber Mk.II"}, False
+    )
+    ld.QUALITIES_BY_INDEX = {15: "Decorated Weapon"}
+    items = ip.enrich_inventory(data)
+    item = items[0]
+    assert item["warpaint_id"] == 104
+    assert item["warpaint_name"] == "Carpet Bomber Mk.II"
+    assert item["name"] == "Decorated Weapon Boomstick (Carpet Bomber Mk.II)"
+
+
 def test_kill_eater_fields(monkeypatch):
     data = {
         "items": [


### PR DESCRIPTION
## Summary
- add `_slug_to_paintkit_name` helper to handle schema suffixes
- support fuzzy lookup of paintkit names when exact match fails
- test Mk.II paintkit resolution from schema name

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py`

------
https://chatgpt.com/codex/tasks/task_e_686d1cbd2f448326a56b9e1443b62226