### PR TITLE
Add fallback src attributes for item images

### DIFF
--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -15,10 +15,25 @@
     <span class="item-qty">x{{ item.quantity }}</span>
   {% endif %}
   {% if item.unusual_effect_id %}
-    <img class="particle-bg" data-src="/static/images/effects/{{ item.unusual_effect_id }}.png" alt="effect">
+    <img
+      class="particle-bg"
+      loading="lazy"
+      src="/static/images/effects/{{ item.unusual_effect_id }}.png"
+      data-src="/static/images/effects/{{ item.unusual_effect_id }}.png"
+      alt="effect"
+    >
   {% endif %}
   {% if item.image_url %}
-    <img class="item-img" data-src="{{ item.image_url }}" alt="{{ item.display_name }}" width="64" height="64" onerror="this.style.display='none';">
+    <img
+      class="item-img"
+      loading="lazy"
+      src="{{ item.image_url }}"
+      data-src="{{ item.image_url }}"
+      alt="{{ item.display_name }}"
+      width="64"
+      height="64"
+      onerror="this.style.display='none';"
+    >
   {% else %}
     <div class="missing-icon"></div>
   {% endif %}


### PR DESCRIPTION
## Summary
- ensure particle and item images load even when JS fails
- add lazy loading hints

## Testing
- `pre-commit run --files templates/item_card.html`

------
https://chatgpt.com/codex/tasks/task_e_68704bedabb48326b9cbbbd6770ab7b0