### PR TITLE
Add killstreak badge color in item modal

### DIFF
--- a/static/modal.js
+++ b/static/modal.js
@@ -67,14 +67,21 @@
 
     if (data.killstreak_tier) {
       const tierMap = { 1: 'Killstreak', 2: 'Specialized', 3: 'Professional' };
-      const ksParts = [];
-      ksParts.push(tierMap[data.killstreak_tier] || data.killstreak_tier);
-      if (data.sheen) ksParts.push(esc(data.sheen));
-      let ksHtml = 'Killstreak: ' + ksParts.join(', ');
+      const tierName = tierMap[data.killstreak_tier] || data.killstreak_tier;
+      const color = data.sheen_color || '#f97316';
+      let ksHtml =
+        '<div><span class="badge ks-tier" style="background:' +
+        esc(color) + ';">' +
+        esc(tierName) +
+        '</span>';
+      if (data.sheen) {
+        ksHtml += ' ' + esc(data.sheen);
+      }
       if (data.killstreak_effect) {
         ksHtml += ', <span class="ks-effect">' + esc(data.killstreak_effect) + '</span>';
       }
-      attrs.push('<div>' + ksHtml + '</div>');
+      ksHtml += '</div>';
+      attrs.push(ksHtml);
     }
 
     if (data.unusual_effect) {

--- a/templates/_modal.html
+++ b/templates/_modal.html
@@ -1,4 +1,10 @@
 <div class="modal-content">
+  {% if item.killstreak_name %}
+    <span class="badge killstreak-badge"
+          style="background-color: {{ item.sheen_color or '#f97316' }};">
+      {{ item.killstreak_name }}
+    </span>
+  {% endif %}
   {% if item.unusual_effect_name %}
     <p><strong>Unusual Effect:</strong>
       <span class="unusual-effect">{{ item.unusual_effect_name }}</span>

--- a/tests/test_item_modal_template.py
+++ b/tests/test_item_modal_template.py
@@ -1,0 +1,36 @@
+import importlib
+from pathlib import Path
+
+import pytest
+from flask import render_template
+from bs4 import BeautifulSoup
+
+
+@pytest.fixture
+def app(monkeypatch):
+    monkeypatch.setenv("STEAM_API_KEY", "x")
+    monkeypatch.setenv("BPTF_API_KEY", "x")
+    monkeypatch.setattr("utils.local_data.load_files", lambda *a, **k: ({}, {}))
+    monkeypatch.setattr(
+        "utils.price_loader.ensure_prices_cached",
+        lambda refresh=False: Path("prices.json"),
+    )
+    monkeypatch.setattr(
+        "utils.price_loader.ensure_currencies_cached",
+        lambda refresh=False: Path("currencies.json"),
+    )
+    monkeypatch.setattr("utils.price_loader.build_price_map", lambda path: {})
+    mod = importlib.import_module("app")
+    importlib.reload(mod)
+    return mod.app
+
+
+def test_killstreak_badge_color(app):
+    item = {"killstreak_name": "Professional Killstreak", "sheen_color": "#8847ff"}
+    with app.app_context():
+        html = render_template("_modal.html", item=item)
+    soup = BeautifulSoup(html, "html.parser")
+    badge = soup.find("span", class_="killstreak-badge")
+    assert badge is not None
+    assert badge.text.strip() == "Professional Killstreak"
+    assert "#8847ff" in badge.get("style", "")


### PR DESCRIPTION
## Summary
- show killstreak tier in `_modal.html`
- render badge using sheen color in `modal.js`
- add a regression test for the modal template

## Testing
- `pre-commit run --files templates/_modal.html static/modal.js tests/test_item_modal_template.py`

------
https://chatgpt.com/codex/tasks/task_e_686d740558548326b264cc0f51a0a8cf