### PR TITLE
Fix failed inventory selector for refresh button

### DIFF
--- a/static/retry.js
+++ b/static/retry.js
@@ -58,7 +58,7 @@ function retryInventory(id) {
 }
 
 function getFailedUsers() {
-  return [...document.querySelectorAll('.user.failed')]
+  return [...document.querySelectorAll('.user-card.failed')]
     .filter(div => !div.classList.contains('private'))
     .map(div => div.dataset.steamid);
 }


### PR DESCRIPTION
## Summary
- update JS selector used for detecting failed scans

## Testing
- `SKIP_VALIDATE=1 PATH="$(pwd)/.venv/bin:$PATH" .venv/bin/pre-commit run --files static/retry.js`
- `NODE_PATH=$(pwd)/node_modules node /tmp/test_retry_button.js`

------
https://chatgpt.com/codex/tasks/task_e_687052e6a6ac8326aaefb80f546df853