### PR TITLE
Fix lazyload initialization when loaded dynamically

### DIFF
--- a/static/lazyload.js
+++ b/static/lazyload.js
@@ -39,4 +39,8 @@ window.refreshLazyLoad = function () {
     .forEach(img => observer && observer.observe(img));
 };
 
-document.addEventListener('DOMContentLoaded', initLazyLoad);
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initLazyLoad);
+} else {
+  initLazyLoad();
+}


### PR DESCRIPTION
## Summary
- ensure `initLazyLoad()` runs if the document is already parsed

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files static/lazyload.js`
- `STEAM_API_KEY=test pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68704808df3083269eb6f0ee90bf853c