### PR TITLE
Fix test mode reloader check

### DIFF
--- a/app.py
+++ b/app.py
@@ -324,7 +324,7 @@ def index():
 
 
 if TEST_MODE and (
-    os.getenv("WERKZEUG_RUN_MAIN") == "true" or not os.getenv("WERKZEUG_RUN_MAIN")
+    os.getenv("WERKZEUG_RUN_MAIN") == "true" or os.getenv("FLASK_DEBUG") != "1"
 ):
     _setup_test_mode()
 


### PR DESCRIPTION
## Summary
- ensure `_setup_test_mode()` is only invoked in the reloader child process or when debug mode is disabled

## Testing
- `pre-commit run --files app.py` *(fails: tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_686e833f6ce08326acd44f227bbd2356