### PR TITLE
Handle craftable prices

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -845,7 +845,7 @@ def test_plain_craft_weapon_with_special_origin_hidden(origin, patch_valuation):
     }
     ld.ITEMS_BY_DEFINDEX = {10: {"item_name": "A", "craft_class": "weapon"}}
     ld.QUALITIES_BY_INDEX = {6: "Unique"}
-    price_map = {("A", 6, False, 0, 0): {"value_raw": 1, "currency": "metal"}}
+    price_map = {("A", 6, True, False, 0, 0): {"value_raw": 1, "currency": "metal"}}
     patch_valuation(price_map)
     items = ip.enrich_inventory(data)
     assert len(items) == 1
@@ -860,7 +860,7 @@ def test_plain_craft_weapon_with_special_origin_visible(origin, patch_valuation)
     data = {"items": [{"defindex": 10, "quality": 6, "origin": origin, "tradable": 1}]}
     ld.ITEMS_BY_DEFINDEX = {10: {"item_name": "A", "craft_class": "weapon"}}
     ld.QUALITIES_BY_INDEX = {6: "Unique"}
-    price_map = {("A", 6, False, 0, 0): {"value_raw": 1, "currency": "metal"}}
+    price_map = {("A", 6, True, False, 0, 0): {"value_raw": 1, "currency": "metal"}}
     patch_valuation(price_map)
     items = ip.enrich_inventory(data)
     assert len(items) == 1
@@ -905,13 +905,15 @@ def test_price_map_applied(patch_valuation):
     data = {"items": [{"defindex": 42, "quality": 6}]}
     ld.ITEMS_BY_DEFINDEX = {42: {"item_name": "Answer", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {6: "Unique"}
-    price_map = {("Answer", 6, False, 0, 0): {"value_raw": 5.33, "currency": "metal"}}
+    price_map = {
+        ("Answer", 6, True, False, 0, 0): {"value_raw": 5.33, "currency": "metal"}
+    }
     ld.CURRENCIES = {"keys": {"price": {"value_raw": 50.0}}}
 
     patch_valuation(price_map)
     items = ip.enrich_inventory(data)
     item = items[0]
-    assert item["price"] == price_map[("Answer", 6, False, 0, 0)]
+    assert item["price"] == price_map[("Answer", 6, True, False, 0, 0)]
     assert item["price_string"] == "5.33 ref"
     assert item["formatted_price"] == "5.33 ref"
 
@@ -921,14 +923,17 @@ def test_price_map_strange_lookup(patch_valuation):
     ld.ITEMS_BY_DEFINDEX = {111: {"item_name": "Rocket Launcher", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {11: "Strange"}
     price_map = {
-        ("Rocket Launcher", 11, False, 0, 0): {"value_raw": 5.33, "currency": "metal"}
+        ("Rocket Launcher", 11, True, False, 0, 0): {
+            "value_raw": 5.33,
+            "currency": "metal",
+        }
     }
     ld.CURRENCIES = {"keys": {"price": {"value_raw": 50.0}}}
 
     patch_valuation(price_map)
     items = ip.enrich_inventory(data)
     item = items[0]
-    assert item["price"] == price_map[("Rocket Launcher", 11, False, 0, 0)]
+    assert item["price"] == price_map[("Rocket Launcher", 11, True, False, 0, 0)]
     assert item["price_string"] == "5.33 ref"
     assert item["formatted_price"] == "5.33 ref"
 
@@ -937,7 +942,9 @@ def test_price_map_key_conversion_large_value(patch_valuation):
     data = {"items": [{"defindex": 42, "quality": 6}]}
     ld.ITEMS_BY_DEFINDEX = {42: {"item_name": "Answer", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {6: "Unique"}
-    price_map = {("Answer", 6, False, 0, 0): {"value_raw": 367.73, "currency": "metal"}}
+    price_map = {
+        ("Answer", 6, True, False, 0, 0): {"value_raw": 367.73, "currency": "metal"}
+    }
     ld.CURRENCIES = {"keys": {"price": {"value_raw": 70.0}}}
 
     patch_valuation(price_map)
@@ -960,7 +967,7 @@ def test_price_map_unusual_lookup(patch_valuation):
     ld.ITEMS_BY_DEFINDEX = {30998: {"item_name": "Veil", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {5: "Unusual"}
     price_map = {
-        ("Veil", 5, False, 13, 0): {"value_raw": 164554.25, "currency": "keys"}
+        ("Veil", 5, True, False, 13, 0): {"value_raw": 164554.25, "currency": "keys"}
     }
     ld.CURRENCIES = {"keys": {"price": {"value_raw": 67.165}}}
 
@@ -975,7 +982,9 @@ def test_untradable_item_no_price(patch_valuation):
     data = {"items": [{"defindex": 42, "quality": 6, "flag_cannot_trade": True}]}
     ld.ITEMS_BY_DEFINDEX = {42: {"item_name": "Answer", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {6: "Unique"}
-    price_map = {("Answer", 6, False, 0, 0): {"value_raw": 5.33, "currency": "metal"}}
+    price_map = {
+        ("Answer", 6, True, False, 0, 0): {"value_raw": 5.33, "currency": "metal"}
+    }
     ld.CURRENCIES = {"keys": {"price": {"value_raw": 50.0}}}
 
     patch_valuation(price_map)
@@ -1004,13 +1013,15 @@ def test_trade_hold_item_priced(patch_valuation):
     }
     ld.ITEMS_BY_DEFINDEX = {42: {"item_name": "Answer", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {6: "Unique"}
-    price_map = {("Answer", 6, False, 0, 0): {"value_raw": 5.33, "currency": "metal"}}
+    price_map = {
+        ("Answer", 6, True, False, 0, 0): {"value_raw": 5.33, "currency": "metal"}
+    }
     ld.CURRENCIES = {"keys": {"price": {"value_raw": 50.0}}}
 
     patch_valuation(price_map)
     items = ip.enrich_inventory(data)
     item = items[0]
-    assert item["price"] == price_map[("Answer", 6, False, 0, 0)]
+    assert item["price"] == price_map[("Answer", 6, True, False, 0, 0)]
     assert item["_hidden"] is False
 
 
@@ -1022,7 +1033,9 @@ def test_flag_cannot_trade_overrides_tradable(tradable_val, patch_valuation):
     data = {"items": [asset]}
     ld.ITEMS_BY_DEFINDEX = {42: {"item_name": "Answer", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {6: "Unique"}
-    price_map = {("Answer", 6, False, 0, 0): {"value_raw": 5.33, "currency": "metal"}}
+    price_map = {
+        ("Answer", 6, True, False, 0, 0): {"value_raw": 5.33, "currency": "metal"}
+    }
     ld.CURRENCIES = {"keys": {"price": {"value_raw": 50.0}}}
 
     patch_valuation(price_map)
@@ -1041,7 +1054,9 @@ def test_untradable_origin_hidden(origin, patch_valuation):
     }
     ld.ITEMS_BY_DEFINDEX = {44: {"item_name": "Widget", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {6: "Unique"}
-    price_map = {("Widget", 6, False, 0, 0): {"value_raw": 2.0, "currency": "metal"}}
+    price_map = {
+        ("Widget", 6, True, False, 0, 0): {"value_raw": 2.0, "currency": "metal"}
+    }
 
     patch_valuation(price_map)
     items = ip.enrich_inventory(data)
@@ -1058,7 +1073,9 @@ def test_untradable_nonlisted_origin_hidden(patch_valuation):
     }
     ld.ITEMS_BY_DEFINDEX = {44: {"item_name": "Widget", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {6: "Unique"}
-    price_map = {("Widget", 6, False, 0, 0): {"value_raw": 2.0, "currency": "metal"}}
+    price_map = {
+        ("Widget", 6, True, False, 0, 0): {"value_raw": 2.0, "currency": "metal"}
+    }
 
     patch_valuation(price_map)
     items = ip.enrich_inventory(data)
@@ -1083,13 +1100,15 @@ def test_trade_hold_origin_visible(patch_valuation):
     }
     ld.ITEMS_BY_DEFINDEX = {44: {"item_name": "Widget", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {6: "Unique"}
-    price_map = {("Widget", 6, False, 0, 0): {"value_raw": 2.0, "currency": "metal"}}
+    price_map = {
+        ("Widget", 6, True, False, 0, 0): {"value_raw": 2.0, "currency": "metal"}
+    }
 
     patch_valuation(price_map)
     items = ip.enrich_inventory(data)
     item = items[0]
     assert item["_hidden"] is False
-    assert item["price"] == price_map[("Widget", 6, False, 0, 0)]
+    assert item["price"] == price_map[("Widget", 6, True, False, 0, 0)]
 
 
 @pytest.mark.parametrize("origin", [0, 1, 5, 14])
@@ -1097,7 +1116,9 @@ def test_tradable_origin_visible(origin, patch_valuation):
     data = {"items": [{"defindex": 44, "quality": 6, "origin": origin, "tradable": 1}]}
     ld.ITEMS_BY_DEFINDEX = {44: {"item_name": "Widget", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {6: "Unique"}
-    price_map = {("Widget", 6, False, 0, 0): {"value_raw": 2.0, "currency": "metal"}}
+    price_map = {
+        ("Widget", 6, True, False, 0, 0): {"value_raw": 2.0, "currency": "metal"}
+    }
 
     patch_valuation(price_map)
     items = ip.enrich_inventory(data)
@@ -1153,14 +1174,21 @@ def test_price_map_australium_lookup(patch_valuation):
     ld.ITEMS_BY_DEFINDEX = {205: {"item_name": "Rocket Launcher", "image_url": ""}}
     ld.QUALITIES_BY_INDEX = {6: "Unique"}
     price_map = {
-        ("Rocket Launcher", 6, True, 0, 0): {"value_raw": 100.0, "currency": "keys"}
+        (
+            "Rocket Launcher",
+            6,
+            True,
+            True,
+            0,
+            0,
+        ): {"value_raw": 100.0, "currency": "keys"}
     }
     ld.CURRENCIES = {"keys": {"price": {"value_raw": 50.0}}}
 
     patch_valuation(price_map)
     items = ip.enrich_inventory(data)
     item = items[0]
-    assert item["price"] == price_map[("Rocket Launcher", 6, True, 0, 0)]
+    assert item["price"] == price_map[("Rocket Launcher", 6, True, True, 0, 0)]
     assert item["formatted_price"] == "2 Keys"
 
 
@@ -1261,6 +1289,7 @@ def test_uncraftable_flag_true():
     ld.QUALITIES_BY_INDEX = {6: "Unique"}
     items = ip.enrich_inventory(data)
     assert items[0]["uncraftable"] is True
+    assert items[0]["craftable"] is False
 
 
 def test_uncraftable_flag_absent():
@@ -1269,3 +1298,4 @@ def test_uncraftable_flag_absent():
     ld.QUALITIES_BY_INDEX = {6: "Unique"}
     items = ip.enrich_inventory(data)
     assert items[0]["uncraftable"] is False
+    assert items[0]["craftable"] is True

--- a/tests/test_price_loader.py
+++ b/tests/test_price_loader.py
@@ -38,7 +38,7 @@ def test_price_map_smoke(tmp_path, monkeypatch):
         p = price_loader.ensure_prices_cached(refresh=True)
 
     mapping = price_loader.build_price_map(p)
-    key = ("Mann Co. Supply Crate Key", 6, False, 0, 0)
+    key = ("Mann Co. Supply Crate Key", 6, True, False, 0, 0)
     assert key in mapping
     assert mapping[key]["currency"] == "metal"
 
@@ -77,7 +77,7 @@ def test_price_map_non_craftable(tmp_path, monkeypatch):
         p = price_loader.ensure_prices_cached(refresh=True)
 
     mapping = price_loader.build_price_map(p)
-    key = ("Hat", 5, False, 0, 0)
+    key = ("Hat", 5, False, False, 0, 0)
     assert key in mapping
     assert mapping[key]["currency"] == "keys"
 
@@ -116,7 +116,7 @@ def test_price_map_unusual_effect(tmp_path, monkeypatch):
         p = price_loader.ensure_prices_cached(refresh=True)
 
     mapping = price_loader.build_price_map(p)
-    key = ("Villain's Veil", 5, False, 13, 0)
+    key = ("Villain's Veil", 5, True, False, 13, 0)
     assert key in mapping
     assert mapping[key]["currency"] == "keys"
 
@@ -156,7 +156,7 @@ def test_price_map_australium(tmp_path, monkeypatch):
         p = price_loader.ensure_prices_cached(refresh=True)
 
     mapping = price_loader.build_price_map(p)
-    assert ("Rocket Launcher", 6, True, 0, 0) in mapping
+    assert ("Rocket Launcher", 6, True, True, 0, 0) in mapping
 
 
 def test_price_map_killstreak(tmp_path, monkeypatch):
@@ -193,7 +193,7 @@ def test_price_map_killstreak(tmp_path, monkeypatch):
         p = price_loader.ensure_prices_cached(refresh=True)
 
     mapping = price_loader.build_price_map(p)
-    assert ("Rocket Launcher", 6, False, 0, 3) in mapping
+    assert ("Rocket Launcher", 6, True, False, 0, 3) in mapping
 
 
 def test_price_map_quality_killstreak(tmp_path, monkeypatch):
@@ -230,7 +230,7 @@ def test_price_map_quality_killstreak(tmp_path, monkeypatch):
         p = price_loader.ensure_prices_cached(refresh=True)
 
     mapping = price_loader.build_price_map(p)
-    assert ("Rocket Launcher", 11, False, 0, 3) in mapping
+    assert ("Rocket Launcher", 11, True, False, 0, 3) in mapping
 
 
 def test_missing_api_key(monkeypatch):

--- a/tests/test_utils_extras.py
+++ b/tests/test_utils_extras.py
@@ -23,8 +23,8 @@ def test_process_inventory_sorting():
     }
     ld.QUALITIES_BY_INDEX = {6: "Unique"}
     price_map = {
-        ("A", 6, False, 0, 0): {"value_raw": 1.0, "currency": "metal"},
-        ("B", 6, False, 0, 0): {"value_raw": 1.0, "currency": "metal"},
+        ("A", 6, True, False, 0, 0): {"value_raw": 1.0, "currency": "metal"},
+        ("B", 6, True, False, 0, 0): {"value_raw": 1.0, "currency": "metal"},
     }
     service = ValuationService(price_map=price_map)
     items = ip.process_inventory(data, valuation_service=service)
@@ -39,8 +39,8 @@ def test_process_inventory_sorts_by_price():
     }
     ld.QUALITIES_BY_INDEX = {6: "Unique"}
     price_map = {
-        ("A", 6, False, 0, 0): {"value_raw": 2.0, "currency": "metal"},
-        ("B", 6, False, 0, 0): {"value_raw": 5.0, "currency": "metal"},
+        ("A", 6, True, False, 0, 0): {"value_raw": 2.0, "currency": "metal"},
+        ("B", 6, True, False, 0, 0): {"value_raw": 5.0, "currency": "metal"},
     }
     service = ValuationService(price_map=price_map)
     items = ip.process_inventory(data, valuation_service=service)
@@ -76,8 +76,8 @@ async def test_build_user_data_items_sorted(monkeypatch, app):
     }
     ld.QUALITIES_BY_INDEX = {6: "Unique"}
     price_map = {
-        ("A", 6, False, 0, 0): {"value_raw": 1.0, "currency": "metal"},
-        ("B", 6, False, 0, 0): {"value_raw": 5.0, "currency": "metal"},
+        ("A", 6, True, False, 0, 0): {"value_raw": 1.0, "currency": "metal"},
+        ("B", 6, True, False, 0, 0): {"value_raw": 5.0, "currency": "metal"},
     }
     service = ValuationService(price_map=price_map)
     monkeypatch.setattr(mod.ip, "get_valuation_service", lambda: service)

--- a/tests/test_valuation_service.py
+++ b/tests/test_valuation_service.py
@@ -3,20 +3,50 @@ from utils import local_data
 
 
 def test_get_price_info():
-    price_map = {("Item", 6, False, 0, 0): {"value_raw": 5.0, "currency": "metal"}}
+    price_map = {
+        (
+            "Item",
+            6,
+            True,
+            False,
+            0,
+            0,
+        ): {"value_raw": 5.0, "currency": "metal"}
+    }
     service = ValuationService(price_map=price_map)
-    assert service.get_price_info("Item", 6) == {"value_raw": 5.0, "currency": "metal"}
+    assert service.get_price_info("Item", 6, True) == {
+        "value_raw": 5.0,
+        "currency": "metal",
+    }
 
 
 def test_format_price(monkeypatch):
-    price_map = {("Item", 6, False, 0, 0): {"value_raw": 50.0, "currency": "metal"}}
+    price_map = {
+        (
+            "Item",
+            6,
+            True,
+            False,
+            0,
+            0,
+        ): {"value_raw": 50.0, "currency": "metal"}
+    }
     service = ValuationService(price_map=price_map)
     local_data.CURRENCIES = {"keys": {"price": {"value_raw": 50.0}}}
-    assert service.format_price("Item", 6) == "1 Key"
+    assert service.format_price("Item", 6, True) == "1 Key"
 
 
 def test_killstreak_tier_lookup(monkeypatch):
-    price_map = {("Item", 6, False, 0, 2): {"value_raw": 100.0, "currency": "keys"}}
+    price_map = {
+        (
+            "Item",
+            6,
+            True,
+            False,
+            0,
+            2,
+        ): {"value_raw": 100.0, "currency": "keys"}
+    }
     service = ValuationService(price_map=price_map)
     local_data.CURRENCIES = {"keys": {"price": {"value_raw": 50.0}}}
-    assert service.format_price("Item", 6, killstreak_tier=2) == "2 Keys"
+    assert service.format_price("Item", 6, True, killstreak_tier=2) == "2 Keys"

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -953,6 +953,7 @@ def _process_item(
         valuation_service = None
 
     uncraftable = bool(asset.get("flag_cannot_craft"))
+    craftable = not uncraftable
 
     defindex_raw = asset.get("defindex", 0)
     try:
@@ -1199,6 +1200,7 @@ def _process_item(
         "trade_hold_expires": trade_hold_ts,
         "untradable_hold": untradable_hold,
         "uncraftable": uncraftable,
+        "craftable": craftable,
         "_hidden": hide_item,
     }
 
@@ -1214,6 +1216,7 @@ def _process_item(
                 formatted = valuation_service.format_price(
                     item.get("base_name", base_name),
                     qid,
+                    craftable,
                     bool(is_australium),
                     effect_id=effect_id,
                     killstreak_tier=ks_tier_val,
@@ -1225,6 +1228,7 @@ def _process_item(
                 item["price"] = valuation_service.get_price_info(
                     item.get("base_name", base_name),
                     qid,
+                    craftable,
                     bool(is_australium),
                     effect_id=effect_id,
                     killstreak_tier=ks_tier_val,

--- a/utils/valuation_service.py
+++ b/utils/valuation_service.py
@@ -26,7 +26,9 @@ class ValuationService:
 
     def __init__(
         self,
-        price_map: Dict[Tuple[str, int, bool, int, int], Dict[str, Any]] | None = None,
+        price_map: (
+            Dict[Tuple[str, int, bool, bool, int, int], Dict[str, Any]] | None
+        ) = None,
     ) -> None:
         if price_map is None:
             path = ensure_prices_cached()
@@ -37,20 +39,42 @@ class ValuationService:
         self,
         item_name: str,
         quality: int,
+        craftable: bool = True,
         is_australium: bool = False,
         effect_id: int | None = None,
         killstreak_tier: int | None = None,
     ) -> Dict[str, Any] | None:
         """Return raw price info dict for the item if available."""
-        key = (item_name, quality, is_australium, effect_id or 0, killstreak_tier or 0)
+        key = (
+            item_name,
+            quality,
+            craftable,
+            is_australium,
+            effect_id or 0,
+            killstreak_tier or 0,
+        )
         info = self.price_map.get(key)
         if info is None and killstreak_tier is not None:
             info = self.price_map.get(
-                (item_name, quality, is_australium, effect_id or 0, 0)
+                (
+                    item_name,
+                    quality,
+                    craftable,
+                    is_australium,
+                    effect_id or 0,
+                    0,
+                )
             )
         if info is None and effect_id is not None:
             info = self.price_map.get(
-                (item_name, quality, is_australium, 0, killstreak_tier or 0)
+                (
+                    item_name,
+                    quality,
+                    craftable,
+                    is_australium,
+                    0,
+                    killstreak_tier or 0,
+                )
             )
         return info
 
@@ -58,6 +82,7 @@ class ValuationService:
         self,
         item_name: str,
         quality: int,
+        craftable: bool = True,
         is_australium: bool = False,
         *,
         effect_id: int | None = None,
@@ -68,6 +93,7 @@ class ValuationService:
         info = self.get_price_info(
             item_name,
             quality,
+            craftable,
             is_australium,
             effect_id,
             killstreak_tier,


### PR DESCRIPTION
## Summary
- store craftable flag in price map keys
- allow ValuationService lookups to specify craftable
- propagate craftable through inventory processing
- update tests for craftable-aware pricing

## Testing
- `pre-commit run --files utils/price_loader.py utils/valuation_service.py utils/inventory_processor.py tests/test_price_loader.py tests/test_valuation_service.py tests/test_inventory_processor.py tests/test_utils_extras.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870ee3031688326a0a43daf759a4f0a