### PR TITLE
Add retry card class and batch refresh

### DIFF
--- a/templates/_user.html
+++ b/templates/_user.html
@@ -1,4 +1,4 @@
-<div id="user-{{ user.steamid }}" class="user-card user-box {{ user.status }}" data-steamid="{{ user.steamid }}">
+<div id="user-{{ user.steamid }}" class="user-card user-box {{ user.status }}{% if user.status == 'failed' %} retry-card{% endif %}" data-steamid="{{ user.steamid }}">
   <div class="user-header">
     <div class="user-profile">
       <a href="{{ user.profile }}" target="_blank" class="avatar-link">

--- a/tests/test_user_template.py
+++ b/tests/test_user_template.py
@@ -189,3 +189,16 @@ def test_decorated_quality_not_shown(app):
     title = soup.find("h2", class_="item-title")
     assert title is not None
     assert title.text.strip() == "Warhawk Flamethrower"
+
+
+def test_failed_user_has_retry_class(app):
+    context = {"user": {"steamid": "123", "status": "failed", "items": []}}
+    with app.test_request_context():
+        app_module = importlib.import_module("app")
+        context["user"] = app_module.normalize_user_payload(context["user"])
+        html = render_template_string(HTML, **context)
+    soup = BeautifulSoup(html, "html.parser")
+    card = soup.find("div", {"data-steamid": "123"})
+    assert card is not None
+    classes = card.get("class", [])
+    assert "retry-card" in classes


### PR DESCRIPTION
## Summary
- mark failed user cards with `retry-card` class
- batch retry failed cards in `refreshAll`
- ensure DOM tests check for new class

## Testing
- `pre-commit run --files templates/_user.html static/retry.js tests/test_user_template.py`

------
https://chatgpt.com/codex/tasks/task_e_686fdd744ec483269fe86d9ccddf41c7