### PR TITLE
Add lazy loading to item images

### DIFF
--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -15,10 +15,10 @@
     <span class="item-qty">x{{ item.quantity }}</span>
   {% endif %}
   {% if item.unusual_effect_id %}
-    <img class="particle-bg" src="/static/images/effects/{{ item.unusual_effect_id }}.png" alt="effect">
+    <img class="particle-bg" src="/static/images/effects/{{ item.unusual_effect_id }}.png" alt="effect" loading="lazy">
   {% endif %}
   {% if item.image_url %}
-    <img class="item-img" src="{{ item.image_url }}" alt="{{ item.display_name }}" width="64" height="64" onerror="this.style.display='none';">
+    <img class="item-img" src="{{ item.image_url }}" alt="{{ item.display_name }}" width="64" height="64" loading="lazy" onerror="this.style.display='none';">
   {% else %}
     <div class="missing-icon"></div>
   {% endif %}


### PR DESCRIPTION
## Summary
- enable browser-native lazy loading for item images and effect overlays

## Testing
- `pytest tests/test_user_template.py tests/test_inventory_processor.py::test_user_template_safe tests/test_quantity_badge.py tests/test_user_badges.py -q`
- `SKIP_VALIDATE=1 pre-commit run --files templates/item_card.html templates/_user.html tests/test_user_template.py tests/test_inventory_processor.py tests/test_quantity_badge.py tests/test_user_badges.py`

------
https://chatgpt.com/codex/tasks/task_e_686fe955ea2c83269dbd8073fb6764e5