### PR TITLE
Fix inventory processor tests to use constant color

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -1,6 +1,7 @@
 from utils import inventory_processor as ip
 from utils import steam_api_client as sac
 from utils import local_data as ld
+from utils.inventory_processor import QUALITY_MAP
 from utils.valuation_service import ValuationService
 from pathlib import Path
 import requests
@@ -36,7 +37,7 @@ def test_enrich_inventory():
     items = ip.enrich_inventory(data)
     assert items[0]["name"] == "Strange Rocket Launcher"
     assert items[0]["quality"] == "Strange"
-    assert items[0]["quality_color"] == "#CF6A32"
+    assert items[0]["quality_color"] == QUALITY_MAP[11][1]
     assert items[0]["image_url"].startswith(
         "https://steamcommunity-a.akamaihd.net/economy/image/"
     )


### PR DESCRIPTION
## Summary
- use `QUALITY_MAP` constant in `test_inventory_processor`
- import `QUALITY_MAP` in tests

## Testing
- `pre-commit run --files tests/test_inventory_processor.py` *(with `SKIP_VALIDATE=1`)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e9826f9a483269767f09a3c9c177d