### PR TITLE
Add uncraftable flag support

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -1253,3 +1253,19 @@ def test_extract_wear_attr_749(monkeypatch):
     asset = {"attributes": [{"defindex": 749, "float_value": 0.04}]}
     wear = ip._extract_wear(asset)
     assert wear == "Factory New"
+
+
+def test_uncraftable_flag_true():
+    data = {"items": [{"defindex": 111, "quality": 6, "flag_cannot_craft": True}]}
+    ld.ITEMS_BY_DEFINDEX = {111: {"item_name": "Thing"}}
+    ld.QUALITIES_BY_INDEX = {6: "Unique"}
+    items = ip.enrich_inventory(data)
+    assert items[0]["uncraftable"] is True
+
+
+def test_uncraftable_flag_absent():
+    data = {"items": [{"defindex": 111, "quality": 6}]}
+    ld.ITEMS_BY_DEFINDEX = {111: {"item_name": "Thing"}}
+    ld.QUALITIES_BY_INDEX = {6: "Unique"}
+    items = ip.enrich_inventory(data)
+    assert items[0]["uncraftable"] is False

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -952,6 +952,8 @@ def _process_item(
     if hide_item:
         valuation_service = None
 
+    uncraftable = bool(asset.get("flag_cannot_craft"))
+
     defindex_raw = asset.get("defindex", 0)
     try:
         defindex_int = int(defindex_raw)
@@ -1196,6 +1198,7 @@ def _process_item(
         ),
         "trade_hold_expires": trade_hold_ts,
         "untradable_hold": untradable_hold,
+        "uncraftable": uncraftable,
         "_hidden": hide_item,
     }
 


### PR DESCRIPTION
## Summary
- capture uncraftable status in `_process_item`
- return `"uncraftable"` field in items
- test uncraftable flag behaviour

## Testing
- `pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6870e619182883269ed2f98fb3ee24c4