### PR TITLE
Add session flag support

### DIFF
--- a/app.py
+++ b/app.py
@@ -414,18 +414,21 @@ async def index():
         ids = [await sac.convert_to_steam64(t) for t in raw_ids]
         print(f"Parsed {len(ids)} valid IDs, {len(invalid)} tokens ignored")
         if not ids:
-            flash("No valid Steam IDs found!")
+            if USE_SESSIONS:
+                flash("No valid Steam IDs found!")
             return await render_template(
                 "index.html",
                 users=users,
                 steamids=steamids_input,
                 ids=[],
+                use_sessions=USE_SESSIONS,
             )
     return await render_template(
         "index.html",
         users=users,
         steamids=steamids_input,
         ids=ids,
+        use_sessions=USE_SESSIONS,
         debug_ms=MAX_MERGE_MS if os.getenv("FLASK_DEBUG") else None,
     )
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -89,13 +89,15 @@
     <div class="page-container">
     <main class="content-wrap">
     <h1>TF2 Inventory Checker</h1>
-    {% with msgs = get_flashed_messages() %}
-        {% if msgs %}
-            <ul class="flash">
-            {% for m in msgs %}<li>{{ m }}</li>{% endfor %}
-            </ul>
-        {% endif %}
-    {% endwith %}
+    {% if use_sessions %}
+        {% with msgs = get_flashed_messages() %}
+            {% if msgs %}
+                <ul class="flash">
+                {% for m in msgs %}<li>{{ m }}</li>{% endfor %}
+                </ul>
+            {% endif %}
+        {% endwith %}
+    {% endif %}
     <form id="scan-form" method="post" class="input-form">
         <label for="steamids" class="visually-hidden">Steam IDs</label>
         <div class="input-wrapper">

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import importlib
 import asyncio
 
 import pytest
+import pytest_asyncio
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -14,6 +15,7 @@ def app(monkeypatch):
 
     monkeypatch.setenv("STEAM_API_KEY", "x")
     monkeypatch.setenv("BPTF_API_KEY", "x")
+    monkeypatch.setenv("USE_SESSIONS", "true")
     monkeypatch.setattr("utils.local_data.load_files", lambda *a, **k: ({}, {}))
     monkeypatch.setattr(
         "utils.price_loader.ensure_prices_cached",
@@ -34,15 +36,13 @@ def app(monkeypatch):
     return mod.app
 
 
-import pytest_asyncio
-
-
 @pytest_asyncio.fixture
 async def test_app(monkeypatch):
     """Return Quart app with env and schema mocks."""
 
     monkeypatch.setenv("STEAM_API_KEY", "x")
     monkeypatch.setenv("BPTF_API_KEY", "x")
+    monkeypatch.setenv("USE_SESSIONS", "true")
     monkeypatch.setattr("utils.local_data.load_files", lambda *a, **k: ({}, {}))
     monkeypatch.setattr(
         "utils.price_loader.ensure_prices_cached",


### PR DESCRIPTION
## Summary
- guard flash message logic behind USE_SESSIONS
- expose `use_sessions` flag to templates
- update tests to enable sessions when reloading the app

## Testing
- `pre-commit run --files app.py tests/conftest.py templates/index.html` *(fails: Missing cache files and bs4 module errors)*
- `pytest tests/test_flask_routes.py::test_post_invalid_ids_flash -q` *(fails: event loop running)*

------
https://chatgpt.com/codex/tasks/task_e_686ef0fa54a083268a6802ab55800f0d