### PR TITLE
Add concurrent batch fetching

### DIFF
--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -108,7 +108,7 @@ QUALITY_MAP = {
     3: ("Vintage", "#28344a"),
     5: ("Unusual", "#4f3363"),
     6: ("Unique", "#957e04"),
-    11: ("Strange", "#7a4121"),
+    11: ("Strange", "#CF6A32"),
     13: ("Haunted", "#0c8657"),
     14: ("Collector's", "#1c0101"),
     15: ("Decorated Weapon", "#949494"),


### PR DESCRIPTION
## Summary
- queue up SteamIDs for batch processing
- fetch inventories concurrently with a thread pool
- expose `/fetch_batch` endpoint
- send batches from `retry.js`
- correct `Strange` quality color constant

## Testing
- `pre-commit run --files app.py static/retry.js utils/inventory_processor.py`

------
https://chatgpt.com/codex/tasks/task_e_686e957f85208326b2287d8e5b689ded