### PR TITLE
Normalize Steam IDs to SteamID64

### DIFF
--- a/app.py
+++ b/app.py
@@ -409,9 +409,11 @@ async def index():
         form = await request.form
         steamids_input = form.get("steamids", "")
         tokens = re.split(r"\s+", steamids_input.strip())
-        raw_ids = extract_steam_ids(steamids_input)
-        invalid = [t for t in tokens if t and t not in raw_ids]
-        ids = [await sac.convert_to_steam64(t) for t in raw_ids]
+        ids = extract_steam_ids(steamids_input)
+        pattern = re.compile(
+            r"^(STEAM_0:[01]:\d+|\[U:1:\d+\]|7656119\d{10})$", re.IGNORECASE
+        )
+        invalid = [t for t in tokens if t and not pattern.fullmatch(t)]
         print(f"Parsed {len(ids)} valid IDs, {len(invalid)} tokens ignored")
         if not ids:
             if USE_SESSIONS:

--- a/tests/test_id_parser.py
+++ b/tests/test_id_parser.py
@@ -1,4 +1,3 @@
-import pytest
 from utils.id_parser import extract_steam_ids
 
 
@@ -13,10 +12,10 @@ def test_extract_ids_from_mixed_input():
     """
     ids = extract_steam_ids(text)
     assert ids == [
-        "[U:1:1110742403]",
+        "76561199071008131",
         "76561198881990960",
-        "STEAM_0:0:88939219",
-        "[U:1:99950348]",
+        "76561198138144166",
+        "76561198060216076",
     ]
 
 
@@ -31,7 +30,7 @@ def test_extract_ids_from_status_block():
     """
     ids = extract_steam_ids(text)
     assert ids == [
-        "[U:1:876151635]",
-        "[U:1:1137042230]",
-        "[U:1:2]",
+        "76561198836417363",
+        "76561199097307958",
+        "76561197960265730",
     ]

--- a/utils/id_parser.py
+++ b/utils/id_parser.py
@@ -6,12 +6,58 @@ STEAMID3_RE = re.compile(r"\[U:1:\d+\]")
 STEAMID64_RE = re.compile(r"\b\d{17}\b")
 
 
-def extract_steam_ids(raw_text: str) -> List[str]:
-    """Return valid SteamID tokens found in ``raw_text``.
+def convert_to_steam64(token: str) -> str:
+    """Convert a SteamID token to ``SteamID64``.
 
-    The function scans the input for SteamID64, SteamID2 and SteamID3 patterns
-    and returns them in the order encountered, skipping any other text. Duplicate
-    IDs are removed while preserving first occurrence order.
+    Parameters
+    ----------
+    token:
+        SteamID in ``SteamID64``, ``SteamID2`` or ``SteamID3`` format.
+
+    Returns
+    -------
+    str
+        The normalized ``SteamID64`` value.
+
+    Raises
+    ------
+    ValueError
+        If ``token`` is malformed or unsupported.
+    """
+
+    if STEAMID64_RE.fullmatch(token):
+        return token
+
+    if token.startswith("STEAM_"):
+        try:
+            _, y, z = token.split(":")
+            y = int(y.split("_")[1]) if "_" in y else int(y)
+            z = int(z)
+        except (ValueError, IndexError) as exc:
+            raise ValueError(f"Invalid SteamID2: {token}") from exc
+        account_id = z * 2 + y
+        return str(account_id + 76561197960265728)
+
+    if token.upper().startswith("[U:"):
+        match = re.match(r"\[U:(\d+):(\d+)\]", token, re.IGNORECASE)
+        if match:
+            z = int(match.group(2))
+            return str(z + 76561197960265728)
+        match = re.match(r"\[U:1:(\d+)\]", token, re.IGNORECASE)
+        if match:
+            z = int(match.group(1))
+            return str(z + 76561197960265728)
+        raise ValueError(f"Invalid SteamID3: {token}")
+
+    raise ValueError(f"Unrecognized SteamID token: {token}")
+
+
+def extract_steam_ids(raw_text: str) -> List[str]:
+    """Return unique ``SteamID64`` values parsed from ``raw_text``.
+
+    The function scans ``raw_text`` for ``SteamID64``, ``SteamID2`` and
+    ``SteamID3`` tokens and converts each match to ``SteamID64``. Duplicate IDs
+    are removed while preserving the first occurrence order.
     """
 
     pattern = re.compile(
@@ -22,8 +68,12 @@ def extract_steam_ids(raw_text: str) -> List[str]:
 
     for match in pattern.finditer(raw_text):
         token = match.group(0)
-        if token not in seen:
-            seen.add(token)
-            ids.append(token)
+        try:
+            sid = convert_to_steam64(token)
+        except ValueError:
+            continue
+        if sid not in seen:
+            seen.add(sid)
+            ids.append(sid)
 
     return ids


### PR DESCRIPTION
## Summary
- ensure ID parsing always normalizes tokens to SteamID64
- reflect new logic in web form handler
- update parser tests accordingly

## Testing
- `pre-commit run --files tests/test_id_parser.py utils/id_parser.py app.py` *(fails: LookupError / RuntimeError)*

------
https://chatgpt.com/codex/tasks/task_e_686f6f503aec83269f2416fe3d06970b