### PR TITLE
Fix scanning toast icon

### DIFF
--- a/static/retry.js
+++ b/static/retry.js
@@ -11,7 +11,7 @@ function appendCard(html) {
 function updateScanToast(current, total) {
   const toast = document.getElementById('scan-toast');
   if (!toast) return;
-  toast.textContent = `\u{1F504} Scanning ${current} of ${total} inventories...`;
+  toast.innerHTML = `<i class="fa-solid fa-arrows-rotate fa-spin"></i> Scanning ${current} of ${total} inventories...`;
   toast.classList.remove('hidden');
   toast.classList.add('show');
 }


### PR DESCRIPTION
## Summary
- use `innerHTML` to show spinner icon in scan toast

## Testing
- `pre-commit run --files static/retry.js` *(fails: `RuntimeError` in pytest)*

------
https://chatgpt.com/codex/tasks/task_e_686f752b1e9083269a99c42ffa969a3f