### PR TITLE
Add sheen color to killstreak items

### DIFF
--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -1,6 +1,7 @@
 import pytest
 from utils import inventory_processor as ip
 from utils import local_data as ld
+from utils.constants import KILLSTREAK_SHEEN_COLORS
 
 
 @pytest.fixture(autouse=True)
@@ -65,6 +66,8 @@ def test_enrichment_full_attributes(monkeypatch):
     assert item["killstreak_tier"] == 3
     assert item["killstreak_name"] == "Professional"
     assert item["sheen"] == "Manndarin"
+    assert item["sheen_name"] == "Manndarin"
+    assert item["sheen_color"] == KILLSTREAK_SHEEN_COLORS[3][1]
     assert item["killstreak_effect"] == "Cerebral Discharge"
     assert item["wear_name"] == "Field-Tested"
     assert item["strange_count"] == 10


### PR DESCRIPTION
## Summary
- expose killstreak sheen color in inventory processor
- colour killstreak badge using sheen colour
- test sheen_color field for professional killstreak items

## Testing
- `pre-commit run --files utils/inventory_processor.py tests/test_enrichment.py`
- `STEAM_API_KEY=test pytest tests/test_enrichment.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686d726619248326abaf195e5df6c51f