### PR TITLE
Add resolved name fields for skins

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -541,6 +541,32 @@ def test_warpaint_value_preferred_over_float(monkeypatch):
     assert item["resolved_name"] == "Warhawk Flamethrower"
 
 
+def test_warpaint_tool_resolved(monkeypatch):
+    data = {
+        "items": [
+            {
+                "defindex": 9536,
+                "quality": 15,
+                "attributes": [{"defindex": 834, "value": 350}],
+            }
+        ]
+    }
+    ld.ITEMS_BY_DEFINDEX = {
+        9536: {
+            "item_name": "War Paint",
+            "item_class": "tool",
+            "tool": {"type": "paintkit"},
+        }
+    }
+    monkeypatch.setattr(ld, "PAINTKIT_NAMES_BY_ID", {"350": "Warhawk"}, False)
+    ld.QUALITIES_BY_INDEX = {15: "Decorated Weapon"}
+    items = ip.enrich_inventory(data)
+    item = items[0]
+    assert item["resolved_name"] == "Warhawk War Paint"
+    assert item["base_weapon"] is None
+    assert item["skin_name"] is None
+
+
 def test_warpaint_index_749(monkeypatch):
     data = {
         "items": [

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -786,7 +786,6 @@ def _process_item(
     resolved_name = base_name
 
     if warpaint_tool and warpaint_id is not None:
-        skin_name = paintkit_name
         resolved_name = f"{paintkit_name} War Paint"
     elif warpaintable and warpaint_id is not None:
         skin_name = paintkit_name
@@ -924,7 +923,7 @@ def _process_item(
         "wear_name": wear_name,
         "pattern_seed": pattern_seed,
         "skin_name": skin_name,
-        "base_weapon": base_weapon if skin_name else None,
+        "base_weapon": None if warpaint_tool else base_weapon if skin_name else None,
         "resolved_name": resolved_name,
         "warpaint_id": (
             warpaint_id if warpaintable and warpaint_id is not None else None


### PR DESCRIPTION
## Summary
- expose `skin_name`, `base_weapon` and `resolved_name` in `_process_item`
- handle War Paint tools by setting `resolved_name` but leaving `base_weapon` unset
- test War Paint tool naming logic

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d28dee228832699b17074966cf134