### PR TITLE
Add modal custom name support

### DIFF
--- a/static/modal.js
+++ b/static/modal.js
@@ -143,8 +143,10 @@
 
   function updateHeader(data) {
     const title = document.getElementById('modal-title');
+    const custom = document.getElementById('modal-custom-name');
     const effectBox = document.getElementById('modal-effect');
-    if (title) title.textContent = data.custom_name || data.composite_name || data.name || '';
+    if (title) title.textContent = data.composite_name || data.name || '';
+    if (custom) custom.textContent = data.custom_name || '';
     let effectText = '';
     if (data.unusual_effect) {
       effectText = typeof data.unusual_effect === 'object'

--- a/static/style.css
+++ b/static/style.css
@@ -582,3 +582,9 @@ footer {
     z-index: 0;
     pointer-events: none;
 }
+
+#modal-custom-name {
+    font-size: 0.9rem;
+    color: #ccc;
+    margin-top: 2px;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -122,6 +122,7 @@
       <div class="modal-header">
         <div id="modal-effect" class="modal-effect"></div>
         <h3 id="modal-title"></h3>
+        <div id="modal-custom-name"></div>
         <div id="modal-badges" class="item-badges"></div>
       </div>
       <div class="modal-body">


### PR DESCRIPTION
## Summary
- include element for custom item names in modal
- show item's custom name under the main title
- style custom name

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files static/modal.js templates/index.html static/style.css tests/test_modal.js`

------
https://chatgpt.com/codex/tasks/task_e_686d47e7753c8326a34ad118682a1e3f