### PR TITLE
Refactor SteamID parser

### DIFF
--- a/tests/test_id_parser.py
+++ b/tests/test_id_parser.py
@@ -1,4 +1,5 @@
-from utils.id_parser import extract_steam_ids
+import asyncio
+from utils import steam_api_client as sac
 
 
 def test_extract_ids_from_mixed_input():
@@ -10,7 +11,7 @@ def test_extract_ids_from_mixed_input():
     [U:1:99950348]
     anotherusername
     """
-    ids = extract_steam_ids(text)
+    ids = asyncio.run(sac.extract_steam_ids(text))
     assert ids == [
         "76561199071008131",
         "76561198881990960",
@@ -28,7 +29,7 @@ def test_extract_ids_from_status_block():
     #   315 "Tester" [U:1:1137042230] 01:11 88 0 active
     #   316 "Short" [U:1:2] 00:01 50 0 active
     """
-    ids = extract_steam_ids(text)
+    ids = asyncio.run(sac.extract_steam_ids(text))
     assert ids == [
         "76561198836417363",
         "76561199097307958",
@@ -41,7 +42,7 @@ def test_extract_ids_with_embedded_tokens():
         "Yyffjjuggv [U:1:86514219]. Bbbkiiyccc "
         '# 2 "Player" STEAM_0:0:12345678 00:03 50 0 active'
     )
-    ids = extract_steam_ids(text)
+    ids = asyncio.run(sac.extract_steam_ids(text))
     assert ids == [
         "76561198046779947",
         "76561197984957084",
@@ -50,7 +51,7 @@ def test_extract_ids_with_embedded_tokens():
 
 def test_extract_ids_multiple_embedded_tokens():
     text = "Yyffjiu[U:1:368017243]ggv [U:1:322607312]  Bbbkiiyccc"
-    ids = extract_steam_ids(text)
+    ids = asyncio.run(sac.extract_steam_ids(text))
     assert ids == [
         "76561198328282971",
         "76561198282873040",

--- a/utils/id_parser.py
+++ b/utils/id_parser.py
@@ -1,81 +1,8 @@
-import re
-from typing import List
+"""Deprecated wrappers for Steam ID parsing.
 
-STEAMID2_RE = re.compile(r"STEAM_0:[01]:\d+", re.IGNORECASE)
-# Only accept "[U:1:<id>]" tokens from TF2 status output
-STEAMID3_RE = re.compile(r"\[U:1:\d+\]", re.IGNORECASE)
-STEAMID64_RE = re.compile(r"\b\d{17}\b")
+Use :mod:`utils.steam_api_client` for the canonical implementations.
+"""
 
+from .steam_api_client import convert_to_steam64, extract_steam_ids
 
-def convert_to_steam64(token: str) -> str:
-    """Convert a SteamID token to ``SteamID64``.
-
-    Parameters
-    ----------
-    token:
-        SteamID in ``SteamID64``, ``SteamID2`` or ``SteamID3`` format. ``SteamID3``
-        values must be in the ``[U:1:<id>]`` form.
-
-    Returns
-    -------
-    str
-        The normalized ``SteamID64`` value.
-
-    Raises
-    ------
-    ValueError
-        If ``token`` is malformed or unsupported.
-    """
-
-    if STEAMID64_RE.fullmatch(token):
-        return token
-
-    if token.startswith("STEAM_"):
-        try:
-            _, y, z = token.split(":")
-            y = int(y.split("_")[1]) if "_" in y else int(y)
-            z = int(z)
-        except (ValueError, IndexError) as exc:
-            raise ValueError(f"Invalid SteamID2: {token}") from exc
-        account_id = z * 2 + y
-        return str(account_id + 76561197960265728)
-
-    if token.upper().startswith("[U:"):
-        match = re.match(r"\[U:(\d+):(\d+)\]", token, re.IGNORECASE)
-        if match:
-            z = int(match.group(2))
-            return str(z + 76561197960265728)
-        match = re.match(r"\[U:1:(\d+)\]", token, re.IGNORECASE)
-        if match:
-            z = int(match.group(1))
-            return str(z + 76561197960265728)
-        raise ValueError(f"Invalid SteamID3: {token}")
-
-    raise ValueError(f"Unrecognized SteamID token: {token}")
-
-
-def extract_steam_ids(raw_text: str) -> List[str]:
-    """Return unique ``SteamID64`` values parsed from ``raw_text``.
-
-    The function scans ``raw_text`` for ``SteamID64``, ``SteamID2`` and
-    ``SteamID3`` tokens and converts each match to ``SteamID64``. Duplicate IDs
-    are removed while preserving the first occurrence order.
-    """
-
-    pattern = re.compile(
-        rf"({STEAMID2_RE.pattern}|{STEAMID3_RE.pattern}|{STEAMID64_RE.pattern})",
-        re.IGNORECASE,
-    )
-    ids: List[str] = []
-    seen: set[str] = set()
-
-    for token in pattern.findall(raw_text):
-        try:
-            sid = convert_to_steam64(token)
-        except ValueError:
-            continue
-        if sid not in seen:
-            seen.add(sid)
-            ids.append(sid)
-
-    return ids
+__all__ = ["convert_to_steam64", "extract_steam_ids"]


### PR DESCRIPTION
## Summary
- drop duplicate logic from `utils/id_parser`
- update `tests/test_id_parser.py` to use async parsing

## Testing
- `pre-commit run --files utils/id_parser.py tests/test_id_parser.py app.py utils/steam_api_client.py tests/test_steam_api_client.py tests/test_utils_extras.py` *(fails: LookupError <ContextVar name='quart.request_ctx'...)*

------
https://chatgpt.com/codex/tasks/task_e_686fa3b8591083268c84897045edf281