### PR TITLE
Silence invalid killstreak attribute warning

### DIFF
--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -215,7 +215,7 @@ def _extract_killstreak(
         try:
             val = int(float(val_raw)) if val_raw is not None else None
         except (TypeError, ValueError):
-            logger.warning("Invalid killstreak attribute value: %r", val_raw)
+            logger.debug("Invalid killstreak attribute value: %r", val_raw)
             continue
         attr_class = _get_attr_class(idx)
         if attr_class in KILLSTREAK_TIER_CLASSES:


### PR DESCRIPTION
## Summary
- downgrade noisy logging in `_extract_killstreak`

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -o addopts='' -p no:cov -q` *(fails: 22 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686d996f602c8326a7a66a2258ee635a