### PR TITLE
Flag untradable timed drops as hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,4 @@ All notable changes to this project will be documented in this file.
 - Price loader now reads both Craftable and Non-Craftable price entries.
 - Plain craft weapons from achievements or promotions are no longer filtered and
   such items are hidden without price data.
+- Untradable timed-drop items are now marked as hidden.

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -967,6 +967,19 @@ def test_untradable_item_no_price(patch_valuation):
     assert "price_string" not in item
 
 
+def test_untradable_timed_drop_hidden(patch_valuation):
+    data = {"items": [{"defindex": 44, "quality": 6, "origin": 0, "tradable": 0}]}
+    ld.ITEMS_BY_DEFINDEX = {44: {"item_name": "Widget", "image_url": ""}}
+    ld.QUALITIES_BY_INDEX = {6: "Unique"}
+    price_map = {("Widget", 6, False, 0, 0): {"value_raw": 2.0, "currency": "metal"}}
+
+    patch_valuation(price_map)
+    items = ip.enrich_inventory(data)
+    item = items[0]
+    assert item["_hidden"] is True
+    assert "price" not in item
+
+
 def test_tradable_item_missing_price(patch_valuation):
     data = {"items": [{"defindex": 43, "quality": 6, "tradable": 1}]}
     ld.ITEMS_BY_DEFINDEX = {43: {"item_name": "Bazooka", "image_url": ""}}

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -1148,12 +1148,17 @@ def _process_item(
         ),
         "_hidden": hide_item,
     }
+    tradable_raw = asset.get("tradable", 1)
+    try:
+        tradable_val = int(tradable_raw)
+    except (TypeError, ValueError):  # pragma: no cover - fallback handling
+        tradable_val = 1
+
+    if origin_int == 0 and tradable_val == 0:
+        item["_hidden"] = True
+
     if valuation_service is not None:
-        tradable = asset.get("tradable", 1)
-        try:
-            tradable = int(tradable)
-        except (TypeError, ValueError):  # pragma: no cover - fallback handling
-            tradable = 1
+        tradable = tradable_val
 
         if tradable:
             try:


### PR DESCRIPTION
## Summary
- hide items that are timed drops and untradable
- test that untradable timed-drop items are marked hidden
- document the behavior change

## Testing
- `pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py CHANGELOG.md`
- `STEAM_API_KEY=test pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687069da04e88326bf5415f7f7be37a2