### PR TITLE
Enforce strict SteamID formats

### DIFF
--- a/app.py
+++ b/app.py
@@ -307,7 +307,9 @@ def index():
         ids = [sac.convert_to_steam64(t) for t in raw_ids]
         print(f"Parsed {len(ids)} valid IDs, {len(invalid)} tokens ignored")
         if not ids:
-            flash("No valid Steam IDs found!")
+            flash(
+                "No valid Steam IDs found. Please input in SteamID64, SteamID2, or SteamID3 format."
+            )
             return render_template(
                 "index.html",
                 users=users,

--- a/templates/index.html
+++ b/templates/index.html
@@ -100,7 +100,7 @@
         <label for="steamids" class="visually-hidden">Steam IDs</label>
         <div class="input-wrapper">
             <i class="fa-brands fa-steam input-steam-icon"></i>
-            <textarea id="steamids" name="steamids" placeholder="Enter SteamID, vanity URL, or multiple IDs…">{{ steamids|default('') }}</textarea>
+            <textarea id="steamids" name="steamids" placeholder="Enter SteamID64, SteamID2, or SteamID3—one per line">{{ steamids|default('') }}</textarea>
         </div>
         <div class="form-actions">
             <button type="submit" class="primary-btn action-button"><i class="fa-solid fa-magnifying-glass"></i> Check Inventories</button>

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -27,7 +27,10 @@ def test_post_invalid_ids_flash(app):
     resp = client.post("/", data={"steamids": "foobar"})
     assert resp.status_code == 200
     html = resp.get_data(as_text=True)
-    assert "No valid Steam IDs found!" in html
+    assert (
+        "No valid Steam IDs found. Please input in SteamID64, SteamID2, or SteamID3 format."
+        in html
+    )
 
 
 def test_post_valid_ids_sets_initial_ids(app):

--- a/tests/test_id_parser.py
+++ b/tests/test_id_parser.py
@@ -2,21 +2,22 @@ import utils.steam_api_client as sac
 from utils.id_parser import extract_steam_ids
 
 
-def test_extract_ids_from_status_block():
+def test_extract_ids_only_valid_formats():
     text = """
-    hostname: my tf2 server
-    version : 123
-    # userid name uniqueid connected ping loss state
-    #   314 "Xanmangamer" [U:1:876151635] 00:26 94 74 spawning
-    #   315 "Tester" [U:1:1137042230] 01:11 88 0 active
-    #   316 "Short" [U:1:2] 00:01 50 0 active
+    76561198083937853
+    STEAM_0:1:61836062
+    [U:1:123672125]
+    Dankr
     """
     ids = extract_steam_ids(text)
+    assert ids == [
+        "76561198083937853",
+        "STEAM_0:1:61836062",
+        "[U:1:123672125]",
+    ]
     steam64 = [sac.convert_to_steam64(i) for i in ids]
     assert steam64 == [
-        sac.convert_to_steam64("[U:1:876151635]"),
-        sac.convert_to_steam64("[U:1:1137042230]"),
-        sac.convert_to_steam64("[U:1:2]"),
+        sac.convert_to_steam64("76561198083937853"),
+        sac.convert_to_steam64("STEAM_0:1:61836062"),
+        sac.convert_to_steam64("[U:1:123672125]"),
     ]
-    assert "Xanmangamer" not in ids
-    assert "active" not in ids

--- a/utils/id_parser.py
+++ b/utils/id_parser.py
@@ -1,30 +1,31 @@
 import re
 from typing import List
 
-STEAMID2_RE = re.compile(r"STEAM_0:[01]:\d+")
-STEAMID3_RE = re.compile(r"\[U:1:\d+\]")
-STEAMID64_RE = re.compile(r"\b\d{17}\b")
+STEAMID2_RE = re.compile(r"^STEAM_0:[01]:\d+$")
+STEAMID3_RE = re.compile(r"^\[U:1:\d+\]$")
+STEAMID64_RE = re.compile(r"^\d{17}$")
 
 
 def extract_steam_ids(raw_text: str) -> List[str]:
-    """Extract valid SteamID tokens from free-form text.
+    """Return unique SteamIDs from the given text.
 
-    The function splits the input on whitespace and returns unique IDs in
-    the order encountered. Only strings matching SteamID2, SteamID3 or
-    SteamID64 formats are kept.
+    Each non-empty line is checked against the supported formats. Lines
+    containing anything other than a valid SteamID64, SteamID2 or
+    SteamID3 token are ignored.
     """
 
-    tokens = re.split(r"\s+", raw_text.strip())
+    lines = raw_text.splitlines()
     ids: List[str] = []
     seen: set[str] = set()
 
-    for token in tokens:
+    for line in lines:
+        token = line.strip()
         if not token:
             continue
         if (
-            STEAMID2_RE.fullmatch(token)
+            STEAMID64_RE.fullmatch(token)
+            or STEAMID2_RE.fullmatch(token)
             or STEAMID3_RE.fullmatch(token)
-            or STEAMID64_RE.fullmatch(token)
         ):
             if token not in seen:
                 seen.add(token)


### PR DESCRIPTION
## Summary
- accept only SteamID64, SteamID2 or SteamID3 tokens
- remove vanity URL lookup
- update no-id flash message and placeholder text
- adjust tests for new parsing rules

## Testing
- `pre-commit run --files utils/id_parser.py utils/steam_api_client.py app.py templates/index.html tests/test_id_parser.py tests/test_flask_routes.py`
- `STEAM_API_KEY=test pytest` *(fails: test_enrich_inventory)*

------
https://chatgpt.com/codex/tasks/task_e_687036a18d3c832695ea864db739263c