### PR TITLE
Omit Decorated Weapon label

### DIFF
--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -34,7 +34,7 @@
   {% set quality = item.quality %}
   {% if item.strange or quality == 'Strange' %}
     {% set _ = title_parts.append('Strange') %}
-  {% elif quality and quality not in ('Unique', 'Normal') %}
+  {% elif quality and quality not in ('Unique', 'Normal', 'Decorated Weapon') %}
     {% if not (quality == 'Unusual' and item.unusual_effect_id) %}
       {% set _ = title_parts.append(quality) %}
     {% endif %}

--- a/tests/test_user_template.py
+++ b/tests/test_user_template.py
@@ -164,3 +164,28 @@ def test_war_paint_tool_target_displayed(app):
         context["user"] = app_module.normalize_user_payload(context["user"])
         html = render_template_string(HTML, **context)
     assert "Rocket Launcher" in html
+
+
+def test_decorated_quality_not_shown(app):
+    context = {
+        "user": {
+            "items": [
+                {
+                    "name": "Decorated Weapon Flamethrower",
+                    "composite_name": "Warhawk Flamethrower",
+                    "display_name": "Warhawk Flamethrower",
+                    "image_url": "",
+                    "quality": "Decorated Weapon",
+                    "quality_color": "#fff",
+                }
+            ]
+        }
+    }
+    with app.test_request_context():
+        app_module = importlib.import_module("app")
+        context["user"] = app_module.normalize_user_payload(context["user"])
+        html = render_template_string(HTML, **context)
+    soup = BeautifulSoup(html, "html.parser")
+    title = soup.find("h2", class_="item-title")
+    assert title is not None
+    assert title.text.strip() == "Warhawk Flamethrower"


### PR DESCRIPTION
## Summary
- skip 'Decorated Weapon' quality when building item titles
- verify war paint titles omit quality text

## Testing
- `pre-commit run --files templates/item_card.html tests/test_user_template.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d4e5bc8208326b3b39059a6f48364