### PR TITLE
Switch to async test client

### DIFF
--- a/tests/test_constants_api.py
+++ b/tests/test_constants_api.py
@@ -1,19 +1,17 @@
 from utils import constants
-import asyncio
+import pytest
 
 
-def test_api_constants_route(async_client):
-    async def run():
-        resp = await async_client.get("/api/constants")
-        assert resp.status_code == 200
-        data = resp.get_json()
-        assert data["paint_colors"]["3100495"][0] == "A Color Similar to Slate"
-        assert data["sheen_names"]["1"] == constants.SHEEN_NAMES[1]
-        assert (
-            data["killstreak_sheen_colors"]["2"][0]
-            == constants.KILLSTREAK_SHEEN_COLORS[2][0]
-        )
-        assert data["killstreak_tiers"]["3"] == constants.KILLSTREAK_TIERS[3]
-        assert data["origin_map"]["0"] == constants.ORIGIN_MAP[0]
-
-    asyncio.run(run())
+@pytest.mark.asyncio
+async def test_api_constants_route(async_client):
+    resp = await async_client.get("/api/constants")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["paint_colors"]["3100495"][0] == "A Color Similar to Slate"
+    assert data["sheen_names"]["1"] == constants.SHEEN_NAMES[1]
+    assert (
+        data["killstreak_sheen_colors"]["2"][0]
+        == constants.KILLSTREAK_SHEEN_COLORS[2][0]
+    )
+    assert data["killstreak_tiers"]["3"] == constants.KILLSTREAK_TIERS[3]
+    assert data["origin_map"]["0"] == constants.ORIGIN_MAP[0]

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -1,8 +1,9 @@
 import importlib
-import asyncio
+import pytest
 
 
-def test_get_home_displays_preloaded_user(async_client, app):
+@pytest.mark.asyncio
+async def test_get_home_displays_preloaded_user(async_client, app):
     mod = importlib.import_module("app")
     user = mod.normalize_user_payload(
         {
@@ -17,38 +18,32 @@ def test_get_home_displays_preloaded_user(async_client, app):
     app.config["PRELOADED_USERS"] = [user]
     app.config["TEST_STEAMID"] = "1"
 
-    async def run():
-        resp = await async_client.get("/")
-        assert resp.status_code == 200
-        html = resp.get_data(as_text=True)
-        assert 'id="user-1"' in html
-
-    asyncio.run(run())
+    resp = await async_client.get("/")
+    assert resp.status_code == 200
+    html = resp.text
+    assert 'id="user-1"' in html
 
 
-def test_post_invalid_ids_flash(async_client):
-    async def run():
-        resp = await async_client.post("/", data={"steamids": "foobar"})
-        assert resp.status_code == 200
-        html = resp.get_data(as_text=True)
-        assert "No valid Steam IDs found!" in html
-
-    asyncio.run(run())
+@pytest.mark.asyncio
+async def test_post_invalid_ids_flash(async_client):
+    resp = await async_client.post("/", data={"steamids": "foobar"})
+    assert resp.status_code == 200
+    html = resp.text
+    assert "No valid Steam IDs found!" in html
 
 
-def test_post_valid_ids_sets_initial_ids(async_client):
-    async def run():
-        steamid = "76561198034301681"
-        resp = await async_client.post("/", data={"steamids": steamid})
-        assert resp.status_code == 200
-        html = resp.get_data(as_text=True)
-        assert steamid in html
-        assert "window.initialIds" in html
-
-    asyncio.run(run())
+@pytest.mark.asyncio
+async def test_post_valid_ids_sets_initial_ids(async_client):
+    steamid = "76561198034301681"
+    resp = await async_client.post("/", data={"steamids": steamid})
+    assert resp.status_code == 200
+    html = resp.text
+    assert steamid in html
+    assert "window.initialIds" in html
 
 
-def test_hidden_items_not_rendered(async_client, app):
+@pytest.mark.asyncio
+async def test_hidden_items_not_rendered(async_client, app):
     mod = importlib.import_module("app")
     user = mod.normalize_user_payload(
         {
@@ -66,11 +61,8 @@ def test_hidden_items_not_rendered(async_client, app):
     app.config["PRELOADED_USERS"] = [user]
     app.config["TEST_STEAMID"] = "1"
 
-    async def run():
-        resp = await async_client.get("/")
-        assert resp.status_code == 200
-        html = resp.get_data(as_text=True)
-        assert "Visible" in html
-        assert "Hid" not in html
-
-    asyncio.run(run())
+    resp = await async_client.get("/")
+    assert resp.status_code == 200
+    html = resp.text
+    assert "Visible" in html
+    assert "Hid" not in html

--- a/tests/test_steam_api_client.py
+++ b/tests/test_steam_api_client.py
@@ -1,10 +1,11 @@
-import asyncio
 import types
+import pytest
 
 from utils import steam_api_client as sac
 
 
-def test_get_player_summaries(monkeypatch):
+@pytest.mark.asyncio
+async def test_get_player_summaries(monkeypatch):
     monkeypatch.setattr(sac, "STEAM_API_KEY", "x")
     payload = {"response": {"players": [{"steamid": "1", "personaname": "Bob"}]}}
 
@@ -26,11 +27,12 @@ def test_get_player_summaries(monkeypatch):
             )
 
     monkeypatch.setattr(sac.httpx, "AsyncClient", DummyAsyncClient)
-    players = asyncio.run(sac.get_player_summaries_async(["1"]))
+    players = await sac.get_player_summaries_async(["1"])
     assert players == payload["response"]["players"]
 
 
-def test_get_tf2_playtime_hours(monkeypatch):
+@pytest.mark.asyncio
+async def test_get_tf2_playtime_hours(monkeypatch):
     monkeypatch.setattr(sac, "STEAM_API_KEY", "x")
     payload = {"response": {"games": [{"appid": 440, "playtime_forever": 90}]}}
 
@@ -52,5 +54,5 @@ def test_get_tf2_playtime_hours(monkeypatch):
             )
 
     monkeypatch.setattr(sac.httpx, "AsyncClient", DummyAsyncClient)
-    hours = asyncio.run(sac.get_tf2_playtime_hours_async("1"))
+    hours = await sac.get_tf2_playtime_hours_async("1")
     assert hours == 1.5


### PR DESCRIPTION
## Summary
- create async httpx client fixture using WsgiToAsgi
- update async tests to await HTTP calls directly
- mark async tests with `pytest.mark.asyncio`

## Testing
- `pre-commit run --files tests/conftest.py tests/test_fetch_many.py tests/test_constants_api.py tests/test_flask_routes.py tests/test_steam_api_client.py`
- `pytest tests/test_id_parser.py`

------
https://chatgpt.com/codex/tasks/task_e_686fc1ea40448326a518f31cb15fc354