### PR TITLE
Add killstreak sheen colors

### DIFF
--- a/app.py
+++ b/app.py
@@ -265,6 +265,7 @@ def api_constants():
         {
             "paint_colors": consts.PAINT_COLORS,
             "sheen_names": consts.SHEEN_NAMES,
+            "killstreak_sheen_colors": consts.KILLSTREAK_SHEEN_COLORS,
             "killstreak_tiers": consts.KILLSTREAK_TIERS,
             "killstreak_effects": consts.KILLSTREAK_EFFECTS,
             "origin_map": consts.ORIGIN_MAP,

--- a/tests/test_constants_api.py
+++ b/tests/test_constants_api.py
@@ -8,5 +8,9 @@ def test_api_constants_route(app):
     data = resp.get_json()
     assert data["paint_colors"]["3100495"][0] == "A Color Similar to Slate"
     assert data["sheen_names"]["1"] == constants.SHEEN_NAMES[1]
+    assert (
+        data["killstreak_sheen_colors"]["2"][0]
+        == constants.KILLSTREAK_SHEEN_COLORS[2][0]
+    )
     assert data["killstreak_tiers"]["3"] == constants.KILLSTREAK_TIERS[3]
     assert data["origin_map"]["0"] == constants.ORIGIN_MAP[0]

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -5,6 +5,7 @@ from .constants import (
     KILLSTREAK_EFFECTS,
     ORIGIN_MAP,
     KILLSTREAK_BADGE_ICONS,
+    KILLSTREAK_SHEEN_COLORS,
     SPELL_MAP,
 )
 from .local_data import FOOTPRINT_SPELL_MAP, PAINT_SPELL_MAP
@@ -22,6 +23,7 @@ __all__ = [
     "PAINT_SPELL_MAP",
     "ORIGIN_MAP",
     "KILLSTREAK_BADGE_ICONS",
+    "KILLSTREAK_SHEEN_COLORS",
     "ValuationService",
     "get_valuation_service",
     "_wear_tier",

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -32,6 +32,17 @@ SHEEN_NAMES = {
     7: "Hot Rod",
 }
 
+# Map of sheen id -> (name, hex color)
+KILLSTREAK_SHEEN_COLORS = {
+    1: ("Team Shine", "#B2B2B2"),
+    2: ("Deadly Daffodil", "#FFF428"),
+    3: ("Manndarin", "#FF8D1F"),
+    4: ("Mean Green", "#7FFF4F"),
+    5: ("Agonizing Emerald", "#70B04A"),
+    6: ("Villainous Violet", "#8847FF"),
+    7: ("Hot Rod", "#AA0000"),
+}
+
 # Map of item origin id -> human readable string
 ORIGIN_MAP = {
     0: "Timed Drop",


### PR DESCRIPTION
## Summary
- add `KILLSTREAK_SHEEN_COLORS` mapping
- expose new constant via `/api/constants`
- allow importing the mapping from `utils`
- test for new API response field

## Testing
- `pre-commit run --files utils/constants.py utils/__init__.py app.py tests/test_constants_api.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d6fa2e12c832697c0aac1a5485006