### PR TITLE
Update item images to 32px

### DIFF
--- a/static/modal.js
+++ b/static/modal.js
@@ -155,7 +155,7 @@
     }
 
     const details = attrs.join('') + spells;
-    const imgTag = '<img src="' + esc(data.image_url || '') + '" width="64" height="64" alt="">';
+    const imgTag = '<img src="' + esc(data.image_url || '') + '" width="32" height="32" alt="">';
     return imgTag + '<div id="modal-details">' + details + '</div>';
   }
 

--- a/static/style.css
+++ b/static/style.css
@@ -333,8 +333,8 @@ button {
   margin-right: 4px;
 }
 .item-img {
-  max-width: 64px;
-  max-height: 64px;
+  max-width: 32px;
+  max-height: 32px;
   margin-bottom: 6px;
   position: relative;
   z-index: 2;

--- a/templates/index.html
+++ b/templates/index.html
@@ -130,7 +130,7 @@
       </div>
       <div class="modal-body">
         <div id="modal-effect-bg" class="particle-overlay"></div>
-        <img id="modal-img" src="" width="64" height="64" alt="">
+        <img id="modal-img" src="" width="32" height="32" alt="">
         <div id="modal-details"></div>
       </div>
     </dialog>

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -18,7 +18,7 @@
     <img class="particle-bg" src="/static/images/effects/{{ item.unusual_effect_id }}.png" alt="effect" loading="lazy">
   {% endif %}
   {% if item.image_url %}
-    <img class="item-img" src="{{ item.image_url }}" data-src="{{ item.image_url }}" alt="{{ item.display_name }}" width="64" height="64" loading="lazy" {% if idx is defined and idx < 30 %}preload="auto"{% endif %} onerror="this.style.display='none';">
+    <img class="item-img" src="{{ item.image_url }}" data-src="{{ item.image_url }}" alt="{{ item.display_name }}" width="32" height="32" loading="lazy" {% if idx is defined and idx < 30 %}preload="auto"{% endif %} onerror="this.style.display='none';">
   {% else %}
     <div class="missing-icon"></div>
   {% endif %}

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -26,6 +26,7 @@ def test_inventory_chunk_streams(app, monkeypatch):
 
 def test_index_shows_loading(app):
     client = app.test_client()
-    resp = client.post("/", data={"steamids": "123"})
+    steamid = "76561198034301681"
+    resp = client.post("/", data={"steamids": steamid})
     html = resp.get_data(as_text=True)
     assert "Loading inventory" in html


### PR DESCRIPTION
## Summary
- shrink item image size to 32px in item card template and modal
- update modal JS and stylesheet accordingly
- fix streaming test to use a valid SteamID

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files static/modal.js static/style.css templates/index.html templates/item_card.html tests/test_streaming.py`

------
https://chatgpt.com/codex/tasks/task_e_686e9fcf7fc083268d13a2c9facca95b