### PR TITLE
Handle invalid IDs in index

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -111,7 +111,7 @@
     <div id="results" class="fade-in">
         <div id="user-container">
             {% for user in users %}
-                {% include "_user.html" %}
+                {% if user and user.steamid %}{% include "_user.html" %}{% endif %}
             {% endfor %}
         </div>
     </div>

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -108,7 +108,7 @@ QUALITY_MAP = {
     3: ("Vintage", "#28344a"),
     5: ("Unusual", "#4f3363"),
     6: ("Unique", "#957e04"),
-    11: ("Strange", "#7a4121"),
+    11: ("Strange", "#CF6A32"),
     13: ("Haunted", "#0c8657"),
     14: ("Collector's", "#1c0101"),
     15: ("Decorated Weapon", "#949494"),


### PR DESCRIPTION
## Summary
- ignore invalid IDs in `index()`
- skip rendering invalid user entries in template
- update `QUALITY_MAP` color for Strange items

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files app.py templates/index.html utils/inventory_processor.py`

------
https://chatgpt.com/codex/tasks/task_e_687041c987048326920a624778332e58