### PR TITLE
Add asyncio test fixtures

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,5 @@
 pytest==8.4.0
+pytest-asyncio
 pytest-cov==6.2.1
 responses==0.25.0
 Flask==3.1.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,3 +32,32 @@ def app(monkeypatch):
     importlib.reload(mod)
     mod.app.secret_key = "test"
     return mod.app
+
+
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture
+async def test_app(monkeypatch):
+    """Return Quart app with env and schema mocks."""
+
+    monkeypatch.setenv("STEAM_API_KEY", "x")
+    monkeypatch.setenv("BPTF_API_KEY", "x")
+    monkeypatch.setattr("utils.local_data.load_files", lambda *a, **k: ({}, {}))
+    monkeypatch.setattr(
+        "utils.price_loader.ensure_prices_cached",
+        lambda refresh=False: asyncio.sleep(0, result=Path("prices.json")),
+    )
+    monkeypatch.setattr(
+        "utils.price_loader.ensure_currencies_cached",
+        lambda refresh=False: asyncio.sleep(0, result=Path("currencies.json")),
+    )
+    monkeypatch.setattr(
+        "utils.price_loader.build_price_map",
+        lambda path: {},
+    )
+
+    mod = importlib.import_module("app")
+    importlib.reload(mod)
+    mod.app.secret_key = "test"
+    return mod.app

--- a/tests/test_constants_api.py
+++ b/tests/test_constants_api.py
@@ -1,11 +1,13 @@
 from utils import constants
+import pytest
 
 
-def test_api_constants_route(app):
-    client = app.test_client()
-    resp = client.get("/api/constants")
+@pytest.mark.asyncio
+async def test_api_constants_route(test_app):
+    client = test_app.test_client()
+    resp = await client.get("/api/constants")
     assert resp.status_code == 200
-    data = resp.get_json()
+    data = await resp.get_json()
     assert data["paint_colors"]["3100495"][0] == "A Color Similar to Slate"
     assert data["sheen_names"]["1"] == constants.SHEEN_NAMES[1]
     assert (

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -1,7 +1,10 @@
 import importlib
 
+import pytest
 
-def test_get_home_displays_preloaded_user(app):
+
+@pytest.mark.asyncio
+async def test_get_home_displays_preloaded_user(test_app):
     mod = importlib.import_module("app")
     user = mod.normalize_user_payload(
         {
@@ -13,34 +16,37 @@ def test_get_home_displays_preloaded_user(app):
             "items": [],
         }
     )
-    app.config["PRELOADED_USERS"] = [user]
-    app.config["TEST_STEAMID"] = "1"
-    client = app.test_client()
-    resp = client.get("/")
+    test_app.config["PRELOADED_USERS"] = [user]
+    test_app.config["TEST_STEAMID"] = "1"
+    client = test_app.test_client()
+    resp = await client.get("/")
     assert resp.status_code == 200
-    html = resp.get_data(as_text=True)
+    html = await resp.get_data(as_text=True)
     assert 'id="user-1"' in html
 
 
-def test_post_invalid_ids_flash(app):
-    client = app.test_client()
-    resp = client.post("/", data={"steamids": "foobar"})
+@pytest.mark.asyncio
+async def test_post_invalid_ids_flash(test_app):
+    client = test_app.test_client()
+    resp = await client.post("/", data={"steamids": "foobar"})
     assert resp.status_code == 200
-    html = resp.get_data(as_text=True)
+    html = await resp.get_data(as_text=True)
     assert "No valid Steam IDs found!" in html
 
 
-def test_post_valid_ids_sets_initial_ids(app):
-    client = app.test_client()
+@pytest.mark.asyncio
+async def test_post_valid_ids_sets_initial_ids(test_app):
+    client = test_app.test_client()
     steamid = "76561198034301681"
-    resp = client.post("/", data={"steamids": steamid})
+    resp = await client.post("/", data={"steamids": steamid})
     assert resp.status_code == 200
-    html = resp.get_data(as_text=True)
+    html = await resp.get_data(as_text=True)
     assert steamid in html
     assert "window.initialIds" in html
 
 
-def test_hidden_items_not_rendered(app):
+@pytest.mark.asyncio
+async def test_hidden_items_not_rendered(test_app):
     mod = importlib.import_module("app")
     user = mod.normalize_user_payload(
         {
@@ -55,11 +61,11 @@ def test_hidden_items_not_rendered(app):
             ],
         }
     )
-    app.config["PRELOADED_USERS"] = [user]
-    app.config["TEST_STEAMID"] = "1"
-    client = app.test_client()
-    resp = client.get("/")
+    test_app.config["PRELOADED_USERS"] = [user]
+    test_app.config["TEST_STEAMID"] = "1"
+    client = test_app.test_client()
+    resp = await client.get("/")
     assert resp.status_code == 200
-    html = resp.get_data(as_text=True)
+    html = await resp.get_data(as_text=True)
     assert "Visible" in html
     assert "Hid" not in html


### PR DESCRIPTION
## Summary
- update test requirements
- support async Quart tests via new `test_app` fixture
- mark route tests as async

## Testing
- `pre-commit run --files requirements-test.txt tests/conftest.py tests/test_flask_routes.py tests/test_constants_api.py` *(fails: RuntimeError: This event loop is already running)*

------
https://chatgpt.com/codex/tasks/task_e_686ee1826fc483268503606760ed721f