### PR TITLE
Add strange part helper and badges

### DIFF
--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -59,6 +59,7 @@ def test_enrichment_full_attributes(monkeypatch):
     monkeypatch.setattr(
         ld, "STRANGE_PART_NAMES", {"64": "Kills", "70": "Robots"}, False
     )
+    monkeypatch.setattr(ld, "KILL_EATER_TYPES", {64: "Kills", 70: "Robots"}, False)
 
     items = ip.enrich_inventory(data)
     item = items[0]

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -842,10 +842,39 @@ def test_kill_eater_fields(monkeypatch):
     monkeypatch.setattr(
         ld, "STRANGE_PART_NAMES", {"64": "Kills", "70": "Robots"}, False
     )
+    monkeypatch.setattr(ld, "KILL_EATER_TYPES", {64: "Kills", 70: "Robots"}, False)
     items = ip.enrich_inventory(data)
     item = items[0]
     assert item["strange_count"] == 10
     assert item["score_type"] == "Kills"
+
+
+def test_strange_part_badge(monkeypatch):
+    data = {
+        "items": [
+            {
+                "defindex": 222,
+                "quality": 11,
+                "attributes": [
+                    {"defindex": 214, "value": 3},
+                    {"defindex": 292, "value": 64},
+                ],
+            }
+        ]
+    }
+    ld.ITEMS_BY_DEFINDEX = {222: {"item_name": "Gun", "image_url": ""}}
+    ld.QUALITIES_BY_INDEX = {11: "Strange"}
+    monkeypatch.setattr(ld, "KILL_EATER_TYPES", {64: "Kills"}, False)
+
+    items = ip.enrich_inventory(data)
+    badges = items[0]["badges"]
+    assert {
+        "icon": "\U0001f4ca",
+        "title": "Strange Part \u2022 Kills \u2192 3",
+        "label": "Kills",
+        "color": "#CF6A32",
+        "type": "strange_part",
+    } in badges
 
 
 def test_plain_craft_weapon_filtered():

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -662,6 +662,12 @@ def _extract_kill_eater_info(
     return counts, types
 
 
+def _part_name(type_id: int) -> str:
+    """Return kill-eater type name for ``type_id``."""
+
+    return local_data.KILL_EATER_TYPES.get(type_id) or f"Unknown (sp{type_id})"
+
+
 def _build_item_name(base: str, quality: str, asset: Dict[str, Any]) -> str:
     """Return the display name prefixed with quality and killstreak info."""
 
@@ -1069,6 +1075,21 @@ def _process_item(
             }
         )
 
+    for idx, count in sorted(kill_eater_counts.items()):
+        part_type = score_types.get(idx)
+        if part_type is None:
+            continue
+        part = _part_name(part_type)
+        badges.append(
+            {
+                "icon": "\U0001f4ca",
+                "title": f"Strange Part \u2022 {part} \u2192 {count}",
+                "label": part,
+                "color": "#CF6A32",
+                "type": "strange_part",
+            }
+        )
+
     if warpaint_tool or (warpaintable and paintkit_id is not None):
         display_name = resolved_name
 
@@ -1143,10 +1164,7 @@ def _process_item(
         "strange_parts": strange_parts,
         "strange_count": kill_eater_counts.get(1),
         "score_type": (
-            _PARTS_BY_ID.get(score_types.get(1))
-            or local_data.STRANGE_PART_NAMES.get(str(score_types.get(1)))
-            if score_types.get(1) is not None
-            else None
+            _part_name(score_types.get(1)) if score_types.get(1) is not None else None
         ),
     }
     if valuation_service is not None:


### PR DESCRIPTION
## Summary
- add `_part_name` helper to look up kill‑eater type names
- use helper when populating `score_type`
- show strange parts as badges with counts
- extend tests for new helper and badges

## Testing
- `pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py tests/test_enrichment.py`

------
https://chatgpt.com/codex/tasks/task_e_686e6e0387388326a87cb56643a45fba