### PR TITLE
Add IntersectionObserver lazy loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - SchemaProvider class for fetching schema properties.
 - Paintkits endpoint cached as `warpaints.json`.
 - Async Flask routes with `httpx` replacing `requests` for concurrent HTTP calls.
+- IntersectionObserver-based image lazy loading script.
 
 ### Changed
 - Updated schema caching logic and UI (previous releases).

--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ All modal behaviour is centralized in `static/modal.js`. Other scripts use
 its helper functions and should never manipulate the modal DOM directly.
 Use `showItemModal(html)` to populate and display the dialog.
 
+## Lazy Loading
+
+Item images and unusual effect overlays are lazily loaded via
+`static/lazyload.js`. The script uses `IntersectionObserver` to replace each
+image's `data-src` attribute with `src` only when the card scrolls into view.
+This avoids downloading hundreds of images on page load while keeping the
+markup simple.
+
 ## Spells
 
 Halloween spell detection now relies on a static map of known spells. For each

--- a/static/lazyload.js
+++ b/static/lazyload.js
@@ -1,0 +1,31 @@
+// lazyload.js
+// Basic image lazy loading using IntersectionObserver
+// Applies to images with a `data-src` attribute.
+
+function initLazyLoad() {
+  const images = document.querySelectorAll('img[data-src]');
+  if (!images.length) return;
+
+  const loadImage = img => {
+    img.src = img.dataset.src;
+    img.removeAttribute('data-src');
+  };
+
+  if ('IntersectionObserver' in window) {
+    const observer = new IntersectionObserver(entries => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          loadImage(entry.target);
+          observer.unobserve(entry.target);
+        }
+      });
+    }, { rootMargin: '50px' });
+
+    images.forEach(img => observer.observe(img));
+  } else {
+    // Fallback: load all images immediately
+    images.forEach(loadImage);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', initLazyLoad);

--- a/templates/index.html
+++ b/templates/index.html
@@ -158,6 +158,7 @@
     <script>
       window.initialIds = {{ failed_ids|tojson|safe }};
     </script>
+    <script src="{{ url_for('static', filename='lazyload.js') }}"></script>
     <script src="{{ url_for('static', filename='modal.js') }}"></script>
     <script src="{{ url_for('static', filename='retry.js') }}"></script>
     <script src="{{ url_for('static', filename='submit.js') }}"></script>

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -15,10 +15,10 @@
     <span class="item-qty">x{{ item.quantity }}</span>
   {% endif %}
   {% if item.unusual_effect_id %}
-    <img class="particle-bg" src="/static/images/effects/{{ item.unusual_effect_id }}.png" alt="effect" loading="lazy">
+    <img class="particle-bg" data-src="/static/images/effects/{{ item.unusual_effect_id }}.png" alt="effect">
   {% endif %}
   {% if item.image_url %}
-    <img class="item-img" src="{{ item.image_url }}" alt="{{ item.display_name }}" width="64" height="64" loading="lazy" onerror="this.style.display='none';">
+    <img class="item-img" data-src="{{ item.image_url }}" alt="{{ item.display_name }}" width="64" height="64" onerror="this.style.display='none';">
   {% else %}
     <div class="missing-icon"></div>
   {% endif %}


### PR DESCRIPTION
## Summary
- load item images using IntersectionObserver
- include new `lazyload.js` on the index page
- describe lazy loading in README
- note lazy loading in CHANGELOG

## Testing
- `pre-commit run --files templates/item_card.html templates/index.html static/lazyload.js README.md CHANGELOG.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ff844108c8326a1d80c06d6be8b2c