### PR TITLE
Improve Steam ID extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Coverage and CI badges in the README.
 - SchemaProvider class for fetching schema properties.
 - Paintkits endpoint cached as `warpaints.json`.
+- Strict Steam ID extraction that filters invalid tokens.
 
 ### Changed
 - Updated schema caching logic and UI (previous releases).

--- a/tests/test_id_parser.py
+++ b/tests/test_id_parser.py
@@ -1,9 +1,26 @@
-import asyncio
-import utils.steam_api_client as sac
+import pytest
 from utils.id_parser import extract_steam_ids
 
 
-def test_extract_ids_from_status_block(monkeypatch):
+def test_extract_ids_from_mixed_input():
+    text = """
+    #    354 "AnonyMouse"        [U:1:1110742403]
+    76561198881990960
+    STEAM_0:0:88939219
+    somename
+    [U:1:99950348]
+    anotherusername
+    """
+    ids = extract_steam_ids(text)
+    assert ids == [
+        "[U:1:1110742403]",
+        "76561198881990960",
+        "STEAM_0:0:88939219",
+        "[U:1:99950348]",
+    ]
+
+
+def test_extract_ids_from_status_block():
     text = """
     hostname: my tf2 server
     version : 123
@@ -12,41 +29,9 @@ def test_extract_ids_from_status_block(monkeypatch):
     #   315 "Tester" [U:1:1137042230] 01:11 88 0 active
     #   316 "Short" [U:1:2] 00:01 50 0 active
     """
-
     ids = extract_steam_ids(text)
-
-    assert "Xanmangamer" in ids
-    assert "Tester" in ids
-    assert "Short" in ids
-
-    mapping = {
-        "[U:1:876151635]": "76561198836417363",
-        "[U:1:1137042230]": "76561199097307958",
-        "[U:1:2]": "76561197960265730",
-        "Xanmangamer": "76561198000000001",
-        "Tester": "76561198000000002",
-        "Short": "76561198000000003",
-    }
-
-    async def fake_convert(id_str: str) -> str:
-        if id_str in mapping:
-            return mapping[id_str]
-        raise ValueError(id_str)
-
-    monkeypatch.setattr(sac, "convert_to_steam64", fake_convert)
-
-    steam64 = []
-    for i in ids:
-        try:
-            steam64.append(asyncio.run(sac.convert_to_steam64(i)))
-        except ValueError:
-            continue
-
-    assert steam64 == [
-        mapping["Xanmangamer"],
-        mapping["[U:1:876151635]"],
-        mapping["Tester"],
-        mapping["[U:1:1137042230]"],
-        mapping["Short"],
-        mapping["[U:1:2]"],
+    assert ids == [
+        "[U:1:876151635]",
+        "[U:1:1137042230]",
+        "[U:1:2]",
     ]

--- a/utils/id_parser.py
+++ b/utils/id_parser.py
@@ -7,23 +7,23 @@ STEAMID64_RE = re.compile(r"\b\d{17}\b")
 
 
 def extract_steam_ids(raw_text: str) -> List[str]:
-    """Extract potential SteamID tokens from free-form text.
+    """Return valid SteamID tokens found in ``raw_text``.
 
-    The function splits the input on whitespace and returns unique tokens in the
-    order encountered. Tokens matching ``STEAMID2``, ``STEAMID3`` or
-    ``STEAMID64`` patterns are kept, but any other non-empty strings are also
-    returned so they may be resolved as vanity URLs later.
+    The function scans the input for SteamID64, SteamID2 and SteamID3 patterns
+    and returns them in the order encountered, skipping any other text. Duplicate
+    IDs are removed while preserving first occurrence order.
     """
 
-    tokens = re.split(r"\s+", raw_text.strip())
+    pattern = re.compile(
+        r"(STEAM_0:[01]:\d+|\[U:1:\d+\]|\b7656119\d{10}\b)", re.IGNORECASE
+    )
     ids: List[str] = []
     seen: set[str] = set()
 
-    for token in tokens:
-        token = token.strip('"')
-        if not token:
-            continue
+    for match in pattern.finditer(raw_text):
+        token = match.group(0)
         if token not in seen:
             seen.add(token)
             ids.append(token)
+
     return ids


### PR DESCRIPTION
## Summary
- narrow steam ID parsing to valid SteamID64/2/3 tokens
- adjust tests to match stricter parsing rules
- document change in changelog

## Testing
- `pre-commit run --files utils/id_parser.py tests/test_id_parser.py CHANGELOG.md` *(fails: RuntimeError: This event loop is already running)*

------
https://chatgpt.com/codex/tasks/task_e_686f0a39c90c8326981cfb240572120c