### PR TITLE
Improve item wear display

### DIFF
--- a/static/modal.js
+++ b/static/modal.js
@@ -111,7 +111,15 @@
       attrs.push(html);
     }
 
-    if (data.wear_name) attrs.push('<div>Wear: ' + esc(data.wear_name) + '</div>');
+    if (data.wear_name || data.wear_float !== undefined) {
+      let wear = '';
+      if (data.wear_name) wear += esc(data.wear_name);
+      if (data.wear_float !== undefined && data.wear_float !== null) {
+        const val = Number(data.wear_float).toFixed(2);
+        wear += (wear ? ' ' : '') + '(' + esc(val) + ')';
+      }
+      attrs.push('<div>Wear: ' + wear + '</div>');
+    }
 
     if (data.paintkit_name) attrs.push('<div>Paintkit: ' + esc(data.paintkit_name) + '</div>');
 

--- a/templates/_modal.html
+++ b/templates/_modal.html
@@ -10,4 +10,9 @@
       <span class="unusual-effect">{{ item.unusual_effect_name }}</span>
     </p>
   {% endif %}
+  {% if item.wear_name or item.wear_float is defined %}
+    <p><strong>Wear:</strong>
+      {{ item.wear_name }}{% if item.wear_float is defined and item.wear_float is not none %} ({{ '%.2f'|format(item.wear_float) }}){% endif %}
+    </p>
+  {% endif %}
 </div>

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -51,5 +51,8 @@
     {% set base = item.composite_name or item.base_name or item.display_name or item.name %}
   {% endif %}
   {% set _ = title_parts.append(base) %}
+  {% if item.wear_name %}
+    {% set _ = title_parts.append('(' ~ item.wear_name ~ ')') %}
+  {% endif %}
   <h2 class="item-title">{{ title_parts | join(' ') }}</h2>
 </div>

--- a/tests/test_item_modal_template.py
+++ b/tests/test_item_modal_template.py
@@ -34,3 +34,14 @@ def test_killstreak_badge_color(app):
     assert badge is not None
     assert badge.text.strip() == "Professional Killstreak"
     assert "#8847ff" in badge.get("style", "")
+
+
+def test_modal_shows_wear_info(app):
+    item = {"wear_name": "Field-Tested", "wear_float": 0.23}
+    with app.app_context():
+        html = render_template("_modal.html", item=item)
+    soup = BeautifulSoup(html, "html.parser")
+    text = soup.get_text()
+    assert "Wear:" in text
+    assert "Field-Tested" in text
+    assert "0.23" in text

--- a/tests/test_user_template.py
+++ b/tests/test_user_template.py
@@ -189,3 +189,28 @@ def test_decorated_quality_not_shown(app):
     title = soup.find("h2", class_="item-title")
     assert title is not None
     assert title.text.strip() == "Warhawk Flamethrower"
+
+
+def test_wear_tier_in_title(app):
+    context = {
+        "user": {
+            "items": [
+                {
+                    "name": "Decorated Weapon",
+                    "composite_name": "Warhawk Scattergun",
+                    "display_name": "Warhawk Scattergun",
+                    "image_url": "",
+                    "wear_name": "Field-Tested",
+                    "quality_color": "#fff",
+                }
+            ]
+        }
+    }
+    with app.test_request_context():
+        app_module = importlib.import_module("app")
+        context["user"] = app_module.normalize_user_payload(context["user"])
+        html = render_template_string(HTML, **context)
+    soup = BeautifulSoup(html, "html.parser")
+    title = soup.find("h2", class_="item-title")
+    assert title is not None
+    assert "Field-Tested" in title.text


### PR DESCRIPTION
## Summary
- show wear tier for items on card titles
- display wear tier and float in item modal
- support wear data in generated modal HTML
- test new modal wear info and title display

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files templates/item_card.html templates/_modal.html static/modal.js tests/test_user_template.py tests/test_item_modal_template.py`

------
https://chatgpt.com/codex/tasks/task_e_686dae836a548326bfeaf711d720b4d2