### PR TITLE
Add trade hold item indicator

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -240,6 +240,9 @@ button {
   background-color: var(--quality-color, #1e1e1e);
   position: relative; /* ensure badges overlay */
 }
+.item-card.trade-hold {
+  border: 2px solid #ff4040;
+}
 
 .particle-overlay {
   position: absolute;

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -1,4 +1,4 @@
-<div class="item-card"
+<div class="item-card{% if item.untradable_hold %} trade-hold{% endif %}"
      style="--quality-color: {{ item.quality_color }}; border-color: {{ item.quality_color }};"
      data-item='{{ item|tojson|safe }}'>
   <div class="item-badges">

--- a/tests/test_user_template.py
+++ b/tests/test_user_template.py
@@ -202,3 +202,27 @@ def test_failed_user_has_retry_class(app):
     assert card is not None
     classes = card.get("class", [])
     assert "retry-card" in classes
+
+
+def test_trade_hold_class_rendered(app):
+    context = {
+        "user": {
+            "items": [
+                {
+                    "name": "Widget",
+                    "image_url": "",
+                    "quality_color": "#fff",
+                    "untradable_hold": True,
+                }
+            ]
+        }
+    }
+    with app.test_request_context():
+        app_module = importlib.import_module("app")
+        context["user"] = app_module.normalize_user_payload(context["user"])
+        html = render_template_string(HTML, **context)
+    soup = BeautifulSoup(html, "html.parser")
+    card = soup.find("div", class_="item-card")
+    assert card is not None
+    classes = card.get("class", [])
+    assert "trade-hold" in classes

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -930,6 +930,8 @@ def _process_item(
 
     origin_raw = asset.get("origin")
     tradable_raw = asset.get("tradable", 1)
+    trade_hold_ts = _trade_hold_timestamp(asset)
+    untradable_hold = False
     try:
         origin_int = int(origin_raw)
     except (TypeError, ValueError):
@@ -941,8 +943,9 @@ def _process_item(
         tradable_val = 1
 
     if asset.get("flag_cannot_trade"):
-        if _has_trade_hold(asset):
+        if trade_hold_ts is not None:
             tradable_val = 1
+            untradable_hold = True
         else:
             tradable_val = 0
 
@@ -1192,7 +1195,8 @@ def _process_item(
             if score_types.get(1) is not None
             else None
         ),
-        "trade_hold_expires": _trade_hold_timestamp(asset),
+        "trade_hold_expires": trade_hold_ts,
+        "untradable_hold": untradable_hold,
         "_hidden": hide_item,
     }
 


### PR DESCRIPTION
## Summary
- mark items flagged `cannot trade` but with a trade hold timestamp
- show a red border around items in trade hold
- test HTML template for the new class

## Testing
- `pre-commit run --files utils/inventory_processor.py templates/item_card.html static/style.css tests/test_user_template.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870d4d3d90c83268097554afd136155