### PR TITLE
Add inventory chunk streaming

### DIFF
--- a/templates/_item_cards.html
+++ b/templates/_item_cards.html
@@ -1,0 +1,9 @@
+{% for item in items if not item._hidden %}
+  {% set idx = loop.index0 %}
+  <div class="item-wrapper">
+    {% include "item_card.html" %}
+    {% if item.price_string %}
+      <div class="item-price">{{ item.formatted_price }}</div>
+    {% endif %}
+  </div>
+{% endfor %}

--- a/templates/_user.html
+++ b/templates/_user.html
@@ -38,16 +38,9 @@
         <i class="fa-solid fa-chevron-left"></i>
       </button>
         <div class="inventory-container">
-          {% for item in user.items if not item._hidden %}
-            {% set idx = loop.index0 %}
-            {# ↑ keep border-color for quality #}
-            <div class="item-wrapper">
-              {% include "item_card.html" %}
-              {% if item.price_string %}
-                <div class="item-price">{{ item.formatted_price }}</div>
-              {% endif %}
-            </div>
-          {% endfor %}
+          {% with items = user.items %}
+            {% include "_item_cards.html" %}
+          {% endwith %}
         </div>
       <button class="scroll-arrow right" type="button" aria-label="Scroll right">
         <i class="fa-solid fa-chevron-right"></i>

--- a/templates/index.html
+++ b/templates/index.html
@@ -113,6 +113,9 @@
             {% for user in users %}
                 {% include "_user.html" %}
             {% endfor %}
+            {% for steamid in ids %}
+                <div id="user-{{ steamid }}">Loading inventory…</div>
+            {% endfor %}
         </div>
     </div>
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,0 +1,31 @@
+import importlib
+from flask import Response
+
+
+def test_inventory_chunk_streams(app, monkeypatch):
+    mod = importlib.import_module("app")
+    monkeypatch.setattr(mod, "CHUNK_SIZE", 1)
+    monkeypatch.setattr(
+        mod,
+        "build_user_data",
+        lambda sid: {
+            "steamid": sid,
+            "items": [{"name": "A", "image_url": ""}, {"name": "B", "image_url": ""}],
+            "status": "parsed",
+        },
+    )
+    client = app.test_client()
+    resp: Response = client.get("/inventory_chunk/1")
+    assert resp.status_code == 200
+    assert resp.mimetype == "text/event-stream"
+    chunks = list(resp.response)
+    assert len(chunks) >= 3
+    joined = b"".join(chunks).decode()
+    assert "item-wrapper" in joined
+
+
+def test_index_shows_loading(app):
+    client = app.test_client()
+    resp = client.post("/", data={"steamids": "123"})
+    html = resp.get_data(as_text=True)
+    assert "Loading inventory" in html


### PR DESCRIPTION
## Summary
- show placeholder divs for requested IDs
- add `_item_cards.html` partial and update `_user.html`
- stream inventory chunks via `/inventory_chunk/<steamid>`
- load streamed items in `retry.js`
- test placeholder and stream endpoint

## Testing
- `pre-commit run --files app.py templates/_user.html templates/_item_cards.html templates/index.html static/retry.js tests/test_streaming.py` *(fails: ModuleNotFoundError: No module named 'vdf')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'vdf')*

------
https://chatgpt.com/codex/tasks/task_e_686e9c78afb08326b2d0088c1ca474fa