### PR TITLE
Sort inventory by descending price

### DIFF
--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -1262,11 +1262,17 @@ def process_inventory(
     data: Dict[str, Any],
     valuation_service: ValuationService | None = None,
 ) -> List[Dict[str, Any]]:
-    """Public wrapper that sorts items by name."""
+    """Return enriched items sorted by descending price."""
     if valuation_service is None:
         valuation_service = get_valuation_service()
     items = enrich_inventory(data, valuation_service)
-    return sorted(items, key=lambda i: i["name"])
+
+    def _sort_key(item: Dict[str, Any]) -> tuple[float, str]:
+        price_info = item.get("price") or {}
+        value = price_info.get("value_raw", 0) or 0
+        return -float(value), item["name"]
+
+    return sorted(items, key=_sort_key)
 
 
 def run_enrichment_test(path: str | None = None) -> None:


### PR DESCRIPTION
## Summary
- sort inventory by price with fallback to name
- test price sorting logic when prices tie and when they differ

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files utils/inventory_processor.py tests/test_utils_extras.py`

------
https://chatgpt.com/codex/tasks/task_e_6870bf4641688326ac39d0dbb9e853bb