### PR TITLE
Update README docs for wears cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Coverage and CI badges in the README.
 - SchemaProvider class for fetching schema properties.
 - Paintkits endpoint cached as `warpaints.json`.
+- Wears endpoint cached as `wears.json`.
 
 ### Changed
 - Updated schema caching logic and UI (previous releases).

--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ Submit any supported SteamID format. Each user panel shows the avatar, TF2 playt
   python app.py --refresh  # fetch latest schema files (shows progress)
   python main.py --refresh
   ```
+
+### `wears.json` cache
+
+`wears.json` stores the mapping of wear tiers (Factory New, Field-Tested, etc.)
+used by the app. It is retrieved from the `/properties/wears` schema endpoint.
+Run `python app.py --refresh` (or `python main.py --refresh`) whenever you want
+to refresh this file along with the rest of the schema cache.
+
 - Inspect a single user's inventory from the command line (defaults to a demo
   ID if omitted):
   ```bash


### PR DESCRIPTION
## Summary
- document `wears.json` cache in the README
- note new schema endpoint in `CHANGELOG.md`

## Testing
- `pre-commit run --files README.md CHANGELOG.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686db007dd908326979ccc41be223778