### PR TITLE
Add kill eater score types support

### DIFF
--- a/utils/schema_provider.py
+++ b/utils/schema_provider.py
@@ -26,6 +26,7 @@ class SchemaProvider:
         "qualities": "/properties/qualities",
         "defindexes": "/properties/defindexes",
         "string_lookups": "/raw/schema/string_lookups",
+        "kill_eater_score_types": "/raw/schema/kill_eater_score_types",
     }
 
     def __init__(


### PR DESCRIPTION
## Summary
- load schema/kill_eater_score_types.json
- expose KILL_EATER_TYPES mapping
- include file for auto-refetching

## Testing
- `pre-commit run --files utils/local_data.py utils/schema_provider.py`

------
https://chatgpt.com/codex/tasks/task_e_686e69c96c4483268d1aaba3e8bf218e