### PR TITLE
Throttle bulk inventory refresh

### DIFF
--- a/static/retry.js
+++ b/static/retry.js
@@ -188,17 +188,15 @@ function refreshAll() {
   });
 }
 
-function loadUsers(ids) {
-  if (!ids || !ids.length) return Promise.resolve();
-  const promises = [];
-  ids.forEach(id => {
+async function loadUsers(ids) {
+  if (!ids || !ids.length) return;
+  for (const id of ids) {
     applyLoadingState(id);
-    promises.push(fetchAndInsertSingle(id));
-  });
-  updateRefreshButton();
-  return Promise.all(promises).then(() => {
-    showResults();
-  });
+    updateRefreshButton();
+    await fetchAndInsertSingle(id);
+    await new Promise(res => setTimeout(res, 150));
+  }
+  showResults();
 }
 
 function handleScanSubmit(e) {


### PR DESCRIPTION
## Summary
- space out inventory retry requests to avoid mass failures

## Testing
- `SKIP_VALIDATE=1 STEAM_API_KEY=test pytest` *(fails: LookupError quart.request_ctx)*
- `SKIP_VALIDATE=1 pre-commit run --files static/retry.js` *(fails: multiple tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_686efdd23f34832692cc8dee1839b97c