### PR TITLE
Use ValueError when Steam key missing

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,7 +25,7 @@ from utils.price_loader import (
 
 load_dotenv()
 if not os.getenv("STEAM_API_KEY"):
-    raise RuntimeError(
+    raise ValueError(
         "Required env var missing: STEAM_API_KEY. Make sure you have a .env file or export it."
     )
 

--- a/tests/test_env_loading.py
+++ b/tests/test_env_loading.py
@@ -9,7 +9,7 @@ def test_missing_env_vars_raises(monkeypatch):
     monkeypatch.delenv("STEAM_API_KEY", raising=False)
     monkeypatch.setattr("utils.local_data.load_files", lambda *a, **k: ({}, {}))
     sys.modules.pop("app", None)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValueError):
         importlib.import_module("app")
 
 

--- a/utils/steam_api_client.py
+++ b/utils/steam_api_client.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 def _require_key() -> str:
     """Return the Steam API key or raise an error if missing."""
     if not STEAM_API_KEY:
-        raise RuntimeError(
+        raise ValueError(
             "STEAM_API_KEY is required. Set it in the environment or .env file."
         )
     return STEAM_API_KEY


### PR DESCRIPTION
## Summary
- raise `ValueError` for missing Steam API key
- update helper `_require_key` accordingly
- expect `ValueError` in env loading test
- run `pre-commit`

## Testing
- `pre-commit run --files app.py utils/steam_api_client.py tests/test_env_loading.py`

------
https://chatgpt.com/codex/tasks/task_e_686fc4de9ae483269fea208cc0eb6940