### PR TITLE
Load origin exclusions from JSON

### DIFF
--- a/static/exclusions.json
+++ b/static/exclusions.json
@@ -1,0 +1,4 @@
+{
+  "hidden_origins": [1, 5, 9, 14],
+  "craft_weapon_exclusions": [1, 5, 9, 14]
+}

--- a/tests/test_local_data.py
+++ b/tests/test_local_data.py
@@ -263,3 +263,14 @@ def test_effect_names_file_loaded(tmp_path, monkeypatch):
     ld.load_files()
 
     assert ld.EFFECT_NAMES["3009"] == "Silver Cyclone"
+
+
+def test_load_exclusions(tmp_path, monkeypatch):
+    path = tmp_path / "exclusions.json"
+    data = {"hidden_origins": [2], "craft_weapon_exclusions": [3]}
+    path.write_text(json.dumps(data))
+
+    monkeypatch.setattr(ld, "EXCLUSIONS_FILE", path)
+
+    loaded = ld.load_exclusions()
+    assert loaded == data

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -50,6 +50,11 @@ PATTERN_SEED_HI_CLASSES: set[str] = set()
 PAINTKIT_CLASSES: set[str] = set()
 CRATE_SERIES_CLASSES: set[str] = set()
 
+# Origins configuration loaded from ``static/exclusions.json`` via ``local_data``
+_exclusions = local_data.load_exclusions()
+CRAFT_WEAPON_ALLOWED_ORIGINS = set(_exclusions.get("craft_weapon_exclusions", []))
+HIDDEN_ORIGINS = set(_exclusions.get("hidden_origins", []))
+
 # Sets of attribute defindexes considered "special" for craft weapon detection
 SPECIAL_SPELL_ATTRS: set[int] = set(SPELL_MAP.keys()) | set(range(8900, 8926))
 SPECIAL_KILLSTREAK_ATTRS: set[int] = {2013, 2014, 2025}
@@ -723,12 +728,6 @@ def _is_warpaintable(schema_entry: Dict[str, Any]) -> bool:
 
 
 WAR_PAINT_TOOL_DEFINDEXES = {5681, 5682, 5683}
-
-# Origins that should not cause craft weapons to be filtered out
-CRAFT_WEAPON_ALLOWED_ORIGINS = {1, 5, 9, 14}
-
-# Origins that should hide items and disable pricing
-HIDDEN_ORIGINS = {1, 5, 9, 14}
 
 
 def _has_attr(asset: dict, idx: int) -> bool:

--- a/utils/local_data.py
+++ b/utils/local_data.py
@@ -90,6 +90,10 @@ STRING_LOOKUPS_FILE = Path(
     os.getenv("TF2_STRING_LOOKUPS_FILE", DEFAULT_STRING_LOOKUPS_FILE)
 )
 
+# Path to static exclusions file
+DEFAULT_EXCLUSIONS_FILE = BASE_DIR / "static" / "exclusions.json"
+EXCLUSIONS_FILE = Path(os.getenv("TF2_EXCLUSIONS_FILE", DEFAULT_EXCLUSIONS_FILE))
+
 
 def load_json(relative: str) -> Any:
     """Return parsed JSON from ``BASE_DIR / "cache" / relative`` or ``{}``."""
@@ -102,6 +106,21 @@ def load_json(relative: str) -> Any:
             return json.load(f)
     except Exception:
         return {}
+
+
+def load_exclusions() -> Dict[str, Any]:
+    """Return exclusions configuration from :data:`EXCLUSIONS_FILE`."""
+
+    if not EXCLUSIONS_FILE.exists():
+        return {}
+    try:
+        with EXCLUSIONS_FILE.open() as f:
+            data = json.load(f)
+        if isinstance(data, dict):
+            return data
+    except Exception:
+        pass
+    return {}
 
 
 def _normalize_image_url(url: str | None) -> str | None:


### PR DESCRIPTION
## Summary
- store hidden and craft weapon origins in `static/exclusions.json`
- load exclusions via new helper `load_exclusions`
- use loaded origins in `inventory_processor`
- test loading the exclusions config

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files utils/local_data.py utils/inventory_processor.py static/exclusions.json tests/test_local_data.py`

------
https://chatgpt.com/codex/tasks/task_e_6870ba140f908326ba72e530f291da24