### PR TITLE
Enable lazy loading for scan form

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -96,7 +96,7 @@
             </ul>
         {% endif %}
     {% endwith %}
-    <form method="post" class="input-form">
+    <form id="scan-form" method="post" class="input-form">
         <label for="steamids" class="visually-hidden">Steam IDs</label>
         <div class="input-wrapper">
             <i class="fa-brands fa-steam input-steam-icon"></i>


### PR DESCRIPTION
## Summary
- add `scan-form` id to the main form
- hook new form submit handler in `retry.js`
- parse Steam IDs client-side and fetch inventories asynchronously

## Testing
- `pre-commit run --files templates/index.html static/retry.js` *(fails: LookupError ContextVar, event loop running)*

------
https://chatgpt.com/codex/tasks/task_e_686eea6378f88326af40dc297f5db12f