### PR TITLE
Add wear tier helper

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -639,6 +639,26 @@ def test_warpaint_index_749(monkeypatch):
     assert item["warpaint_name"] == "Warhawk"
 
 
+def test_warpaint_tool_info_wear_name_lookup(monkeypatch):
+    asset = {
+        "attributes": [
+            {"defindex": 134, "value": 350},
+            {"defindex": 725, "float_value": 0.4},
+            {"defindex": 2014, "value": 42},
+        ]
+    }
+    monkeypatch.setattr(ld, "PAINTKIT_NAMES_BY_ID", {"350": "Warhawk"}, False)
+    ld.ITEMS_BY_DEFINDEX = {42: {"item_name": "Pistol"}}
+    monkeypatch.setattr(
+        ld,
+        "WEAR_NAMES",
+        {"0": "FN", "1": "MW", "2": "FT", "3": "WW", "4": "BS"},
+        False,
+    )
+    result = ip._extract_warpaint_tool_info(asset)
+    assert result == (350, "Warhawk", "WW", 42, "Pistol")
+
+
 def test_unknown_defindex_preserves_warpaint(monkeypatch):
     data = {
         "items": [
@@ -1099,3 +1119,16 @@ def test_extract_wear_attr_749(monkeypatch):
     asset = {"attributes": [{"defindex": 749, "float_value": 0.04}]}
     wear = ip._extract_wear(asset)
     assert wear == "Factory New"
+
+
+def test_extract_wear_uses_local_mapping(monkeypatch):
+    ld.SCHEMA_ATTRIBUTES = {749: {"attribute_class": "texture_wear_default"}}
+    monkeypatch.setattr(
+        ld,
+        "WEAR_NAMES",
+        {"0": "FN", "1": "MW", "2": "FT", "3": "WW", "4": "BS"},
+        False,
+    )
+    asset = {"attributes": [{"defindex": 749, "float_value": 0.2}]}
+    wear = ip._extract_wear(asset)
+    assert wear == "FT"

--- a/tests/test_wear_helpers.py
+++ b/tests/test_wear_helpers.py
@@ -1,7 +1,7 @@
 import struct
 import pytest
 
-from utils.wear_helpers import _wear_tier, _decode_seed_info
+from utils.wear_helpers import _wear_tier, _decode_seed_info, wear_tier_from_float
 from utils import local_data
 
 
@@ -59,3 +59,11 @@ def test_decode_seed_info_attr_classes(monkeypatch):
     wear, seed = _decode_seed_info(attrs)
     assert wear == pytest.approx(wear_val)
     assert seed == 789
+
+
+def test_wear_tier_from_float():
+    assert wear_tier_from_float(0.0) == 0
+    assert wear_tier_from_float(0.1) == 1
+    assert wear_tier_from_float(0.2) == 2
+    assert wear_tier_from_float(0.4) == 3
+    assert wear_tier_from_float(0.9) == 4

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -9,7 +9,7 @@ from .constants import (
     SPELL_MAP,
 )
 from .local_data import FOOTPRINT_SPELL_MAP, PAINT_SPELL_MAP
-from .wear_helpers import _wear_tier, _decode_seed_info
+from .wear_helpers import _wear_tier, _decode_seed_info, wear_tier_from_float
 from .valuation_service import ValuationService, get_valuation_service
 from .helpers import best_match_from_keys
 
@@ -28,5 +28,6 @@ __all__ = [
     "get_valuation_service",
     "_wear_tier",
     "_decode_seed_info",
+    "wear_tier_from_float",
     "best_match_from_keys",
 ]

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from . import steam_api_client, local_data
 from .helpers import best_match_from_keys
 from .valuation_service import ValuationService, get_valuation_service
-from .wear_helpers import _wear_tier, _decode_seed_info
+from .wear_helpers import _wear_tier, _decode_seed_info, wear_tier_from_float
 from .constants import (
     KILLSTREAK_TIERS,
     KILLSTREAK_LABELS,
@@ -299,7 +299,8 @@ def _extract_wear(asset: Dict[str, Any]) -> str | None:
                 continue
             if not 0 <= val <= 1:
                 logger.warning("Wear value out of range: %s", val)
-            name = local_data.WEAR_NAMES.get(str(int(val)))
+            tier = wear_tier_from_float(val)
+            name = local_data.WEAR_NAMES.get(str(tier))
             return name or _wear_tier(val)
         elif idx in (725, 749):
             logger.warning("Using numeric fallback for wear index %s", idx)
@@ -313,12 +314,14 @@ def _extract_wear(asset: Dict[str, Any]) -> str | None:
                 continue
             if not 0 <= val <= 1:
                 logger.warning("Wear value out of range: %s", val)
-            name = local_data.WEAR_NAMES.get(str(int(val)))
+            tier = wear_tier_from_float(val)
+            name = local_data.WEAR_NAMES.get(str(tier))
             return name or _wear_tier(val)
 
     wear_float, _ = _decode_seed_info(asset.get("attributes", []))
     if wear_float is not None:
-        name = local_data.WEAR_NAMES.get(str(int(wear_float)))
+        tier = wear_tier_from_float(wear_float)
+        name = local_data.WEAR_NAMES.get(str(tier))
         return name or _wear_tier(wear_float)
 
     return None
@@ -771,7 +774,8 @@ def _extract_warpaint_tool_info(
             except (TypeError, ValueError):
                 continue
             if 0 <= val <= 1:
-                name = local_data.WEAR_NAMES.get(str(int(val)))
+                tier = wear_tier_from_float(val)
+                name = local_data.WEAR_NAMES.get(str(tier))
                 wear_name = name or _wear_tier(val)
         elif idx == 2014:
             raw = (

--- a/utils/wear_helpers.py
+++ b/utils/wear_helpers.py
@@ -18,6 +18,20 @@ def _wear_tier(value: float) -> str:
     return "Battle Scarred"
 
 
+def wear_tier_from_float(value: float) -> int:
+    """Return a numeric wear tier for ``value`` between 0 and 1."""
+
+    if value < 0.07:
+        return 0
+    if value < 0.15:
+        return 1
+    if value < 0.38:
+        return 2
+    if value < 0.45:
+        return 3
+    return 4
+
+
 def _decode_seed_info(attrs: Iterable[dict]) -> Tuple[float | None, int | None]:
     """Return ``(wear_float, pattern_seed)`` from custom paintkit seed attrs."""
 


### PR DESCRIPTION
## Summary
- implement `wear_tier_from_float` for numeric tier lookups
- update wear extraction functions to use tier helper
- expose the helper via `utils.__init__`
- test tier logic and name lookups

## Testing
- `pytest -q`
- `pre-commit run --files tests/test_inventory_processor.py tests/test_wear_helpers.py utils/__init__.py utils/inventory_processor.py utils/wear_helpers.py`

------
https://chatgpt.com/codex/tasks/task_e_686da89802088326933016049e036d4f