### PR TITLE
Fix extract_steam_ids for embedded IDs

### DIFF
--- a/tests/test_id_parser.py
+++ b/tests/test_id_parser.py
@@ -46,3 +46,12 @@ def test_extract_ids_with_embedded_tokens():
         "76561198046779947",
         "76561197984957084",
     ]
+
+
+def test_extract_ids_multiple_embedded_tokens():
+    text = "Yyffjiu[U:1:368017243]ggv [U:1:322607312]  Bbbkiiyccc"
+    ids = extract_steam_ids(text)
+    assert ids == [
+        "76561198328282971",
+        "76561198282873040",
+    ]

--- a/utils/id_parser.py
+++ b/utils/id_parser.py
@@ -61,14 +61,13 @@ def extract_steam_ids(raw_text: str) -> List[str]:
     """
 
     pattern = re.compile(
-        r"(STEAM_0:[01]:\d+|\[U:[01]:\d+\]|\b7656119\d{10}\b)",
+        rf"({STEAMID2_RE.pattern}|{STEAMID3_RE.pattern}|{STEAMID64_RE.pattern})",
         re.IGNORECASE,
     )
     ids: List[str] = []
     seen: set[str] = set()
 
-    for match in pattern.finditer(raw_text):
-        token = match.group(0)
+    for token in pattern.findall(raw_text):
         try:
             sid = convert_to_steam64(token)
         except ValueError:


### PR DESCRIPTION
## Summary
- ensure regex finds all embedded Steam IDs
- test multiple embedded Steam ID tokens

## Testing
- `pre-commit run --files utils/id_parser.py tests/test_id_parser.py` *(fails: ModuleNotFoundError: No module named 'quart')*

------
https://chatgpt.com/codex/tasks/task_e_686f8250e938832696f70c876817a70f