### PR TITLE
Simplify ID parsing

### DIFF
--- a/tests/test_steam_api_client.py
+++ b/tests/test_steam_api_client.py
@@ -174,3 +174,13 @@ def test_extract_steam_ids_with_vanity(monkeypatch):
     text = "STEAM_0:1:1 foo [U:1:2] https://steamcommunity.com/id/foo"
     ids = asyncio.run(sac.extract_steam_ids(text))
     assert ids == ["76561197960265731", "76561197960265730", "76561198000000000"]
+
+
+def test_extract_ids_status_sebektam():
+    text = """
+    hostname: s
+    # userid name uniqueid connected ping loss state
+    #   1 \"Sebektam\" [U:1:921725235] 00:01 50 0 active
+    """
+    ids = asyncio.run(sac.extract_steam_ids(text))
+    assert ids == ["76561198881990963"]


### PR DESCRIPTION
## Summary
- extract Steam IDs for entire text in one call
- track invalid tokens after normalization
- await Quart `flash`
- test Sebektam status parsing

## Testing
- `black app.py tests/test_steam_api_client.py`
- `ruff check app.py tests/test_steam_api_client.py`
- `PYTHONPATH=. python scripts/validate_attributes.py`
- `STEAM_API_KEY=test pytest tests/test_steam_api_client.py::test_extract_ids_status_sebektam -q`


------
https://chatgpt.com/codex/tasks/task_e_686fa030773c8326a13ad141da66fd62