### PR TITLE
Handle trade holds for pricing

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,14 @@ item attribute with a defindex from `1004` to `1009`, the numeric value is
 matched against this table to produce the spell name. No schema lookups are
 required and spell names are always resolved offline.
 
+## Inventory Filtering Rules
+
+Items may be hidden or skipped from pricing based on `static/exclusions.json`.
+Items flagged with `flag_cannot_trade` are treated as untradable **unless** the
+item also contains `steam_market_tradeable_after` or
+`steam_market_marketable_after` in its description data. In that case, the item
+is priced and displayed normally despite the temporary trade hold.
+
 ## Testing
 
 Run linting and tests before committing:


### PR DESCRIPTION
## Summary
- detect temporary trade holds via `steam_market_tradeable_after` in item descriptions
- treat held items as tradable when pricing
- describe the rule in the README
- test held items remain visible and priced

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870b6c17e6c8326946504e2f56e9e2b