### PR TITLE
Fix item deduplication

### DIFF
--- a/app.py
+++ b/app.py
@@ -82,7 +82,15 @@ except Exception:
 
 # --- Utility functions ------------------------------------------------------
 
-IGNORED_STACK_KEYS = {"level", "custom_description", "custom_name", "origin"}
+IGNORED_STACK_KEYS = {
+    "level",
+    "custom_description",
+    "custom_name",
+    "origin",
+    "id",
+    "original_id",
+    "inventory",
+}
 
 
 def kill_process_on_port(port: int) -> None:

--- a/tests/test_quantity_badge.py
+++ b/tests/test_quantity_badge.py
@@ -17,6 +17,29 @@ def test_stack_items_collapses_duplicates():
     assert result[0]["quantity"] == 2
 
 
+def test_stack_items_ignores_ids(monkeypatch):
+    monkeypatch.setenv("STEAM_API_KEY", "x")
+    monkeypatch.setenv("BPTF_API_KEY", "x")
+    monkeypatch.setattr(
+        "utils.price_loader.ensure_prices_cached", lambda refresh=False: Path("prices.json")
+    )
+    monkeypatch.setattr(
+        "utils.price_loader.ensure_currencies_cached",
+        lambda refresh=False: Path("currencies.json"),
+    )
+    monkeypatch.setattr("utils.price_loader.build_price_map", lambda path: {})
+    monkeypatch.setattr("utils.local_data.load_files", lambda *a, **k: ({}, {}))
+    mod = importlib.import_module("app")
+    importlib.reload(mod)
+    items = [
+        {"name": "Crate", "image_url": "", "quality_color": "#fff", "id": 1},
+        {"name": "Crate", "image_url": "", "quality_color": "#fff", "id": 2},
+    ]
+    result = mod.stack_items(items)
+    assert len(result) == 1
+    assert result[0]["quantity"] == 2
+
+
 def test_quantity_badge_rendered(monkeypatch):
     monkeypatch.setenv("STEAM_API_KEY", "x")
     monkeypatch.setenv("BPTF_API_KEY", "x")


### PR DESCRIPTION
## Summary
- de-duplicate inventory items regardless of unique IDs
- test item stacking with different item IDs

## Testing
- `pytest tests/test_quantity_badge.py::test_stack_items_ignores_ids -q`

------
https://chatgpt.com/codex/tasks/task_e_68701e908ec08326b4886153dee8af61