### PR TITLE
Update SteamID validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-An async-enabled Flask 3 web app that inspects one or more Steam users' Team Fortress 2 inventories. It accepts **SteamID64**, **SteamID3**, **SteamID2**, and **vanity URLs**, resolves them to SteamID64, and enriches the inventory using the Steam Web API and cached item schema. All routes are `async def` functions and HTTP calls are made with `httpx`.
+An async-enabled Flask 3 web app that inspects one or more Steam users' Team Fortress 2 inventories. It accepts **SteamID64**, **SteamID3**, and **SteamID2** formats only, resolves them to SteamID64, and enriches the inventory using the Steam Web API and cached item schema. All routes are `async def` functions and HTTP calls are made with `httpx`.
 
 ## Setup
 

--- a/app.py
+++ b/app.py
@@ -385,7 +385,9 @@ async def index():
         if ids:
             users, failed_ids = await fetch_and_process_many(ids)
         else:
-            flash("No valid Steam IDs found!")
+            flash(
+                "No valid Steam IDs found. Please input in SteamID64, SteamID2, or SteamID3 format."
+            )
             return render_template(
                 "index.html",
                 users=users,

--- a/templates/index.html
+++ b/templates/index.html
@@ -100,7 +100,7 @@
         <label for="steamids" class="visually-hidden">Steam IDs</label>
         <div class="input-wrapper">
             <i class="fa-brands fa-steam input-steam-icon"></i>
-            <textarea id="steamids" name="steamids" placeholder="Enter SteamID, vanity URL, or multiple IDs…">{{ steamids|default('') }}</textarea>
+            <textarea id="steamids" name="steamids" placeholder="Enter SteamID64, SteamID2, or SteamID3…">{{ steamids|default('') }}</textarea>
         </div>
         <div class="form-actions">
             <button type="submit" class="primary-btn action-button"><i class="fa-solid fa-magnifying-glass"></i> Check Inventories</button>

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -29,7 +29,10 @@ async def test_post_invalid_ids_flash(async_client):
     resp = await async_client.post("/", data={"steamids": "foobar"})
     assert resp.status_code == 200
     html = resp.text
-    assert "No valid Steam IDs found!" in html
+    assert (
+        "No valid Steam IDs found. Please input in SteamID64, SteamID2, or SteamID3 format."
+        in html
+    )
 
 
 @pytest.mark.asyncio

--- a/utils/id_parser.py
+++ b/utils/id_parser.py
@@ -1,9 +1,9 @@
 import re
 from typing import List
 
-STEAMID2_RE = re.compile(r"STEAM_0:[01]:\d+")
-STEAMID3_RE = re.compile(r"\[U:1:\d+\]")
-STEAMID64_RE = re.compile(r"\b\d{17}\b")
+STEAMID2_RE = re.compile(r"^STEAM_0:[01]:\d+$")
+STEAMID3_RE = re.compile(r"^\[U:1:\d+\]$")
+STEAMID64_RE = re.compile(r"^\d{17}$")
 
 
 def extract_steam_ids(raw_text: str) -> List[str]:

--- a/utils/steam_api_client.py
+++ b/utils/steam_api_client.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Iterator, List, Tuple
 import logging
 import httpx
 import requests
+import re
 from dotenv import load_dotenv
 
 # Ensure .env values are available even when this module is imported early.
@@ -195,43 +196,24 @@ async def fetch_inventory_async(steamid: str) -> Tuple[str, Dict[str, Any]]:
 
 
 def convert_to_steam64(id_str: str) -> str:
-    """Convert Steam identifiers to SteamID64."""
-    import re
+    """Convert Steam identifiers (SteamID64, SteamID2, SteamID3) to SteamID64."""
 
     if re.fullmatch(r"\d{17}", id_str):
         return id_str
 
-    if id_str.startswith("STEAM_"):
-        try:
-            _, y, z = id_str.split(":")
-            y = int(y.split("_")[1]) if "_" in y else int(y)
-            z = int(z)
-        except (ValueError, IndexError):
-            raise ValueError(f"Invalid SteamID2: {id_str}") from None
+    match = re.fullmatch(r"STEAM_0:([01]):(\d+)", id_str)
+    if match:
+        y = int(match.group(1))
+        z = int(match.group(2))
         account_id = z * 2 + y
         return str(account_id + 76561197960265728)
 
-    if id_str.startswith("[U:"):
-        match = re.match(r"\[U:(\d+):(\d+)\]", id_str)
-        if match:
-            z = int(match.group(2))
-            return str(z + 76561197960265728)
-        match = re.match(r"\[U:1:(\d+)\]", id_str)
-        if match:
-            z = int(match.group(1))
-            return str(z + 76561197960265728)
+    match = re.fullmatch(r"\[U:1:(\d+)\]", id_str)
+    if match:
+        z = int(match.group(1))
+        return str(z + 76561197960265728)
 
-    key = _require_key()
-    url = (
-        "https://api.steampowered.com/ISteamUser/ResolveVanityURL/v1/"
-        f"?key={key}&vanityurl={id_str}"
-    )
-    r = requests.get(url, timeout=10)
-    r.raise_for_status()
-    data = r.json().get("response", {})
-    if data.get("success") != 1:
-        raise ValueError(f"Unable to resolve vanity URL: {id_str}")
-    return data["steamid"]
+    raise ValueError(f"Invalid Steam ID format: {id_str}")
 
 
 def get_tf2_playtime_hours(steamid: str) -> float:


### PR DESCRIPTION
## Summary
- only accept SteamID64, SteamID2 and SteamID3 when extracting IDs
- remove vanity URL resolution from `convert_to_steam64`
- clarify invalid input feedback in UI and tests
- refresh placeholder text and README wording

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files utils/id_parser.py utils/steam_api_client.py app.py README.md templates/index.html tests/test_flask_routes.py`

------
https://chatgpt.com/codex/tasks/task_e_687038a6f9988326a8d3ab9a7be7fde1