### PR TITLE
Add trade hold timestamp support

### DIFF
--- a/static/modal.js
+++ b/static/modal.js
@@ -145,7 +145,13 @@
 
     if (data.id && (!data.quantity || data.quantity <= 1) && !data._hidden) {
       const url = 'https://next.backpack.tf/item/' + esc(data.id);
-      attrs.push('<div><a href="' + url + '" target="_blank" rel="noopener" class="history-link">History\ud83d\udd0e</a></div>');
+      let link = '<div><a href="' + url + '" target="_blank" rel="noopener" class="history-link">History\ud83d\udd0e</a>';
+      if (data.trade_hold_expires) {
+        const dateStr = new Date(data.trade_hold_expires * 1000).toLocaleString();
+        link += ' Tradable after: ' + esc(dateStr);
+      }
+      link += '</div>';
+      attrs.push(link);
     }
 
     const details = attrs.join('') + spells;

--- a/tests/test_modal.js
+++ b/tests/test_modal.js
@@ -65,6 +65,15 @@ const htmlHistory = modal.generateModalHTML({ id: 123 });
 if (!htmlHistory.includes('https://next.backpack.tf/item/123')) {
   throw new Error('History link missing');
 }
+const thTs = 1600000000;
+const htmlHold = modal.generateModalHTML({ id: 123, trade_hold_expires: thTs });
+const expectedDate = new Date(thTs * 1000).toLocaleString();
+if (!htmlHold.includes('Tradable after:')) {
+  throw new Error('Trade hold text missing');
+}
+if (!htmlHold.includes(expectedDate)) {
+  throw new Error('Trade hold date missing');
+}
 const htmlStacked = modal.generateModalHTML({ id: 123, quantity: 2 });
 if (htmlStacked.includes('backpack.tf')) {
   throw new Error('History link should not show for stacked items');


### PR DESCRIPTION
## Summary
- expose `_trade_hold_timestamp` helper for parsing trade hold dates
- surface `trade_hold_expires` in processed items
- render trade hold expiry in modal next to History link
- test modal HTML formatting for trade hold text

## Testing
- `pre-commit run --files utils/inventory_processor.py static/modal.js tests/test_modal.js`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870d2d9582c8326bc95dc13155c3ff9