### PR TITLE
Implement async inventory fetch

### DIFF
--- a/static/retry.js
+++ b/static/retry.js
@@ -23,24 +23,34 @@ function hideScanToast() {
   setTimeout(() => toast.classList.add('hidden'), 300);
 }
 
-function retryInventory(id) {
-  let card = document.getElementById('user-' + id);
-  if (card) {
-    card.classList.remove('failed', 'success');
-    card.classList.add('loading');
-  } else {
-    card = document.createElement('div');
-    card.id = 'user-' + id;
-    card.dataset.steamid = id;
-    card.className = 'user-card user-box loading';
-    document.getElementById('user-container').appendChild(card);
-  }
+function showToast(message) {
+  const toast = document.getElementById('scan-toast');
+  if (!toast) return;
+  toast.textContent = message;
+  toast.classList.remove('hidden');
+  toast.classList.add('show');
+  setTimeout(() => {
+    toast.classList.remove('show');
+    setTimeout(() => toast.classList.add('hidden'), 300);
+  }, 3000);
+}
 
-  const pill = card.querySelector('.status-pill');
-  if (pill) {
-    pill.innerHTML = '<i class="fa-solid fa-arrows-rotate fa-spin"></i>';
-  }
+function showLoadingCard(id) {
+  const container = document.getElementById('user-container');
+  if (!container) return;
+  if (document.getElementById('loading-' + id)) return;
+  const placeholder = document.createElement('div');
+  placeholder.id = 'loading-' + id;
+  placeholder.dataset.steamid = id;
+  placeholder.className = 'user-card user-box loading';
+  placeholder.innerHTML =
+    '<div class="user-header"><span class="pill status-pill"><i class="fa-solid fa-arrows-rotate fa-spin"></i></span></div>';
+  container.appendChild(placeholder);
+}
 
+function fetchAndInsertSingle(id) {
+  const placeholder =
+    document.getElementById('loading-' + id) || document.getElementById('user-' + id);
   return fetch('/retry/' + id, { method: 'POST' })
     .then(r => r.text())
     .then(html => {
@@ -48,20 +58,42 @@ function retryInventory(id) {
       wrapper.innerHTML = html;
       const newCard = wrapper.firstElementChild;
       if (newCard) {
-        card.replaceWith(newCard);
+        if (placeholder) {
+          placeholder.replaceWith(newCard);
+        } else {
+          document.getElementById('user-container').appendChild(newCard);
+        }
       }
       attachHandlers();
       updateRefreshButton();
       showResults();
     })
     .catch(() => {
-      const existing = document.getElementById('user-' + id);
+      const existing = placeholder;
       if (existing) {
         existing.classList.remove('loading');
         existing.classList.add('failed');
+        existing.id = 'user-' + id;
       }
+      showToast('Failed to load inventory');
       updateRefreshButton();
     });
+}
+
+function retryInventory(id) {
+  let card = document.getElementById('user-' + id);
+  if (card) {
+    card.classList.remove('failed', 'success');
+    card.classList.add('loading');
+    const pill = card.querySelector('.status-pill');
+    if (pill) {
+      pill.innerHTML = '<i class="fa-solid fa-arrows-rotate fa-spin"></i>';
+    }
+  } else {
+    showLoadingCard(id);
+    card = document.getElementById('loading-' + id);
+  }
+  fetchAndInsertSingle(id);
 }
 
 function updateRefreshButton() {
@@ -107,41 +139,17 @@ function refreshAll() {
 
 function loadUsers(ids) {
   if (!ids || !ids.length) return Promise.resolve();
-  const container = document.getElementById('user-container');
+  const promises = [];
   ids.forEach(id => {
-    if (!document.getElementById('user-' + id)) {
-      const placeholder = document.createElement('div');
-      placeholder.id = 'user-' + id;
-      placeholder.dataset.steamid = id;
-      placeholder.className = 'user-card user-box loading';
-      container.appendChild(placeholder);
+    if (
+      !document.getElementById('user-' + id) &&
+      !document.getElementById('loading-' + id)
+    ) {
+      showLoadingCard(id);
     }
+    promises.push(fetchAndInsertSingle(id));
   });
-  updateScanToast(1, ids.length);
-  return fetch('/fetch_batch', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ ids })
-  })
-    .then(r => r.json())
-    .then(data => {
-      (data.results || []).forEach(res => {
-        const wrapper = document.createElement('div');
-        wrapper.innerHTML = res.html;
-        const card = wrapper.firstElementChild;
-        if (!card) return;
-        const existing = document.getElementById('user-' + res.steamid);
-        if (existing) {
-          existing.replaceWith(card);
-        } else {
-          container.appendChild(card);
-        }
-      });
-      attachHandlers();
-      updateRefreshButton();
-      showResults();
-    })
-    .finally(() => hideScanToast());
+  return Promise.all(promises);
 }
 
 function showResults() {

--- a/templates/_user.html
+++ b/templates/_user.html
@@ -2,7 +2,7 @@
   <div class="user-header">
     <div class="user-profile">
       <a href="{{ user.profile }}" target="_blank" class="avatar-link">
-        <img src="{{ user.avatar }}" alt="Avatar" class="profile-pic" />
+        <img src="{{ user.avatar }}" alt="Avatar" class="profile-pic" loading="lazy" />
       </a>
       <div class="profile-details">
         <div class="username">{{ user.username }}</div>
@@ -10,7 +10,7 @@
         <div class="profile-link">
           <a href="https://next.backpack.tf/profiles/{{ user.steamid }}" class="backpack-link" target="_blank" rel="noopener">
             Backpack.tf
-            <img src="/static/images/logos/bptf_small.PNG" alt="Backpack.tf" class="inline-icon" />
+            <img src="/static/images/logos/bptf_small.PNG" alt="Backpack.tf" class="inline-icon" loading="lazy" />
           </a>
         </div>
       </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -127,7 +127,7 @@
       </div>
       <div class="modal-body">
         <div id="modal-effect-bg" class="particle-overlay"></div>
-        <img id="modal-img" src="" width="64" height="64" alt="">
+        <img id="modal-img" src="" width="64" height="64" alt="" loading="lazy">
         <div id="modal-details"></div>
       </div>
     </dialog>
@@ -137,7 +137,7 @@
       <p class="attribution">
         Pricing and particles provided by
         <a href="https://backpack.tf" target="_blank" rel="noopener" class="bptf-link">
-          Backpack.tf <img src="/static/images/logos/bptf_small.PNG" alt="Backpack.tf logo" class="footer-icon">
+          Backpack.tf <img src="/static/images/logos/bptf_small.PNG" alt="Backpack.tf logo" class="footer-icon" loading="lazy">
         </a>
       </p>
 

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -15,10 +15,10 @@
     <span class="item-qty">x{{ item.quantity }}</span>
   {% endif %}
   {% if item.unusual_effect_id %}
-    <img class="particle-bg" src="/static/images/effects/{{ item.unusual_effect_id }}.png" alt="effect">
+    <img class="particle-bg" src="/static/images/effects/{{ item.unusual_effect_id }}.png" alt="effect" loading="lazy">
   {% endif %}
   {% if item.image_url %}
-    <img class="item-img" src="{{ item.image_url }}" alt="{{ item.display_name }}" width="64" height="64" onerror="this.style.display='none';">
+    <img class="item-img" src="{{ item.image_url }}" alt="{{ item.display_name }}" width="64" height="64" loading="lazy" onerror="this.style.display='none';">
   {% else %}
     <div class="missing-icon"></div>
   {% endif %}


### PR DESCRIPTION
## Summary
- fetch user inventories one at a time using `/retry/<steamid>`
- add loading placeholders and error toast logic
- lazy-load all images

## Testing
- `pre-commit run --files static/retry.js templates/_user.html templates/index.html templates/item_card.html` *(fails: ModuleNotFoundError and runtime errors)*

------
https://chatgpt.com/codex/tasks/task_e_686ee80c6d6483269a6a2543eccde2d6