### PR TITLE
Add wear tier info in inventory processor

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -1056,6 +1056,8 @@ def test_war_paint_tool_attributes(monkeypatch):
     assert item["paintkit_id"] == 350
     assert item["paintkit_name"] == "Warhawk"
     assert item["wear_name"] == "Field-Tested"
+    assert item["wear_tier"] == 2
+    assert item["wear_value"] == 0.2
     assert item["target_weapon_defindex"] == 222
     assert item["target_weapon_name"] == "Rocket Launcher"
     assert item["resolved_name"] == "War Paint: Warhawk (Field-Tested)"
@@ -1085,6 +1087,8 @@ def test_skin_detection(monkeypatch):
     assert item["paintkit_id"] == 350
     assert item["paintkit_name"] == "Warhawk"
     assert item["wear_name"] == "Factory New"
+    assert item["wear_tier"] == 0
+    assert item["wear_value"] == 0.04
     assert item["resolved_name"] == "Warhawk Flamethrower"
 
 
@@ -1110,6 +1114,8 @@ def test_skin_attribute_order(monkeypatch):
     item = items[0]
     assert item["paintkit_id"] == 350
     assert item["wear_name"] == "Factory New"
+    assert item["wear_tier"] == 0
+    assert item["wear_value"] == 0.04
     assert item["display_name"] == "Warhawk Flamethrower"
     assert item["wear_float"] == 0.04
 

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -910,8 +910,14 @@ def _process_item(
 
     paintkit_id = paintkit_name = None
     target_weapon_def = target_weapon_name = None
-    wear_name = _extract_wear(asset)
     wear_float = _extract_wear_float(asset)
+    wear_tier = None
+    wear_name = None
+    if wear_float is not None:
+        wear_tier = wear_tier_from_float(wear_float)
+        wear_name = local_data.WEAR_NAMES.get(str(wear_tier)) or _wear_tier(wear_float)
+    else:
+        wear_name = _extract_wear(asset)
 
     if warpaint_tool:
         (
@@ -1088,7 +1094,9 @@ def _process_item(
         "paint_name": paint_name,
         "paint_hex": paint_hex,
         "wear_name": wear_name,
+        "wear_tier": wear_tier,
         "wear_float": wear_float,
+        "wear_value": wear_float,
         "pattern_seed": pattern_seed,
         "skin_name": skin_name,
         "composite_name": composite_name,


### PR DESCRIPTION
## Summary
- compute numeric wear tier from wear float
- store `wear_tier` and `wear_value` on item dicts
- derive wear name using the numeric tier
- test for new wear fields in inventory processor

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686dab53cd6c832695c871b7df789e28