### PR TITLE
Improve Steam ID extraction

### DIFF
--- a/tests/test_id_parser.py
+++ b/tests/test_id_parser.py
@@ -34,3 +34,15 @@ def test_extract_ids_from_status_block():
         "76561199097307958",
         "76561197960265730",
     ]
+
+
+def test_extract_ids_with_embedded_tokens():
+    text = (
+        "Yyffjjuggv [U:1:86514219]. Bbbkiiyccc "
+        '# 2 "Player" STEAM_0:0:12345678 00:03 50 0 active'
+    )
+    ids = extract_steam_ids(text)
+    assert ids == [
+        "76561198046779947",
+        "76561197984957084",
+    ]

--- a/utils/id_parser.py
+++ b/utils/id_parser.py
@@ -1,8 +1,8 @@
 import re
 from typing import List
 
-STEAMID2_RE = re.compile(r"STEAM_0:[01]:\d+")
-STEAMID3_RE = re.compile(r"\[U:1:\d+\]")
+STEAMID2_RE = re.compile(r"STEAM_0:[01]:\d+", re.IGNORECASE)
+STEAMID3_RE = re.compile(r"\[U:[01]:\d+\]", re.IGNORECASE)
 STEAMID64_RE = re.compile(r"\b\d{17}\b")
 
 
@@ -61,7 +61,8 @@ def extract_steam_ids(raw_text: str) -> List[str]:
     """
 
     pattern = re.compile(
-        r"(STEAM_0:[01]:\d+|\[U:1:\d+\]|\b7656119\d{10}\b)", re.IGNORECASE
+        r"(STEAM_0:[01]:\d+|\[U:[01]:\d+\]|\b7656119\d{10}\b)",
+        re.IGNORECASE,
     )
     ids: List[str] = []
     seen: set[str] = set()

--- a/utils/steam_api_client.py
+++ b/utils/steam_api_client.py
@@ -179,7 +179,7 @@ async def extract_steam_ids(raw_text: str, resolve_vanity: bool = False) -> List
     import re
 
     pattern = re.compile(
-        r"(STEAM_0:[01]:\d+|\[U:1:\d+\]|\b7656119\d{10}\b|https?://steamcommunity\.com/(?:profiles/\d{17}|id/[A-Za-z0-9_-]+))",
+        r"(STEAM_0:[01]:\d+|\[U:[01]:\d+\]|\b7656119\d{10}\b|https?://steamcommunity\.com/(?:profiles/\d{17}|id/[A-Za-z0-9_-]+))",
         re.IGNORECASE,
     )
 


### PR DESCRIPTION
## Summary
- broaden regex for ID3 tokens
- update extractor pattern for text containing surrounding characters
- keep server client pattern in sync
- test capturing IDs inside chat text

## Testing
- `ruff check utils/id_parser.py utils/steam_api_client.py tests/test_id_parser.py`
- `pytest tests/test_id_parser.py tests/test_steam_api_client.py::test_extract_steam_ids tests/test_steam_api_client.py::test_extract_steam_ids_skip_vanity` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*
- `pre-commit run --files utils/id_parser.py utils/steam_api_client.py tests/test_id_parser.py tests/test_steam_api_client.py` *(fails: No module named 'vdf')*

------
https://chatgpt.com/codex/tasks/task_e_686f7f7265d08326bca7a0a1789514af