### PR TITLE
Refactor item click handling

### DIFF
--- a/static/retry.js
+++ b/static/retry.js
@@ -140,32 +140,39 @@ function showResults() {
   }, 10);
 }
 
+function handleItemClick(event) {
+  const card = event.currentTarget || event;
+  let data = card.dataset.item;
+  if (!data) return;
+  try {
+    data = JSON.parse(data);
+  } catch (e) {
+    return;
+  }
+  if (window.modal && typeof window.modal.updateHeader === 'function') {
+    window.modal.updateHeader(data);
+  }
+  if (window.modal && typeof window.modal.setParticleBackground === 'function') {
+    window.modal.setParticleBackground(data.unusual_effect_id);
+  }
+  if (window.modal && typeof window.modal.generateModalHTML === 'function') {
+    const html = window.modal.generateModalHTML(data);
+    if (window.modal.showItemModal) {
+      window.modal.showItemModal(html);
+    }
+  }
+  if (window.modal && typeof window.modal.renderBadges === 'function') {
+    window.modal.renderBadges(data.badges);
+  }
+}
+
 function attachItemModal() {
-  document.querySelectorAll('.item-card').forEach(card => {
-    card.addEventListener('click', () => {
-      let data = card.dataset.item;
-      if (!data) return;
-      try {
-        data = JSON.parse(data);
-      } catch (e) {
-        return;
-      }
-      if (window.modal && typeof window.modal.updateHeader === 'function') {
-        window.modal.updateHeader(data);
-      }
-      if (window.modal && typeof window.modal.setParticleBackground === 'function') {
-        window.modal.setParticleBackground(data.unusual_effect_id);
-      }
-      if (window.modal && typeof window.modal.generateModalHTML === 'function') {
-        const html = window.modal.generateModalHTML(data);
-        if (window.modal.showItemModal) {
-          window.modal.showItemModal(html);
-        }
-      }
-      if (window.modal && typeof window.modal.renderBadges === 'function') {
-        window.modal.renderBadges(data.badges);
-      }
-    });
+  const container = document.getElementById('user-container');
+  if (!container) return;
+  container.querySelectorAll('.item-card').forEach(card => {
+    if (card.dataset.handler) return;
+    card.dataset.handler = 'true';
+    card.addEventListener('click', handleItemClick);
   });
 }
 
@@ -178,7 +185,6 @@ document.addEventListener('DOMContentLoaded', () => {
   if (window.initialIds && window.initialIds.length) {
     loadUsers(window.initialIds);
   }
-  attachItemModal();
   if (window.modal && typeof window.modal.initModal === 'function') {
     window.modal.initModal();
   }


### PR DESCRIPTION
## Summary
- refactor retry.js item click logic into a `handleItemClick` function
- ensure each `.item-card` only registers one listener
- call `attachItemModal` through `attachHandlers` only once

## Testing
- `pre-commit run --files static/retry.js tests/test_modal.js`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686ff1a4ea1c83268097c6e59a7bce8b