### PR TITLE
Implement async SteamID extraction

### DIFF
--- a/tests/test_steam_api_client.py
+++ b/tests/test_steam_api_client.py
@@ -116,3 +116,51 @@ def test_get_tf2_playtime_hours(monkeypatch):
     monkeypatch.setattr(aiohttp, "ClientSession", lambda *a, **k: DummySession())
     hours = asyncio.run(sac.get_tf2_playtime_hours("1"))
     assert hours == 1.5
+
+
+def test_extract_steam_ids(monkeypatch):
+    async def fake_convert(token: str) -> str:
+        mapping = {
+            "STEAM_0:0:88939219": "76561198138144166",
+            "[U:1:1110742403]": "76561199071008131",
+            "[U:1:99950348]": "76561198060216076",
+            "foo": "76561198000000000",
+        }
+        return mapping.get(token, token)
+
+    monkeypatch.setattr(sac, "convert_to_steam64", fake_convert)
+
+    text = """
+    #    354 "AnonyMouse"        [U:1:1110742403]
+    76561198881990960
+    STEAM_0:0:88939219
+    somename
+    [U:1:99950348]
+    https://steamcommunity.com/id/foo
+    anotherusername
+    """
+
+    ids = asyncio.run(sac.extract_steam_ids(text, resolve_vanity=True))
+    assert ids == [
+        "76561199071008131",
+        "76561198881990960",
+        "76561198138144166",
+        "76561198060216076",
+        "76561198000000000",
+    ]
+
+
+def test_extract_steam_ids_skip_vanity(monkeypatch):
+    async def fake_convert(token: str) -> str:
+        mapping = {
+            "STEAM_0:1:1": "76561197960265731",
+            "[U:1:2]": "76561197960265730",
+            "foo": "76561198000000000",
+        }
+        return mapping.get(token, token)
+
+    monkeypatch.setattr(sac, "convert_to_steam64", fake_convert)
+
+    text = "STEAM_0:1:1 foo [U:1:2] https://steamcommunity.com/id/foo"
+    ids = asyncio.run(sac.extract_steam_ids(text))
+    assert ids == ["76561197960265731", "76561197960265730"]


### PR DESCRIPTION
## Summary
- add `extract_steam_ids` helper to `steam_api_client`
- test async parsing logic with vanity URL handling
- skip vanity URL conversion unless enabled

## Testing
- `ruff check utils/steam_api_client.py tests/test_steam_api_client.py`
- `pytest -q tests/test_steam_api_client.py`
- `pre-commit run --files utils/steam_api_client.py tests/test_steam_api_client.py` *(fails: ContextVar errors)*

------
https://chatgpt.com/codex/tasks/task_e_686f15448f3083269464d5f70b6f27b4