### PR TITLE
Implement lazy loading for user cards

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -117,6 +117,7 @@
                 <div id="user-{{ steamid }}">Loading inventory…</div>
             {% endfor %}
         </div>
+        <div id="lazy-load-sentinel"></div>
     </div>
 
     <div id="scan-toast" class="toast hidden"></div>


### PR DESCRIPTION
## Summary
- add a lazy-load sentinel in `index.html`
- queue initial IDs and implement `lazyLoadNext` in `retry.js`
- fetch each user sequentially when the sentinel is visible
- initialize an IntersectionObserver and begin lazy loading on page load

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files templates/index.html static/retry.js`

------
https://chatgpt.com/codex/tasks/task_e_686eafad05f0832696eff035b3cee930