### PR TITLE
Fix dedupes, private handling and lazy loading

### DIFF
--- a/static/lazyload.js
+++ b/static/lazyload.js
@@ -33,13 +33,10 @@ function initLazyLoad() {
   }
 }
 
-function refreshLazyLoad() {
+window.refreshLazyLoad = function () {
   document
     .querySelectorAll('img[data-src]')
     .forEach(img => observer && observer.observe(img));
-}
+};
 
-document.addEventListener('DOMContentLoaded', () => {
-  initLazyLoad();
-  window.refreshLazyLoad = refreshLazyLoad;
-});
+document.addEventListener('DOMContentLoaded', initLazyLoad);


### PR DESCRIPTION
## Summary
- skip users without summaries and allow private inventories
- deduplicate ID list before building tasks
- expose `refreshLazyLoad` and refresh when inserting HTML
- retry only failed public users and keep accurate failure count

## Testing
- `pre-commit run --files app.py static/lazyload.js static/retry.js`
- `STEAM_API_KEY=test pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687005a43ef08326b35a49a24859294a