### PR TITLE
Fix invalid SteamID input boxes

### DIFF
--- a/app.py
+++ b/app.py
@@ -383,6 +383,8 @@ async def index():
         ids = [sac.convert_to_steam64(t) for t in raw_ids]
         print(f"Parsed {len(ids)} valid IDs, {len(invalid)} tokens ignored")
         if ids:
+            if invalid:
+                flash(f"Ignored {len(invalid)} invalid input(s).")
             users, failed_ids = await fetch_and_process_many(ids)
         else:
             flash(

--- a/static/submit.js
+++ b/static/submit.js
@@ -42,13 +42,32 @@ async function fetchUserCard(id) {
   }
 }
 
+function extractSteamIds(text) {
+  const tokens = text.trim().split(/\s+/);
+  const steam2 = /^STEAM_0:[01]:\d+$/;
+  const steam3 = /^\[U:1:\d+\]$/;
+  const steam64 = /^\d{17}$/;
+  const ids = [];
+  const seen = new Set();
+  for (const token of tokens) {
+    if (!token) continue;
+    if (steam2.test(token) || steam3.test(token) || steam64.test(token)) {
+      if (!seen.has(token)) {
+        seen.add(token);
+        ids.push(token);
+      }
+    }
+  }
+  return ids;
+}
+
 function handleSubmit(e) {
   e.preventDefault();
   const container = document.getElementById('user-container');
   if (!container) return;
   container.innerHTML = '';
   const text = document.getElementById('steamids').value || '';
-  const ids = Array.from(new Set(text.split(/\s+/).filter(Boolean)));
+  const ids = extractSteamIds(text);
   ids.forEach(id => {
     const ph = createPlaceholder(id);
     container.appendChild(ph);

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -71,6 +71,30 @@ async def test_post_returns_user_cards(monkeypatch, async_client):
 
 
 @pytest.mark.asyncio
+async def test_post_mixed_input_ignores_invalid(monkeypatch, async_client):
+    mod = importlib.import_module("app")
+
+    captured_ids = []
+
+    async def fake_fetch(ids):
+        captured_ids.extend(ids)
+        return [f"<div id='user-{i}'></div>" for i in ids], []
+
+    monkeypatch.setattr(mod, "fetch_and_process_many", fake_fetch)
+    monkeypatch.setattr(mod.sac, "convert_to_steam64", lambda x: x)
+
+    resp = await async_client.post(
+        "/",
+        data={"steamids": "STEAM_0:1:4 invalid"},
+    )
+    assert resp.status_code == 200
+    html = resp.text
+    assert "user-STEAM_0:1:4" in html
+    assert "user-invalid" not in html
+    assert captured_ids == ["STEAM_0:1:4"]
+
+
+@pytest.mark.asyncio
 async def test_hidden_items_not_rendered(async_client, app):
     mod = importlib.import_module("app")
     user = mod.normalize_user_payload(


### PR DESCRIPTION
## Summary
- parse IDs on the client using regexes so invalid tokens don't create placeholders
- flash a message when some tokens are ignored on POST
- add regression test for mixed valid/invalid input

## Testing
- `pre-commit run --files static/submit.js app.py tests/test_flask_routes.py`

------
https://chatgpt.com/codex/tasks/task_e_687043e4d8208326bf564a1d08b4c875