### PR TITLE
Fix repeated prompts when launching test mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -323,13 +323,9 @@ def index():
     )
 
 
-if TEST_MODE and (
-    os.getenv("WERKZEUG_RUN_MAIN") == "true" or os.getenv("FLASK_DEBUG") != "1"
-):
-    _setup_test_mode()
-
-
 if __name__ == "__main__":
     port = int(os.getenv("PORT", 5000))
     kill_process_on_port(port)
-    app.run(host="0.0.0.0", port=port, debug=True)
+    if TEST_MODE:
+        _setup_test_mode()
+    app.run(host="0.0.0.0", port=port, debug=True, use_reloader=not TEST_MODE)


### PR DESCRIPTION
## Summary
- avoid running `_setup_test_mode` twice
- disable the Flask reloader when running with `--test`

## Testing
- `pre-commit run --files app.py` *(fails: ModuleNotFoundError: No module named 'vdf')*

------
https://chatgpt.com/codex/tasks/task_e_686e873eee308326ad161560ee951147