### PR TITLE
Add war paint tool target weapon badge

### DIFF
--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -57,4 +57,7 @@
       <div class="badge warpaint-badge">Warpaint: {{ item.warpaint_name }}</div>
     {% endif %}
   {% endif %}
+  {% if item.is_war_paint_tool and item.target_weapon_name %}
+    <div class="badge target-weapon-badge">For: {{ item.target_weapon_name }}</div>
+  {% endif %}
 </div>

--- a/tests/test_user_template.py
+++ b/tests/test_user_template.py
@@ -140,3 +140,27 @@ def test_unusual_effect_rendered(app):
     text = title.text.strip()
     assert text.startswith("Strange Burning Flames Cap")
     assert "Unusual" not in text
+
+
+def test_war_paint_tool_target_displayed(app):
+    context = {
+        "user": {
+            "items": [
+                {
+                    "name": "War Paint",
+                    "display_name": "War Paint: Warhawk (Field-Tested)",
+                    "image_url": "",
+                    "badges": [],
+                    "warpaint_name": "Warhawk",
+                    "target_weapon_name": "Rocket Launcher",
+                    "is_war_paint_tool": True,
+                    "quality_color": "#fff",
+                }
+            ]
+        }
+    }
+    with app.test_request_context():
+        app_module = importlib.import_module("app")
+        context["user"] = app_module.normalize_user_payload(context["user"])
+        html = render_template_string(HTML, **context)
+    assert "Rocket Launcher" in html


### PR DESCRIPTION
## Summary
- show the target weapon name for war paint tools in item cards
- test that the item template renders the target weapon name

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files templates/item_card.html tests/test_user_template.py`

------
https://chatgpt.com/codex/tasks/task_e_686d3cbc9f648326b1ce8e401487ddd1