### PR TITLE
Switch helpers to aiohttp

### DIFF
--- a/app.py
+++ b/app.py
@@ -181,7 +181,7 @@ def stack_items(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
 def get_player_summary(steamid64: str) -> Dict[str, Any]:
     """Return profile name, avatar URL and TF2 playtime for a user."""
     print(f"Fetching player summary for {steamid64}")
-    players = sac.get_player_summaries([steamid64])
+    players = asyncio.run(sac.get_player_summaries([steamid64]))
     profile = f"https://steamcommunity.com/profiles/{steamid64}"
     if players:
         player = players[0]
@@ -192,7 +192,7 @@ def get_player_summary(steamid64: str) -> Dict[str, Any]:
         username = steamid64
         avatar = ""
 
-    playtime = sac.get_tf2_playtime_hours(steamid64)
+    playtime = asyncio.run(sac.get_tf2_playtime_hours(steamid64))
 
     return {
         "username": username,
@@ -210,7 +210,7 @@ def fetch_inventory(steamid64: str) -> Dict[str, Any]:
         status = TEST_INVENTORY_STATUS or "parsed"
         data = TEST_INVENTORY_RAW
     else:
-        status, data = sac.fetch_inventory(steamid64)
+        status, data = asyncio.run(sac.fetch_inventory(steamid64))
     items: List[Dict[str, Any]] = []
     if status == "parsed":
         try:
@@ -327,7 +327,7 @@ def _setup_test_mode() -> None:
                 TEST_INVENTORY_STATUS = "parsed"
                 print("Loaded cached inventory for testing.")
                 break
-        status, data = sac.fetch_inventory(steamid)
+        status, data = asyncio.run(sac.fetch_inventory(steamid))
         if status != "failed":
             TEST_INVENTORY_RAW = data
             TEST_INVENTORY_STATUS = status
@@ -403,7 +403,7 @@ async def index():
         tokens = re.split(r"\s+", steamids_input.strip())
         raw_ids = extract_steam_ids(steamids_input)
         invalid = [t for t in tokens if t and t not in raw_ids]
-        ids = [sac.convert_to_steam64(t) for t in raw_ids]
+        ids = [await sac.convert_to_steam64(t) for t in raw_ids]
         print(f"Parsed {len(ids)} valid IDs, {len(invalid)} tokens ignored")
         if not ids:
             flash("No valid Steam IDs found!")

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,6 +3,7 @@ pytest-cov==6.2.1
 responses==0.25.0
 Flask==3.1.1
 requests==2.32.4
+aiohttp==3.9.5
 python-dotenv==1.1.1
 vdf==3.4
 beautifulsoup4==4.13.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ Flask==3.1.1
 Quart==0.20.0
 Hypercorn==0.17.3
 requests==2.32.4
+aiohttp==3.9.5
 python-dotenv==1.1.1
 vdf==3.4
 beautifulsoup4==4.13.4

--- a/tests/test_id_parser.py
+++ b/tests/test_id_parser.py
@@ -1,3 +1,4 @@
+import asyncio
 import utils.steam_api_client as sac
 from utils.id_parser import extract_steam_ids
 
@@ -12,11 +13,11 @@ def test_extract_ids_from_status_block():
     #   316 "Short" [U:1:2] 00:01 50 0 active
     """
     ids = extract_steam_ids(text)
-    steam64 = [sac.convert_to_steam64(i) for i in ids]
+    steam64 = [asyncio.run(sac.convert_to_steam64(i)) for i in ids]
     assert steam64 == [
-        sac.convert_to_steam64("[U:1:876151635]"),
-        sac.convert_to_steam64("[U:1:1137042230]"),
-        sac.convert_to_steam64("[U:1:2]"),
+        asyncio.run(sac.convert_to_steam64("[U:1:876151635]")),
+        asyncio.run(sac.convert_to_steam64("[U:1:1137042230]")),
+        asyncio.run(sac.convert_to_steam64("[U:1:2]")),
     ]
     assert "Xanmangamer" not in ids
     assert "active" not in ids

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -1,11 +1,12 @@
+import asyncio
+from pathlib import Path
+import aiohttp
+import requests
+import pytest
 from utils import inventory_processor as ip
 from utils import steam_api_client as sac
 from utils import local_data as ld
 from utils.valuation_service import ValuationService
-from pathlib import Path
-import requests
-import responses
-import pytest
 
 
 @pytest.fixture(autouse=True)
@@ -257,31 +258,58 @@ def test_get_inventories_adds_user_agent(monkeypatch):
     captured = {}
 
     class DummyResp:
-        def __init__(self, status=200):
-            self.status_code = status
+        status = 200
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
 
         def raise_for_status(self):
-            if self.status_code != 200:
-                raise requests.HTTPError(response=self)
+            pass
 
-        def json(self):
+        async def json(self):
             return {"result": {"items": []}}
 
-    def fake_get(url, headers=None, timeout=10):
-        captured["ua"] = headers.get("User-Agent") if headers else None
-        return DummyResp()
+    class DummyRequestCtx:
+        def __init__(self, resp):
+            self.resp = resp
 
-    monkeypatch.setattr(sac.requests, "get", fake_get)
-    sac.get_inventories(["1"])
+        def __await__(self):
+            async def _coro():
+                return self.resp
+
+            return _coro().__await__()
+
+        async def __aenter__(self):
+            return self.resp
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+    class DummySession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        def get(self, url, headers=None, timeout=None):
+            captured["ua"] = headers.get("User-Agent") if headers else None
+            return DummyRequestCtx(DummyResp())
+
+    monkeypatch.setattr(aiohttp, "ClientSession", lambda *a, **k: DummySession())
+    asyncio.run(sac.get_inventories(["1"]))
     assert captured["ua"] == "Mozilla/5.0"
 
 
 def test_fetch_inventory_handles_http_error(monkeypatch):
-    def fake_fetch(_id):
+    async def fake_fetch(_id):
         return "failed", {}
 
     monkeypatch.setattr(sac, "fetch_inventory", fake_fetch)
-    data, status = ip.fetch_inventory("1")
+    data, status = asyncio.run(ip.fetch_inventory("1"))
     assert data == {"items": []}
     assert status == "failed"
 
@@ -304,9 +332,54 @@ def test_fetch_inventory_statuses(monkeypatch, payload, expected):
         "https://api.steampowered.com/IEconItems_440/GetPlayerItems/v0001/"
         "?key=x&steamid=1"
     )
-    with responses.RequestsMock() as rsps:
-        rsps.add(responses.GET, url, **payload)
-        status, data = sac.fetch_inventory("1")
+
+    class DummyResp:
+        status = payload.get("status", 200)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        def raise_for_status(self):
+            if self.status >= 400:
+                raise aiohttp.ClientResponseError(None, None, status=self.status)
+
+        async def json(self):
+            return payload.get("json", {})
+
+    class DummyRequestCtx:
+        def __init__(self, resp):
+            self.resp = resp
+
+        def __await__(self):
+            async def _coro():
+                return self.resp
+
+            return _coro().__await__()
+
+        async def __aenter__(self):
+            return self.resp
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+    class DummySession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        def get(self, url_arg, **kwargs):
+            assert url_arg == url
+            if "body" in payload:
+                raise aiohttp.ClientError()
+            return DummyRequestCtx(DummyResp())
+
+    monkeypatch.setattr(aiohttp, "ClientSession", lambda *a, **k: DummySession())
+    status, data = asyncio.run(sac.fetch_inventory("1"))
     assert status == expected
 
 
@@ -341,7 +414,7 @@ def test_user_template_safe(monkeypatch, status):
         status=status,
     )
 
-    with app.app.app_context():
+    with app.app.test_request_context():
         app.render_template("_user.html", user=user)
 
 

--- a/tests/test_item_modal_template.py
+++ b/tests/test_item_modal_template.py
@@ -27,7 +27,7 @@ def app(monkeypatch):
 
 def test_killstreak_badge_color(app):
     item = {"killstreak_name": "Professional Killstreak", "sheen_color": "#8847ff"}
-    with app.app_context():
+    with app.test_request_context():
         html = render_template("_modal.html", item=item)
     soup = BeautifulSoup(html, "html.parser")
     badge = soup.find("span", class_="killstreak-badge")

--- a/tests/test_quantity_badge.py
+++ b/tests/test_quantity_badge.py
@@ -42,7 +42,7 @@ def test_quantity_badge_rendered(monkeypatch):
         "status": "parsed",
         "items": [item],
     }
-    with mod.app.app_context():
+    with mod.app.test_request_context():
         user_ns = mod.normalize_user_payload(user)
         html = render_template_string(HTML, user=user_ns)
     soup = BeautifulSoup(html, "html.parser")

--- a/tests/test_user_badges.py
+++ b/tests/test_user_badges.py
@@ -51,7 +51,7 @@ def test_item_badges_rendered(app):
         "status": "parsed",
         "items": [item],
     }
-    with app.app_context():
+    with app.test_request_context():
         app_module = importlib.import_module("app")
         user_ns = app_module.normalize_user_payload(user)
         html = render_template_string(HTML, user=user_ns)

--- a/tests/test_utils_extras.py
+++ b/tests/test_utils_extras.py
@@ -1,3 +1,4 @@
+import asyncio
 from utils import steam_api_client as sac
 from utils import inventory_processor as ip
 from utils import local_data as ld
@@ -5,8 +6,8 @@ import pytest
 
 
 def test_convert_to_steam64():
-    assert sac.convert_to_steam64("STEAM_0:1:4") == "76561197960265737"
-    assert sac.convert_to_steam64("[U:1:4]") == "76561197960265732"
+    assert asyncio.run(sac.convert_to_steam64("STEAM_0:1:4")) == "76561197960265737"
+    assert asyncio.run(sac.convert_to_steam64("[U:1:4]")) == "76561197960265732"
 
 
 @pytest.fixture(autouse=True)

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -668,10 +668,10 @@ def _build_item_name(base: str, quality: str, asset: Dict[str, Any]) -> str:
     return " ".join(parts)
 
 
-def fetch_inventory(steamid: str) -> Tuple[Dict[str, Any], str]:
+async def fetch_inventory(steamid: str) -> Tuple[Dict[str, Any], str]:
     """Return inventory data and status using the Steam API helper."""
 
-    status, data = steam_api_client.fetch_inventory(steamid)
+    status, data = await steam_api_client.fetch_inventory(steamid)
     if status not in ("parsed", "incomplete"):
         data = {"items": []}
     else:

--- a/utils/steam_api_client.py
+++ b/utils/steam_api_client.py
@@ -1,8 +1,8 @@
 import os
+import logging
 from typing import Any, Dict, Iterator, List, Tuple
 
-import logging
-import requests
+import aiohttp
 from dotenv import load_dotenv
 
 # Ensure .env values are available even when this module is imported early.
@@ -27,40 +27,52 @@ def _chunks(seq: List[str], size: int) -> Iterator[List[str]]:
         yield seq[i : i + size]
 
 
-def get_player_summaries(steamids: List[str]) -> List[Dict[str, Any]]:
+async def get_player_summaries(steamids: List[str]) -> List[Dict[str, Any]]:
     """Return player summary data for all provided SteamIDs."""
+
     results: List[Dict[str, Any]] = []
-    for chunk in _chunks(steamids, 100):
-        key = _require_key()
-        url = (
-            "https://api.steampowered.com/ISteamUser/GetPlayerSummaries/v2/"
-            f"?key={key}&steamids={','.join(chunk)}"
-        )
-        r = requests.get(url, timeout=10)
-        r.raise_for_status()
-        players = r.json().get("response", {}).get("players", [])
-        results.extend(players)
-    return results
-
-
-def get_inventories(steamids: List[str]) -> Dict[str, Any]:
-    """Fetch TF2 inventories for each user via the Steam Web API."""
-    results: Dict[str, Any] = {}
-    headers = {"User-Agent": "Mozilla/5.0"}
-    for chunk in _chunks(steamids, 20):
-        for sid in chunk:
+    async with aiohttp.ClientSession() as session:
+        for chunk in _chunks(steamids, 100):
             key = _require_key()
             url = (
-                "https://api.steampowered.com/IEconItems_440/GetPlayerItems/v0001/"
-                f"?key={key}&steamid={sid}"
+                "https://api.steampowered.com/ISteamUser/GetPlayerSummaries/v2/"
+                f"?key={key}&steamids={','.join(chunk)}"
             )
-            r = requests.get(url, headers=headers, timeout=10)
-            r.raise_for_status()
-            results[sid] = r.json().get("result", {})
+            async with session.get(
+                url, timeout=aiohttp.ClientTimeout(total=10)
+            ) as resp:
+                resp.raise_for_status()
+                data = await resp.json()
+                players = data.get("response", {}).get("players", [])
+                results.extend(players)
     return results
 
 
-def fetch_inventory(steamid: str) -> Tuple[str, Dict[str, Any]]:
+async def get_inventories(steamids: List[str]) -> Dict[str, Any]:
+    """Fetch TF2 inventories for each user via the Steam Web API."""
+
+    results: Dict[str, Any] = {}
+    headers = {"User-Agent": "Mozilla/5.0"}
+    async with aiohttp.ClientSession() as session:
+        for chunk in _chunks(steamids, 20):
+            for sid in chunk:
+                key = _require_key()
+                url = (
+                    "https://api.steampowered.com/IEconItems_440/GetPlayerItems/v0001/"
+                    f"?key={key}&steamid={sid}"
+                )
+                async with session.get(
+                    url,
+                    headers=headers,
+                    timeout=aiohttp.ClientTimeout(total=10),
+                ) as resp:
+                    resp.raise_for_status()
+                    data = await resp.json()
+                    results[sid] = data.get("result", {})
+    return results
+
+
+async def fetch_inventory(steamid: str) -> Tuple[str, Dict[str, Any]]:
     """Fetch a user's inventory and classify visibility."""
 
     headers = {"User-Agent": "Mozilla/5.0"}
@@ -71,23 +83,25 @@ def fetch_inventory(steamid: str) -> Tuple[str, Dict[str, Any]]:
     )
 
     try:
-        resp = requests.get(url, headers=headers, timeout=20)
-    except requests.RequestException:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                url,
+                headers=headers,
+                timeout=aiohttp.ClientTimeout(total=20),
+            ) as resp:
+                if resp.status in (400, 403):
+                    logger.info("Inventory %s: Private", steamid)
+                    return "private", {}
+                if resp.status != 200:
+                    logger.info("Inventory %s: HTTP %s", steamid, resp.status)
+                    return "failed", {}
+                try:
+                    data = await resp.json()
+                except ValueError:
+                    logger.info("Inventory %s: invalid JSON", steamid)
+                    return "failed", {}
+    except aiohttp.ClientError:
         logger.info("Inventory %s: Fetch Failed", steamid)
-        return "failed", {}
-
-    if resp.status_code in (400, 403):
-        logger.info("Inventory %s: Private", steamid)
-        return "private", {}
-
-    if resp.status_code != 200:
-        logger.info("Inventory %s: HTTP %s", steamid, resp.status_code)
-        return "failed", {}
-
-    try:
-        data = resp.json()
-    except ValueError:
-        logger.info("Inventory %s: invalid JSON", steamid)
         return "failed", {}
 
     result = data.get("result")
@@ -110,7 +124,7 @@ def fetch_inventory(steamid: str) -> Tuple[str, Dict[str, Any]]:
     return "private", result
 
 
-def convert_to_steam64(id_str: str) -> str:
+async def convert_to_steam64(id_str: str) -> str:
     """Convert Steam identifiers to SteamID64."""
     import re
 
@@ -142,16 +156,19 @@ def convert_to_steam64(id_str: str) -> str:
         "https://api.steampowered.com/ISteamUser/ResolveVanityURL/v1/"
         f"?key={key}&vanityurl={id_str}"
     )
-    r = requests.get(url, timeout=10)
-    r.raise_for_status()
-    data = r.json().get("response", {})
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url, timeout=aiohttp.ClientTimeout(total=10)) as resp:
+            resp.raise_for_status()
+            data = await resp.json()
+    data = data.get("response", {})
     if data.get("success") != 1:
         raise ValueError(f"Unable to resolve vanity URL: {id_str}")
     return data["steamid"]
 
 
-def get_tf2_playtime_hours(steamid: str) -> float:
+async def get_tf2_playtime_hours(steamid: str) -> float:
     """Return TF2 playtime in hours for a Steam user."""
+
     url = "https://api.steampowered.com/IPlayerService/GetOwnedGames/v0001/"
     key = _require_key()
     params = {
@@ -160,9 +177,16 @@ def get_tf2_playtime_hours(steamid: str) -> float:
         "include_played_free_games": 1,
         "format": "json",
     }
-    r = requests.get(url, params=params, timeout=10)
-    r.raise_for_status()
-    data = r.json().get("response", {})
+    async with aiohttp.ClientSession() as session:
+        async with session.get(
+            url,
+            params=params,
+            timeout=aiohttp.ClientTimeout(total=10),
+        ) as resp:
+            resp.raise_for_status()
+            data = await resp.json()
+
+    data = data.get("response", {})
     for game in data.get("games", []):
         if game.get("appid") == 440:
             return game.get("playtime_forever", 0) / 60.0


### PR DESCRIPTION
## Summary
- replace requests-based helpers with aiohttp async versions
- update inventory processor and app to call async helpers
- adjust tests for new async API
- add aiohttp dependency

## Testing
- `pre-commit run --files utils/steam_api_client.py utils/inventory_processor.py app.py tests/test_utils_extras.py tests/test_id_parser.py tests/test_steam_api_client.py tests/test_inventory_processor.py tests/test_item_modal_template.py tests/test_quantity_badge.py tests/test_user_badges.py` *(fails: 18 failed, 118 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686ed24cfce48326b1ff35f2af8b8b6e