### PR TITLE
Improve item styling with sheen colors and value badges

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -292,6 +292,26 @@ button {
   pointer-events:none;
   z-index:3;
 }
+.item-value-box{
+  position:absolute;
+  right:2px;
+  bottom:2px;
+  background:rgba(0,0,0,0.6);
+  color:#fff;
+  padding:1px 3px;
+  border-radius:4px;
+  font-size:11px;
+  pointer-events:none;
+  z-index:3;
+}
+.sheen-label{
+  display:inline-block;
+  margin-left:4px;
+  padding:2px 4px;
+  border-radius:4px;
+  background:rgba(0,0,0,0.4);
+  font-weight:600;
+}
 .item-badges .badge{
   filter:drop-shadow(0 0 2px #0008);
 }

--- a/templates/_modal.html
+++ b/templates/_modal.html
@@ -4,6 +4,11 @@
           style="background-color: {{ item.sheen_color or '#f97316' }};">
       {{ item.killstreak_name }}
     </span>
+    {% if item.sheen_name %}
+      <span class="sheen-label" style="color: {{ item.sheen_color or '#f97316' }}; text-shadow: 0 0 4px {{ item.sheen_color or '#f97316' }};">
+        {{ item.sheen_name }}
+      </span>
+    {% endif %}
   {% endif %}
   {% if item.unusual_effect_name %}
     <p><strong>Unusual Effect:</strong>

--- a/templates/_user.html
+++ b/templates/_user.html
@@ -42,9 +42,6 @@
             {# ↑ keep border-color for quality #}
             <div class="item-wrapper">
               {% include "item_card.html" %}
-              {% if item.price_string %}
-                <div class="item-price">{{ item.formatted_price }}</div>
-              {% endif %}
             </div>
           {% endfor %}
         </div>

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -55,4 +55,7 @@
     {% set _ = title_parts.append('(' ~ item.wear_name ~ ')') %}
   {% endif %}
   <h2 class="item-title">{{ title_parts | join(' ') }}</h2>
+  {% if item.price_string %}
+    <div class="item-value-box">{{ item.formatted_price }}</div>
+  {% endif %}
 </div>

--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -67,7 +67,9 @@ def test_enrichment_full_attributes(monkeypatch):
     assert item["killstreak_name"] == "Professional"
     assert item["sheen"] == "Manndarin"
     assert item["sheen_name"] == "Manndarin"
-    assert item["sheen_color"] == KILLSTREAK_SHEEN_COLORS[3][1]
+    assert item["sheen_color"] == ip.SHEEN_COLORS.get(
+        item["sheen_name"], KILLSTREAK_SHEEN_COLORS[3][1]
+    )
     assert item["killstreak_effect"] == "Cerebral Discharge"
     assert item["wear_name"] == "Field-Tested"
     assert item["strange_count"] == 10

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -22,6 +22,17 @@ from .constants import (
     SPELL_MAP,
 )
 
+SHEEN_COLORS = {
+    "Team Shine - Red": "#F30000",
+    "Team Shine - Blue": "#0062FF",
+    "Mean Green": "#00FF00",
+    "Villianous Violet": "#662C91",
+    "Agonising Emerald": "#05BE00",
+    "Deadly Daffodil": "#FFFF00",
+    "Manndarin": "#FF8500",
+    "Hot Rod": "#FF3E84",
+}
+
 
 logger = logging.getLogger(__name__)
 
@@ -975,10 +986,13 @@ def _process_item(
 
     ks_tier_val = _extract_killstreak_tier(asset)
     ks_tier, sheen_name, sheen_id = _extract_killstreak(asset)
-    sheen_color = (
-        KILLSTREAK_SHEEN_COLORS.get(sheen_id, (None, None))[1]
-        if sheen_id is not None
-        else None
+    sheen_color = SHEEN_COLORS.get(
+        sheen_name,
+        (
+            KILLSTREAK_SHEEN_COLORS.get(sheen_id, (None, None))[1]
+            if sheen_id is not None
+            else None
+        ),
     )
     ks_effect = _extract_killstreak_effect(asset)
     paint_name, paint_hex = _extract_paint(asset)


### PR DESCRIPTION
## Summary
- add new sheen color mapping
- style killstreak sheen label in modal
- show item value overlay box on card
- update enrichment tests for new sheen color map

## Testing
- `pre-commit run --files templates/_modal.html templates/_user.html templates/item_card.html static/style.css utils/inventory_processor.py tests/test_enrichment.py`

------
https://chatgpt.com/codex/tasks/task_e_686db8c688cc8326995c162d078b3af4