### PR TITLE
Fix History link style

### DIFF
--- a/static/modal.js
+++ b/static/modal.js
@@ -145,7 +145,7 @@
 
     if (data.id && (!data.quantity || data.quantity <= 1) && !data._hidden) {
       const url = 'https://next.backpack.tf/item/' + esc(data.id);
-      attrs.push('<div><a href="' + url + '" target="_blank" rel="noopener">History\ud83d\udd0e</a></div>');
+      attrs.push('<div><a href="' + url + '" target="_blank" rel="noopener" class="history-link">History\ud83d\udd0e</a></div>');
     }
 
     const details = attrs.join('') + spells;

--- a/static/style.css
+++ b/static/style.css
@@ -404,6 +404,20 @@ a.backpack-link:visited {
   color: #ddd;
 }
 
+.history-link {
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px solid currentColor;
+}
+
+.history-link:hover {
+  text-decoration: underline;
+}
+
+.history-link:visited {
+  color: inherit;
+}
+
 .inline-icon {
   height: 1em;
   width: auto;


### PR DESCRIPTION
## Summary
- add `.history-link` styles
- apply new class in `modal.js`

## Testing
- `pre-commit run --files static/style.css static/modal.js` *(fails: ModuleNotFoundError: No module named 'vdf')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_68705c7550d48326af0f6e7e8637aac8