### PR TITLE
Add async streaming form submission

### DIFF
--- a/static/submit.js
+++ b/static/submit.js
@@ -1,0 +1,65 @@
+function createPlaceholder(id) {
+  const ph = document.createElement('div');
+  ph.id = 'user-' + id;
+  ph.dataset.steamid = id;
+  ph.className = 'user-card user-box loading';
+  return ph;
+}
+
+async function fetchUserCard(id) {
+  try {
+    const resp = await fetch('/api/users', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ids: [id] })
+    });
+    if (!resp.ok) throw new Error('Request failed');
+    const data = await resp.json();
+    const html = Array.isArray(data.html) ? data.html[0] : '';
+    const wrapper = document.createElement('div');
+    wrapper.innerHTML = html;
+    const card = wrapper.firstElementChild;
+    const placeholder = document.getElementById('user-' + id);
+    if (card && placeholder) {
+      placeholder.replaceWith(card);
+      if (window.attachHandlers) {
+        window.attachHandlers();
+      }
+    } else if (placeholder) {
+      placeholder.classList.remove('loading');
+      placeholder.classList.add('failed');
+    }
+  } catch (err) {
+    console.error('Failed to fetch user', id, err);
+    const placeholder = document.getElementById('user-' + id);
+    if (placeholder) {
+      placeholder.classList.remove('loading');
+      placeholder.classList.add('failed');
+    }
+  }
+}
+
+function handleSubmit(e) {
+  e.preventDefault();
+  const container = document.getElementById('user-container');
+  if (!container) return;
+  container.innerHTML = '';
+  const text = document.getElementById('steamids').value || '';
+  const ids = text.split(/\s+/).filter(Boolean);
+  ids.forEach(id => {
+    const ph = createPlaceholder(id);
+    container.appendChild(ph);
+    fetchUserCard(id);
+  });
+  const results = document.getElementById('results');
+  if (results) {
+    results.classList.add('show');
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.querySelector('form.input-form');
+  if (form) {
+    form.addEventListener('submit', handleSubmit);
+  }
+});

--- a/templates/index.html
+++ b/templates/index.html
@@ -96,7 +96,7 @@
             </ul>
         {% endif %}
     {% endwith %}
-    <form method="post" class="input-form">
+    <form method="post" class="input-form" id="scan-form">
         <label for="steamids" class="visually-hidden">Steam IDs</label>
         <div class="input-wrapper">
             <i class="fa-brands fa-steam input-steam-icon"></i>
@@ -160,6 +160,7 @@
     </script>
     <script src="{{ url_for('static', filename='modal.js') }}"></script>
     <script src="{{ url_for('static', filename='retry.js') }}"></script>
+    <script src="{{ url_for('static', filename='submit.js') }}"></script>
     <script>
       function attachScrollButtons() {
         document.querySelectorAll('.inventory-scroll').forEach(wrapper => {


### PR DESCRIPTION
## Summary
- stream individual inventory results via submit.js
- expose form id for JavaScript hook and include new script

## Testing
- `pre-commit run --files templates/index.html static/submit.js`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686feaa3fd1083268fefc1e94d971cb4