### PR TITLE
Display warpaint names in item cards

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -368,15 +368,7 @@ button {
   word-wrap: break-word;
 }
 
-.warpaint-badge {
-  background: #282828;
-  color: #f4d03f;
-  padding: 2px 4px;
-  border-radius: 4px;
-  font-size: 14px;
-  margin-top: 4px;
-  display: inline-block;
-}
+
 
 /* ───── Paint colour dot (used in card & modal) ───────────────────── */
 .paint-dot {

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -39,20 +39,17 @@
       {% set _ = title_parts.append(quality) %}
     {% endif %}
   {% endif %}
-  {% if item.unusual_effect_id %}
+  {% if item.is_war_paint_tool %}
+    {% if item.target_weapon_name %}
+      {% set base = (item.warpaint_name ~ ' ' ~ item.target_weapon_name) %}
+    {% else %}
+      {% set base = item.warpaint_name or item.display_name %}
+    {% endif %}
+  {% elif item.unusual_effect_id %}
     {% set base = item.display_name %}
   {% else %}
     {% set base = item.composite_name or item.base_name or item.display_name or item.name %}
   {% endif %}
   {% set _ = title_parts.append(base) %}
   <h2 class="item-title">{{ title_parts | join(' ') }}</h2>
-  {% if item.warpaint_name %}
-    {% set wp_badge = item.badges | selectattr('type', 'equalto', 'warpaint') | first %}
-    {% if wp_badge %}
-      <div class="badge warpaint-badge" title="{{ item.warpaint_name }}">{{ wp_badge.icon }}</div>
-    {% endif %}
-  {% endif %}
-  {% if item.is_war_paint_tool and item.target_weapon_name %}
-    <div class="badge target-weapon-badge">For: {{ item.target_weapon_name }}</div>
-  {% endif %}
 </div>


### PR DESCRIPTION
## Summary
- remove warpaint badge styling
- show warpaint names directly in item card titles

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files templates/item_card.html static/style.css`

------
https://chatgpt.com/codex/tasks/task_e_686d4c48ed008326be941aeb9cf7b155