### PR TITLE
Allow promo weapons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,4 @@ All notable changes to this project will be documented in this file.
 - Updated schema caching logic and UI (previous releases).
 - Security audit using git-secrets and pip-audit.
 - Price loader now reads both Craftable and Non-Craftable price entries.
+- Plain craft weapons from achievements or promotions are no longer filtered.

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -836,6 +836,15 @@ def test_plain_craft_weapon_filtered():
     assert items == []
 
 
+@pytest.mark.parametrize("origin", [1, 5, 9, 14])
+def test_plain_craft_weapon_with_special_origin_kept(origin):
+    data = {"items": [{"defindex": 10, "quality": 6, "origin": origin}]}
+    ld.ITEMS_BY_DEFINDEX = {10: {"item_name": "A", "craft_class": "weapon"}}
+    ld.QUALITIES_BY_INDEX = {6: "Unique"}
+    items = ip.enrich_inventory(data)
+    assert len(items) == 1
+
+
 def test_special_craft_weapon_kept():
     data = {
         "items": [

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -724,6 +724,9 @@ def _is_warpaintable(schema_entry: Dict[str, Any]) -> bool:
 
 WAR_PAINT_TOOL_DEFINDEXES = {5681, 5682, 5683}
 
+# Origins that should not cause craft weapons to be filtered out
+CRAFT_WEAPON_ALLOWED_ORIGINS = {1, 5, 9, 14}
+
 
 def _has_attr(asset: dict, idx: int) -> bool:
     """Return True if ``asset`` contains an attribute with ``defindex`` ``idx``."""
@@ -825,6 +828,13 @@ def _is_plain_craft_weapon(asset: dict, schema_entry: Dict[str, Any]) -> bool:
     try:
         quality = int(asset.get("quality", 0))
     except (TypeError, ValueError):
+        return False
+
+    try:
+        origin = int(asset.get("origin", -1))
+    except (TypeError, ValueError):
+        origin = -1
+    if origin in CRAFT_WEAPON_ALLOWED_ORIGINS:
         return False
 
     if quality != 6:


### PR DESCRIPTION
## Summary
- add constant to list allowed origins for craft weapons
- do not filter craft weapons from achievements or promotions
- test plain craft weapons with promo origins
- document change

## Testing
- `pre-commit run black --files utils/inventory_processor.py tests/test_inventory_processor.py CHANGELOG.md`
- `pre-commit run ruff --files utils/inventory_processor.py tests/test_inventory_processor.py CHANGELOG.md`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_687061e38e288326911bba65cd6642bf