### PR TITLE
Implement failed-ID retry tracking

### DIFF
--- a/static/retry.js
+++ b/static/retry.js
@@ -123,7 +123,11 @@ function loadUsers(ids) {
   (async () => {
     for (let i = 0; i < ids.length; i++) {
       const id = ids[i];
-      if (!document.getElementById('user-' + id)) {
+      const existing = document.getElementById('user-' + id);
+      if (existing && !existing.classList.contains('failed')) {
+        continue;
+      }
+      if (!existing) {
         const placeholder = document.createElement('div');
         placeholder.id = 'user-' + id;
         placeholder.dataset.steamid = id;

--- a/templates/index.html
+++ b/templates/index.html
@@ -156,7 +156,7 @@
     </div>
 
     <script>
-      window.initialIds = {{ ids|tojson|safe }};
+      window.initialIds = {{ failed_ids|tojson|safe }};
     </script>
     <script src="{{ url_for('static', filename='modal.js') }}"></script>
     <script src="{{ url_for('static', filename='retry.js') }}"></script>

--- a/tests/test_fetch_many.py
+++ b/tests/test_fetch_many.py
@@ -23,9 +23,10 @@ async def test_fetch_many_concurrent(monkeypatch, app):
 
     with app.test_request_context():
         start = time.perf_counter()
-        results = await mod.fetch_and_process_many(["1", "2", "3"])
+        results, failed = await mod.fetch_and_process_many(["1", "2", "3"])
         duration = time.perf_counter() - start
     assert len(results) == 3
+    assert failed == []
     assert duration < 0.15
 
 
@@ -34,7 +35,7 @@ async def test_api_users_returns_html(monkeypatch, async_client):
     mod = importlib.import_module("app")
 
     async def fake_fetch(ids):
-        return [f"<div>{i}</div>" for i in ids]
+        return [f"<div>{i}</div>" for i in ids], []
 
     monkeypatch.setattr(mod, "fetch_and_process_many", fake_fetch)
 

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -37,7 +37,7 @@ async def test_post_valid_ids_sets_initial_ids(monkeypatch, async_client):
     mod = importlib.import_module("app")
 
     async def fake_fetch(ids):
-        return [f'<div id="user-{i}"></div>' for i in ids]
+        return [f'<div id="user-{i}"></div>' for i in ids], []
 
     monkeypatch.setattr(mod, "fetch_and_process_many", fake_fetch)
     monkeypatch.setattr(mod.sac, "convert_to_steam64", lambda x: x)
@@ -55,7 +55,7 @@ async def test_post_returns_user_cards(monkeypatch, async_client):
     mod = importlib.import_module("app")
 
     async def fake_fetch(ids):
-        return [f'<div id="user-{i}">User {i}</div>' for i in ids]
+        return [f'<div id="user-{i}">User {i}</div>' for i in ids], []
 
     monkeypatch.setattr(mod, "fetch_and_process_many", fake_fetch)
     monkeypatch.setattr(mod.sac, "convert_to_steam64", lambda x: x)

--- a/tests/test_refresh_button.py
+++ b/tests/test_refresh_button.py
@@ -4,7 +4,9 @@ from bs4 import BeautifulSoup
 
 def test_refresh_button_has_button_type(app):
     with app.test_request_context():
-        html = render_template("index.html", steamids="", users=[], ids=[])
+        html = render_template(
+            "index.html", steamids="", users=[], ids=[], failed_ids=[]
+        )
     soup = BeautifulSoup(html, "html.parser")
     refresh_btn = soup.find("button", id="refresh-failed-btn")
     assert refresh_btn is not None


### PR DESCRIPTION
## Summary
- return failing SteamIDs from `fetch_and_process_many`
- surface those IDs in `index` and retry only them on page load
- update retry.js to skip already-successful cards
- adjust tests for new return signature

## Testing
- `pre-commit run --files app.py static/retry.js templates/index.html tests/test_fetch_many.py tests/test_flask_routes.py tests/test_refresh_button.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fe6dc47c8832688637f3f3f6419cb