### PR TITLE
Remove warpaint text label from item cards

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -371,9 +371,9 @@ button {
 .warpaint-badge {
   background: #282828;
   color: #f4d03f;
-  padding: 2px 6px;
+  padding: 2px 4px;
   border-radius: 4px;
-  font-size: 11px;
+  font-size: 14px;
   margin-top: 4px;
   display: inline-block;
 }

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -47,10 +47,9 @@
   {% set _ = title_parts.append(base) %}
   <h2 class="item-title">{{ title_parts | join(' ') }}</h2>
   {% if item.warpaint_name %}
-    {% if item.base_weapon %}
-      <div class="badge warpaint-badge">Paintkit: {{ item.warpaint_name }}</div>
-    {% else %}
-      <div class="badge warpaint-badge">Warpaint: {{ item.warpaint_name }}</div>
+    {% set wp_badge = item.badges | selectattr('type', 'equalto', 'warpaint') | first %}
+    {% if wp_badge %}
+      <div class="badge warpaint-badge" title="{{ item.warpaint_name }}">{{ wp_badge.icon }}</div>
     {% endif %}
   {% endif %}
   {% if item.is_war_paint_tool and item.target_weapon_name %}


### PR DESCRIPTION
## Summary
- show a simple icon-only warpaint badge
- tweak `.warpaint-badge` styles

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files templates/item_card.html static/style.css`

------
https://chatgpt.com/codex/tasks/task_e_686d49477460832690dfd218e4775384