### PR TITLE
Add retry button for failed inventory scans

### DIFF
--- a/static/retry.js
+++ b/static/retry.js
@@ -82,8 +82,8 @@ function updateRefreshButton() {
 document.addEventListener('DOMContentLoaded', updateRefreshButton);
 
 function attachHandlers() {
-  document.querySelectorAll('.retry-pill').forEach(el => {
-    el.addEventListener('click', () => retryInventory(el.dataset.steamid));
+  document.querySelectorAll('.retry-button').forEach(btn => {
+    btn.addEventListener('click', () => retryInventory(btn.dataset.steamid));
   });
   updateRefreshButton();
 

--- a/templates/_user.html
+++ b/templates/_user.html
@@ -16,15 +16,26 @@
       </div>
     </div>
     <div class="privacy-status">
-      <span class="pill status-pill {{ user.status }}{% if user.status == 'failed' %} retry-pill{% endif %}" {% if user.status == 'failed' %}data-steamid="{{ user.steamid }}" title="Retry scan for this user"{% endif %}>
-        {% if user.status == 'parsed' %}
-          <i class="fa-solid fa-check"></i> Public
-        {% elif user.status == 'private' %}
-          <i class="fa-solid fa-lock"></i> Private
-        {% else %}
-          <i class="fa-solid fa-arrows-rotate"></i> Failed
-        {% endif %}
-      </span>
+      {% if user.status == 'failed' %}
+        <button
+          class="pill status-pill failed retry-button"
+          type="button"
+          data-steamid="{{ user.steamid }}"
+          aria-label="Retry scan for this user"
+        >
+          <i class="fa-solid fa-arrows-rotate"></i> Retry
+        </button>
+      {% else %}
+        <span class="pill status-pill {{ user.status }}">
+          {% if user.status == 'parsed' %}
+            <i class="fa-solid fa-check"></i> Public
+          {% elif user.status == 'private' %}
+            <i class="fa-solid fa-lock"></i> Private
+          {% else %}
+            <i class="fa-solid fa-arrows-rotate"></i> Failed
+          {% endif %}
+        </span>
+      {% endif %}
     </div>
   </div>
   <div class="card-body">

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,7 +7,7 @@
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" rel="stylesheet">
     <style>
         img { vertical-align: middle; }
-        .retry-pill:hover {
+        .retry-button:hover {
             background: rgba(255, 0, 0, 0.1);
         }
         .inventory-scroll {


### PR DESCRIPTION
## Summary
- add `retry-button` in user card for failed scans
- hook `.retry-button` in retry.js
- update in-page CSS selector

## Testing
- `pre-commit run --files templates/_user.html static/retry.js templates/index.html`

------
https://chatgpt.com/codex/tasks/task_e_686fd78677a4832680df189c784ade31