### PR TITLE
Implement price sorting for inventories

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,7 +12,6 @@ from types import SimpleNamespace
 from dotenv import load_dotenv
 from flask import Flask, render_template, request, flash, jsonify
 from utils.id_parser import extract_steam_ids
-from utils.inventory_processor import enrich_inventory
 import utils.inventory_processor as ip
 
 from utils import steam_api_client as sac
@@ -172,7 +171,9 @@ async def fetch_inventory(steamid64: str) -> Dict[str, Any]:
     items: List[Dict[str, Any]] = []
     if status == "parsed":
         try:
-            items = enrich_inventory(data, valuation_service=ip.get_valuation_service())
+            items = ip.process_inventory(
+                data, valuation_service=ip.get_valuation_service()
+            )
         except Exception:
             app.logger.exception("Failed to enrich inventory for %s", steamid64)
             status = "failed"

--- a/tests/test_utils_extras.py
+++ b/tests/test_utils_extras.py
@@ -45,3 +45,42 @@ def test_process_inventory_sorts_by_price():
     service = ValuationService(price_map=price_map)
     items = ip.process_inventory(data, valuation_service=service)
     assert [item["name"] for item in items] == ["B", "A"]
+
+
+@pytest.mark.asyncio
+async def test_build_user_data_items_sorted(monkeypatch, app):
+    import importlib
+
+    mod = importlib.import_module("app")
+
+    async def fake_summary(_id):
+        return {"username": "Test", "avatar": "", "playtime": 0, "profile": ""}
+
+    raw_result = {
+        "status": 1,
+        "items": [
+            {"defindex": 1, "quality": 6},
+            {"defindex": 2, "quality": 6},
+        ],
+    }
+
+    async def fake_fetch(_id):
+        return "parsed", raw_result
+
+    monkeypatch.setattr(mod, "get_player_summary", fake_summary)
+    monkeypatch.setattr(mod.sac, "fetch_inventory_async", fake_fetch)
+
+    ld.ITEMS_BY_DEFINDEX = {
+        1: {"item_name": "A", "image_url": ""},
+        2: {"item_name": "B", "image_url": ""},
+    }
+    ld.QUALITIES_BY_INDEX = {6: "Unique"}
+    price_map = {
+        ("A", 6, False, 0, 0): {"value_raw": 1.0, "currency": "metal"},
+        ("B", 6, False, 0, 0): {"value_raw": 5.0, "currency": "metal"},
+    }
+    service = ValuationService(price_map=price_map)
+    monkeypatch.setattr(mod.ip, "get_valuation_service", lambda: service)
+
+    result = await mod.build_user_data_async("1")
+    assert [item["name"] for item in result["items"]] == ["B", "A"]


### PR DESCRIPTION
## Summary
- use `process_inventory` in `fetch_inventory` for price-aware ordering
- keep stacking logic in `build_user_data_async`
- add a test ensuring inventories are sorted by price

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files app.py tests/test_utils_extras.py`

------
https://chatgpt.com/codex/tasks/task_e_6870c3046dd88326800ec82bc4ebd8f7