### PR TITLE
Improve paintkit name resolution with fuzzy matching

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,11 @@
+from utils.helpers import best_match_from_keys
+
+
+def test_best_match_success():
+    keys = ["Warhawk", "Airwolf", "Carpet Bomber"]
+    assert best_match_from_keys("Carpet Bomb", keys) == "Carpet Bomber"
+
+
+def test_best_match_none():
+    keys = ["Warhawk", "Airwolf"]
+    assert best_match_from_keys("Totally Different", keys) is None

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -658,6 +658,31 @@ def test_warpaint_resolved_from_schema_name_mk_ii(monkeypatch):
     assert item["name"] == "Decorated Weapon Boomstick (Carpet Bomber Mk.II)"
 
 
+def test_warpaint_resolved_with_best_match(monkeypatch):
+    data = {
+        "items": [
+            {
+                "defindex": 15156,
+                "quality": 15,
+                "attributes": [],
+            }
+        ]
+    }
+    ld.ITEMS_BY_DEFINDEX = {
+        15156: {
+            "name": "warbird_flamethrower_warhak",
+            "item_name": "Flamethrower",
+            "craft_class": "weapon",
+        }
+    }
+    monkeypatch.setattr(ld, "PAINTKIT_NAMES", {"Warhawk": 350}, False)
+    ld.QUALITIES_BY_INDEX = {15: "Decorated Weapon"}
+    items = ip.enrich_inventory(data)
+    item = items[0]
+    assert item["warpaint_id"] == 350
+    assert item["warpaint_name"] == "Warhawk"
+
+
 def test_kill_eater_fields(monkeypatch):
     data = {
         "items": [

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -10,6 +10,7 @@ from .constants import (
 from .local_data import FOOTPRINT_SPELL_MAP, PAINT_SPELL_MAP
 from .wear_helpers import _wear_tier, _decode_seed_info
 from .valuation_service import ValuationService, get_valuation_service
+from .helpers import best_match_from_keys
 
 __all__ = [
     "PAINT_COLORS",
@@ -25,4 +26,5 @@ __all__ = [
     "get_valuation_service",
     "_wear_tier",
     "_decode_seed_info",
+    "best_match_from_keys",
 ]

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -1,0 +1,21 @@
+import difflib
+from typing import Iterable, Optional
+
+
+def best_match_from_keys(query: str, keys: Iterable[str]) -> Optional[str]:
+    """Return the closest match to ``query`` from ``keys`` using :func:`difflib.get_close_matches`.
+
+    Parameters
+    ----------
+    query:
+        The search string to compare.
+    keys:
+        Collection of possible target strings.
+
+    Returns
+    -------
+    Optional[str]
+        The closest matching key or ``None`` if no match exceeds the cutoff.
+    """
+    matches = difflib.get_close_matches(query, list(keys), n=1, cutoff=0.6)
+    return matches[0] if matches else None

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -1,13 +1,13 @@
 from typing import Any, Dict, List, Tuple
 import logging
 import re
-import difflib
 from html import unescape
 
 import json
 from pathlib import Path
 
 from . import steam_api_client, local_data
+from .helpers import best_match_from_keys
 from .valuation_service import ValuationService, get_valuation_service
 from .wear_helpers import _wear_tier, _decode_seed_info
 from .constants import (
@@ -365,14 +365,10 @@ def _extract_paintkit(
                 warpaint_name = _slug_to_paintkit_name(paint_slug)
                 warpaint_id = local_data.PAINTKIT_NAMES.get(warpaint_name)
                 if warpaint_id is None:
-                    matches = difflib.get_close_matches(
-                        warpaint_name,
-                        list(local_data.PAINTKIT_NAMES.keys()),
-                        n=1,
-                        cutoff=0.6,
+                    match = best_match_from_keys(
+                        warpaint_name, local_data.PAINTKIT_NAMES.keys()
                     )
-                    if matches:
-                        match = matches[0]
+                    if match:
                         warpaint_id = local_data.PAINTKIT_NAMES.get(match)
                         warpaint_name = match
                 if warpaint_id is not None:


### PR DESCRIPTION
## Summary
- add `best_match_from_keys` utility for fuzzy dictionary lookups
- expose helper via `utils.__init__`
- use helper when resolving paintkit names from schema
- test helper and fuzzy paintkit resolution

## Testing
- `ruff check tests/test_helpers.py utils/helpers.py utils/__init__.py utils/inventory_processor.py tests/test_inventory_processor.py`
- `pytest -k "test_helpers or warpaint_resolved_with_best_match" -q`
- `SKIP_VALIDATE=1 pre-commit run --files utils/helpers.py utils/__init__.py utils/inventory_processor.py tests/test_helpers.py tests/test_inventory_processor.py`

------
https://chatgpt.com/codex/tasks/task_e_686d1f36c94c8326baeca4526dcc8704