### PR TITLE
Handle hidden promotional origins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,4 +18,5 @@ All notable changes to this project will be documented in this file.
 - Updated schema caching logic and UI (previous releases).
 - Security audit using git-secrets and pip-audit.
 - Price loader now reads both Craftable and Non-Craftable price entries.
-- Plain craft weapons from achievements or promotions are no longer filtered.
+- Plain craft weapons from achievements or promotions are no longer filtered and
+  such items are hidden without price data.

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -837,12 +837,18 @@ def test_plain_craft_weapon_filtered():
 
 
 @pytest.mark.parametrize("origin", [1, 5, 9, 14])
-def test_plain_craft_weapon_with_special_origin_kept(origin):
+def test_plain_craft_weapon_with_special_origin_hidden(origin, patch_valuation):
     data = {"items": [{"defindex": 10, "quality": 6, "origin": origin}]}
     ld.ITEMS_BY_DEFINDEX = {10: {"item_name": "A", "craft_class": "weapon"}}
     ld.QUALITIES_BY_INDEX = {6: "Unique"}
+    price_map = {("A", 6, False, 0, 0): {"value_raw": 1, "currency": "metal"}}
+    patch_valuation(price_map)
     items = ip.enrich_inventory(data)
     assert len(items) == 1
+    item = items[0]
+    assert item["_hidden"] is True
+    assert "price" not in item
+    assert "price_string" not in item
 
 
 def test_special_craft_weapon_kept():

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -727,6 +727,9 @@ WAR_PAINT_TOOL_DEFINDEXES = {5681, 5682, 5683}
 # Origins that should not cause craft weapons to be filtered out
 CRAFT_WEAPON_ALLOWED_ORIGINS = {1, 5, 9, 14}
 
+# Origins that should hide items and disable pricing
+HIDDEN_ORIGINS = {1, 5, 9, 14}
+
 
 def _has_attr(asset: dict, idx: int) -> bool:
     """Return True if ``asset`` contains an attribute with ``defindex`` ``idx``."""
@@ -890,6 +893,16 @@ def _process_item(
 
     if valuation_service is None:
         valuation_service = get_valuation_service()
+
+    origin_raw = asset.get("origin")
+    try:
+        origin_int = int(origin_raw)
+    except (TypeError, ValueError):
+        origin_int = -1
+
+    hide_item = origin_int in HIDDEN_ORIGINS
+    if hide_item:
+        valuation_service = None
 
     defindex_raw = asset.get("defindex", 0)
     try:
@@ -1081,7 +1094,7 @@ def _process_item(
         "item_class": schema_entry.get("item_class"),
         "slot_type": schema_entry.get("item_slot") or schema_entry.get("slot_type"),
         "level": asset.get("level"),
-        "origin": ORIGIN_MAP.get(asset.get("origin")),
+        "origin": ORIGIN_MAP.get(origin_int),
         "custom_name": asset.get("custom_name"),
         "custom_description": asset.get("custom_desc"),
         "unusual_effect": effect,
@@ -1133,6 +1146,7 @@ def _process_item(
             if score_types.get(1) is not None
             else None
         ),
+        "_hidden": hide_item,
     }
     if valuation_service is not None:
         tradable = asset.get("tradable", 1)


### PR DESCRIPTION
## Summary
- add `HIDDEN_ORIGINS` constant
- hide promotional/achievement items in `_process_item`
- mark hidden items and skip pricing
- adjust inventory processor test
- document hidden promotional items in changelog

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py CHANGELOG.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687066d7ce18832683338c5dc9e4a549