### PR TITLE
Handle wear attribute 749

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -1066,3 +1066,10 @@ def test_skin_detection(monkeypatch):
     assert item["paintkit_name"] == "Warhawk"
     assert item["wear_name"] == "Factory New"
     assert item["resolved_name"] == "Warhawk Flamethrower"
+
+
+def test_extract_wear_attr_749(monkeypatch):
+    ld.SCHEMA_ATTRIBUTES = {749: {"attribute_class": "texture_wear_default"}}
+    asset = {"attributes": [{"defindex": 749, "float_value": 0.04}]}
+    wear = ip._extract_wear(asset)
+    assert wear == "Factory New"

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -77,7 +77,7 @@ def _refresh_attr_classes() -> None:
     KILLSTREAK_SHEEN_CLASSES = {cls(2014)} - {None}
     KILLSTREAK_EFFECT_CLASSES = {cls(2013)} - {None}
     PAINT_CLASSES = {cls(142), cls(261)} - {None}
-    WEAR_CLASSES = {cls(725)} - {None}
+    WEAR_CLASSES = {cls(725), cls(749)} - {None}
     PATTERN_SEED_LO_CLASSES = {cls(866)} - {None}
     PATTERN_SEED_HI_CLASSES = {cls(867)} - {None}
     PAINTKIT_CLASSES = {cls(834)} - {None}


### PR DESCRIPTION
## Summary
- include attribute 749 in wear class refresh
- add direct test for wear extraction from attribute 749

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py`

------
https://chatgpt.com/codex/tasks/task_e_686d3ab076488326ae3e315a5e771f3e