### PR TITLE
Remove custom name branch from item card

### DIFF
--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -31,25 +31,21 @@
       {% set _ = title_parts.append('Killstreak') %}
     {% endif %}
   {% endif %}
-  {% if item.custom_name %}
-    <h2 class="item-title">{{ item.custom_name }}</h2>
-  {% else %}
-    {% set quality = item.quality %}
-    {% if item.strange or quality == 'Strange' %}
-      {% set _ = title_parts.append('Strange') %}
-    {% elif quality and quality not in ('Unique', 'Normal') %}
-      {% if not (quality == 'Unusual' and item.unusual_effect_id) %}
-        {% set _ = title_parts.append(quality) %}
-      {% endif %}
+  {% set quality = item.quality %}
+  {% if item.strange or quality == 'Strange' %}
+    {% set _ = title_parts.append('Strange') %}
+  {% elif quality and quality not in ('Unique', 'Normal') %}
+    {% if not (quality == 'Unusual' and item.unusual_effect_id) %}
+      {% set _ = title_parts.append(quality) %}
     {% endif %}
-    {% if item.unusual_effect_id %}
-      {% set base = item.display_name %}
-    {% else %}
-      {% set base = item.composite_name or item.base_name or item.display_name or item.name %}
-    {% endif %}
-    {% set _ = title_parts.append(base) %}
-    <h2 class="item-title">{{ title_parts | join(' ') }}</h2>
   {% endif %}
+  {% if item.unusual_effect_id %}
+    {% set base = item.display_name %}
+  {% else %}
+    {% set base = item.composite_name or item.base_name or item.display_name or item.name %}
+  {% endif %}
+  {% set _ = title_parts.append(base) %}
+  <h2 class="item-title">{{ title_parts | join(' ') }}</h2>
   {% if item.warpaint_name %}
     {% if item.base_weapon %}
       <div class="badge warpaint-badge">Paintkit: {{ item.warpaint_name }}</div>


### PR DESCRIPTION
## Summary
- remove `{% if item.custom_name %}` block from item card template
- always build title using `title_parts`

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files templates/item_card.html`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d429edd788326a7c0d3816a52bb2b