### PR TITLE
Migrate to Quart async framework

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 Flask==3.1.1
+Quart==0.20.0
+Hypercorn==0.17.3
 requests==2.32.4
 python-dotenv==1.1.1
 vdf==3.4


### PR DESCRIPTION
## Summary
- switch from Flask to Quart
- wrap test helpers for sync compatibility
- adjust routes and handlers to async
- run server with Hypercorn

## Testing
- `pre-commit run --files app.py requirements.txt` *(fails: tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_686eccbbe6d88326b60a2f124c3a5938