### PR TITLE
Add async build_user_data wrapper

### DIFF
--- a/app.py
+++ b/app.py
@@ -198,6 +198,12 @@ async def build_user_data_async(steamid64: str) -> Dict[str, Any]:
     return summary
 
 
+async def build_user_data(steamid64: str) -> Dict[str, Any]:
+    """Compatibility wrapper for :func:`build_user_data_async`."""
+
+    return await build_user_data_async(steamid64)
+
+
 def normalize_user_payload(user: Dict[str, Any]) -> SimpleNamespace:
     """Return a namespace with ``items`` guaranteed to be a list."""
 


### PR DESCRIPTION
## Summary
- add `build_user_data` thin wrapper

## Testing
- `pre-commit run --files app.py tests/test_fetch_many.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fcb3ea7108326aa86abaf0ad71f54