### PR TITLE
Fix duplicate users and lazy load refresh

### DIFF
--- a/app.py
+++ b/app.py
@@ -232,12 +232,16 @@ async def fetch_and_process_many(ids: List[str]) -> tuple[List[str], List[str]]:
     failed_ids: List[str] = []
     seen: set[str] = set()
 
-    for sid, user in zip(tasks.keys(), results):
-        user_ns = normalize_user_payload(user)
-        if sid in seen:
-            print("DUPLICATE PANEL:", sid)
+    for _, user in zip(tasks.keys(), results):
+        if not user or not isinstance(user, dict):
             continue
-        seen.add(sid)
+        if not user.get("username") and not user.get("personaname"):
+            continue
+        user_ns = normalize_user_payload(user)
+        if user_ns.steamid in seen:
+            print("DUPLICATE PANEL:", user_ns.steamid)
+            continue
+        seen.add(user_ns.steamid)
         if user_ns.status == "failed":
             failed_ids.append(user_ns.steamid)
         html_snippets.append(render_template("_user.html", user=user_ns))

--- a/static/lazyload.js
+++ b/static/lazyload.js
@@ -2,24 +2,29 @@
 // Basic image lazy loading using IntersectionObserver
 // Applies to images with a `data-src` attribute.
 
+let observer;
+
+function loadImage(img) {
+  img.src = img.dataset.src;
+  img.removeAttribute('data-src');
+}
+
 function initLazyLoad() {
   const images = document.querySelectorAll('img[data-src]');
   if (!images.length) return;
 
-  const loadImage = img => {
-    img.src = img.dataset.src;
-    img.removeAttribute('data-src');
-  };
-
   if ('IntersectionObserver' in window) {
-    const observer = new IntersectionObserver(entries => {
-      entries.forEach(entry => {
-        if (entry.isIntersecting) {
-          loadImage(entry.target);
-          observer.unobserve(entry.target);
-        }
-      });
-    }, { rootMargin: '50px' });
+    observer = new IntersectionObserver(
+      entries => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) {
+            loadImage(entry.target);
+            observer.unobserve(entry.target);
+          }
+        });
+      },
+      { rootMargin: '50px' }
+    );
 
     images.forEach(img => observer.observe(img));
   } else {
@@ -28,4 +33,13 @@ function initLazyLoad() {
   }
 }
 
-document.addEventListener('DOMContentLoaded', initLazyLoad);
+function refreshLazyLoad() {
+  document
+    .querySelectorAll('img[data-src]')
+    .forEach(img => observer && observer.observe(img));
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  initLazyLoad();
+  window.refreshLazyLoad = refreshLazyLoad;
+});

--- a/static/retry.js
+++ b/static/retry.js
@@ -41,6 +41,9 @@ function retryInventory(id) {
         card.replaceWith(newCard);
       }
       attachHandlers();
+      if (window.refreshLazyLoad) {
+        window.refreshLazyLoad();
+      }
       updateRefreshButton();
       showResults();
     })
@@ -57,7 +60,7 @@ function retryInventory(id) {
 function updateRefreshButton() {
   const btn = document.getElementById('refresh-failed-btn');
   if (!btn) return;
-  const failures = document.querySelectorAll('.user-box.failed').length;
+  const failures = document.querySelectorAll('.user.failed').length;
   if (failures === 0) {
     btn.disabled = true;
     btn.textContent = 'Nothing to Refresh';
@@ -94,7 +97,7 @@ async function refreshAll() {
   const original = btn.textContent;
   btn.textContent = 'Refreshing…';
   const cards = Array.from(
-    document.querySelectorAll('.retry-card[data-steamid]')
+    document.querySelectorAll('.user.failed[data-steamid]')
   );
   const total = cards.length;
   const BATCH_SIZE = 3;

--- a/static/submit.js
+++ b/static/submit.js
@@ -25,6 +25,9 @@ async function fetchUserCard(id) {
       if (window.attachHandlers) {
         window.attachHandlers();
       }
+      if (window.refreshLazyLoad) {
+        window.refreshLazyLoad();
+      }
     } else if (placeholder) {
       placeholder.classList.remove('loading');
       placeholder.classList.add('failed');


### PR DESCRIPTION
## Summary
- handle bad summaries when building user cards and deduplicate by steamid
- refresh IntersectionObserver after dynamic inserts
- track only `.user.failed` elements for refresh button logic

## Testing
- `pre-commit run --files static/lazyload.js static/submit.js static/retry.js app.py`

------
https://chatgpt.com/codex/tasks/task_e_686fff52f6a8832697c66d1b9fba854e