### PR TITLE
Prevent duplicate user panels and remove auto-retries

### DIFF
--- a/static/retry.js
+++ b/static/retry.js
@@ -189,9 +189,6 @@ document.addEventListener('DOMContentLoaded', () => {
   if (btn) {
     btn.addEventListener('click', refreshAll);
   }
-  if (window.initialIds && window.initialIds.length) {
-    loadUsers(window.initialIds);
-  }
   if (window.modal && typeof window.modal.initModal === 'function') {
     window.modal.initModal();
   }

--- a/static/submit.js
+++ b/static/submit.js
@@ -45,7 +45,7 @@ function handleSubmit(e) {
   if (!container) return;
   container.innerHTML = '';
   const text = document.getElementById('steamids').value || '';
-  const ids = text.split(/\s+/).filter(Boolean);
+  const ids = Array.from(new Set(text.split(/\s+/).filter(Boolean)));
   ids.forEach(id => {
     const ph = createPlaceholder(id);
     container.appendChild(ph);

--- a/tests/test_fetch_many.py
+++ b/tests/test_fetch_many.py
@@ -45,3 +45,30 @@ async def test_api_users_returns_html(monkeypatch, async_client):
     assert resp.status_code == 200
     data = resp.json()
     assert data == {"html": ["<div>1</div>", "<div>2</div>"]}
+
+
+@pytest.mark.asyncio
+async def test_fetch_many_deduplicates(monkeypatch, app):
+    mod = importlib.import_module("app")
+
+    calls = []
+
+    async def fake_build(id_):
+        calls.append(id_)
+        return {
+            "steamid": id_,
+            "avatar": "",
+            "username": id_,
+            "playtime": 0,
+            "status": "parsed",
+            "items": [],
+        }
+
+    monkeypatch.setattr(mod, "build_user_data_async", fake_build)
+
+    with app.test_request_context():
+        results, failed = await mod.fetch_and_process_many(["1", "1", "2", "2"])
+
+    assert len(results) == 2
+    assert failed == []
+    assert calls == ["1", "2"]


### PR DESCRIPTION
## Summary
- deduplicate steamid processing in `fetch_and_process_many`
- avoid duplicate retry listeners on page load
- remove automatic load of failed ids
- cleanly handle Steam API errors without retries
- dedupe IDs on form submit
- test that duplicate ids only processed once

## Testing
- `pre-commit run --files app.py static/retry.js static/submit.js utils/steam_api_client.py tests/test_fetch_many.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ffb8b811c832698efb5e302b63e56