### PR TITLE
Update hidden item rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,8 @@ Items may be hidden or skipped from pricing based on `static/exclusions.json`.
 Items flagged with `flag_cannot_trade` are treated as untradable **unless** the
 item also contains `steam_market_tradeable_after` or
 `steam_market_marketable_after` in its description data. In that case, the item
-is priced and displayed normally despite the temporary trade hold.
+is priced and displayed normally despite the temporary trade hold. Any
+untradable item without a temporary trade hold is hidden from display.
 
 ## Testing
 

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -983,6 +983,7 @@ def test_untradable_item_no_price(patch_valuation):
     item = items[0]
     assert "price" not in item
     assert "price_string" not in item
+    assert item["_hidden"] is True
 
 
 def test_trade_hold_item_priced(patch_valuation):
@@ -1036,6 +1037,23 @@ def test_untradable_origin_hidden(origin, patch_valuation):
     data = {
         "items": [
             {"defindex": 44, "quality": 6, "origin": origin, "flag_cannot_trade": True}
+        ]
+    }
+    ld.ITEMS_BY_DEFINDEX = {44: {"item_name": "Widget", "image_url": ""}}
+    ld.QUALITIES_BY_INDEX = {6: "Unique"}
+    price_map = {("Widget", 6, False, 0, 0): {"value_raw": 2.0, "currency": "metal"}}
+
+    patch_valuation(price_map)
+    items = ip.enrich_inventory(data)
+    item = items[0]
+    assert item["_hidden"] is True
+    assert "price" not in item
+
+
+def test_untradable_nonlisted_origin_hidden(patch_valuation):
+    data = {
+        "items": [
+            {"defindex": 44, "quality": 6, "origin": 3, "flag_cannot_trade": True}
         ]
     }
     ld.ITEMS_BY_DEFINDEX = {44: {"item_name": "Widget", "image_url": ""}}

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -53,7 +53,6 @@ CRATE_SERIES_CLASSES: set[str] = set()
 # Origins configuration loaded from ``static/exclusions.json`` via ``local_data``
 _exclusions = local_data.load_exclusions()
 CRAFT_WEAPON_ALLOWED_ORIGINS = set(_exclusions.get("craft_weapon_exclusions", []))
-HIDDEN_ORIGINS = set(_exclusions.get("hidden_origins", []))
 
 # Sets of attribute defindexes considered "special" for craft weapon detection
 SPECIAL_SPELL_ATTRS: set[int] = set(SPELL_MAP.keys()) | set(range(8900, 8926))
@@ -949,7 +948,7 @@ def _process_item(
         else:
             tradable_val = 0
 
-    hide_item = tradable_val == 0 and origin_int in HIDDEN_ORIGINS
+    hide_item = tradable_val == 0
     if hide_item:
         valuation_service = None
 


### PR DESCRIPTION
## Summary
- hide all untradable items regardless of origin
- ensure tests check for `_hidden` flag on untradable items
- add test for unlisted origin behavior
- clarify filtering rule in README

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870df61ec70832680c2a9784639c6c0