### PR TITLE
Handle lowercase SteamID3

### DIFF
--- a/static/retry.js
+++ b/static/retry.js
@@ -69,12 +69,12 @@ function convertToSteam64(id) {
       }
     }
   }
-  let m = id.match(/^\[U:(\d+):(\d+)\]$/);
+  let m = id.match(/^\[U:(\d+):(\d+)\]$/i);
   if (m) {
     const z = parseInt(m[2], 10);
     if (!Number.isNaN(z)) return String(z + 76561197960265728);
   }
-  m = id.match(/^\[U:1:(\d+)\]$/);
+  m = id.match(/^\[U:1:(\d+)\]$/i);
   if (m) {
     const z = parseInt(m[1], 10);
     if (!Number.isNaN(z)) return String(z + 76561197960265728);

--- a/tests/test_utils_extras.py
+++ b/tests/test_utils_extras.py
@@ -8,6 +8,7 @@ import pytest
 def test_convert_to_steam64():
     assert asyncio.run(sac.convert_to_steam64("STEAM_0:1:4")) == "76561197960265737"
     assert asyncio.run(sac.convert_to_steam64("[U:1:4]")) == "76561197960265732"
+    assert asyncio.run(sac.convert_to_steam64("[u:1:4]")) == "76561197960265732"
 
 
 @pytest.fixture(autouse=True)

--- a/utils/steam_api_client.py
+++ b/utils/steam_api_client.py
@@ -141,12 +141,12 @@ async def convert_to_steam64(id_str: str) -> str:
         account_id = z * 2 + y
         return str(account_id + 76561197960265728)
 
-    if id_str.startswith("[U:"):
-        match = re.match(r"\[U:(\d+):(\d+)\]", id_str)
+    if id_str.upper().startswith("[U:"):
+        match = re.match(r"\[U:(\d+):(\d+)\]", id_str, re.IGNORECASE)
         if match:
             z = int(match.group(2))
             return str(z + 76561197960265728)
-        match = re.match(r"\[U:1:(\d+)\]", id_str)
+        match = re.match(r"\[U:1:(\d+)\]", id_str, re.IGNORECASE)
         if match:
             z = int(match.group(1))
             return str(z + 76561197960265728)


### PR DESCRIPTION
## Summary
- fix SteamID64 conversion for lowercase `[u:...]`
- mirror case-insensitive matching in client `retry.js`
- test lowercase ID3 conversion works

## Testing
- `pre-commit run --files utils/steam_api_client.py static/retry.js tests/test_utils_extras.py` *(fails: LookupError, ClientConnectorError)*

------
https://chatgpt.com/codex/tasks/task_e_686f04be91d083268f54a44ab2420a16