### PR TITLE
Add uncraftable item style

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -243,6 +243,9 @@ button {
 .item-card.trade-hold {
   border: 2px solid #ff4040;
 }
+.item-card.uncraftable {
+  border-style: dashed;
+}
 
 .particle-overlay {
   position: absolute;

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -1,4 +1,4 @@
-<div class="item-card{% if item.untradable_hold %} trade-hold{% endif %}"
+<div class="item-card{% if item.untradable_hold %} trade-hold{% endif %}{% if item.uncraftable %} uncraftable{% endif %}"
      style="--quality-color: {{ item.quality_color }}; border-color: {{ item.quality_color }};"
      data-item='{{ item|tojson|safe }}'>
   <div class="item-badges">

--- a/tests/test_user_template.py
+++ b/tests/test_user_template.py
@@ -226,3 +226,27 @@ def test_trade_hold_class_rendered(app):
     assert card is not None
     classes = card.get("class", [])
     assert "trade-hold" in classes
+
+
+def test_uncraftable_class_rendered(app):
+    context = {
+        "user": {
+            "items": [
+                {
+                    "name": "Gadget",
+                    "image_url": "",
+                    "quality_color": "#fff",
+                    "uncraftable": True,
+                }
+            ]
+        }
+    }
+    with app.test_request_context():
+        app_module = importlib.import_module("app")
+        context["user"] = app_module.normalize_user_payload(context["user"])
+        html = render_template_string(HTML, **context)
+    soup = BeautifulSoup(html, "html.parser")
+    card = soup.find("div", class_="item-card")
+    assert card is not None
+    classes = card.get("class", [])
+    assert "uncraftable" in classes


### PR DESCRIPTION
## Summary
- mark uncraftable items with a CSS class
- style uncraftable item cards with a dashed border
- test that uncraftable items render the new class

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files templates/item_card.html static/style.css tests/test_user_template.py`

------
https://chatgpt.com/codex/tasks/task_e_6870e7af872083269909f3a4c23d34ad