### PR TITLE
Add backpack history link

### DIFF
--- a/static/modal.js
+++ b/static/modal.js
@@ -143,6 +143,11 @@
       spells += '</ul>';
     }
 
+    if (data.id && (!data.quantity || data.quantity <= 1) && !data._hidden) {
+      const url = 'https://next.backpack.tf/item/' + esc(data.id);
+      attrs.push('<div><a href="' + url + '" target="_blank" rel="noopener">History\ud83d\udd0e</a></div>');
+    }
+
     const details = attrs.join('') + spells;
     const imgTag = '<img src="' + esc(data.image_url || '') + '" width="64" height="64" alt="">';
     return imgTag + '<div id="modal-details">' + details + '</div>';

--- a/tests/test_modal.js
+++ b/tests/test_modal.js
@@ -61,6 +61,18 @@ if (!html2.includes('<li>Ghosts (2)</li>')) {
 if (!html2.includes('<li>Fire</li>')) {
   throw new Error('Spell object not rendered');
 }
+const htmlHistory = modal.generateModalHTML({ id: 123 });
+if (!htmlHistory.includes('https://next.backpack.tf/item/123')) {
+  throw new Error('History link missing');
+}
+const htmlStacked = modal.generateModalHTML({ id: 123, quantity: 2 });
+if (htmlStacked.includes('backpack.tf')) {
+  throw new Error('History link should not show for stacked items');
+}
+const htmlHidden = modal.generateModalHTML({ id: 123, _hidden: true });
+if (htmlHidden.includes('backpack.tf')) {
+  throw new Error('History link should not show for hidden items');
+}
 modal.closeModal();
 modal.showItemModal('<p>Race</p>');
 setTimeout(() => {

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -1049,6 +1049,7 @@ def _process_item(
         display_name = resolved_name
 
     item = {
+        "id": asset.get("id"),
         "defindex": defindex,
         "name": name,
         "original_name": original_name,


### PR DESCRIPTION
## Summary
- include `id` in processed items
- show backpack history link in modal when item isn't stacked or hidden
- test new link logic

## Testing
- `pre-commit run --files utils/inventory_processor.py static/modal.js tests/test_modal.js`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870592156c88326a850469ec27ccb95