### PR TITLE
Add craftable info to item modal

### DIFF
--- a/static/modal.js
+++ b/static/modal.js
@@ -96,6 +96,14 @@
     ;[
       ['Type', data.item_type_name],
       ['Level', data.level],
+      [
+        'Craftable',
+        typeof data.craftable === 'boolean'
+          ? data.craftable
+            ? 'Craftable'
+            : 'Uncraftable'
+          : null,
+      ],
       ['Origin', data.origin],
     ].forEach(([label, value]) => {
       if (!value) return;

--- a/templates/_modal.html
+++ b/templates/_modal.html
@@ -10,4 +10,7 @@
       <span class="unusual-effect">{{ item.unusual_effect_name }}</span>
     </p>
   {% endif %}
+  {% if item.craftable is not none %}
+    <p><strong>{% if item.craftable %}Craftable{% else %}Uncraftable{% endif %}</strong></p>
+  {% endif %}
 </div>

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -1,6 +1,7 @@
 <div class="item-card{% if item.untradable_hold %} trade-hold{% endif %}{% if item.uncraftable %} uncraftable{% endif %}"
      style="--quality-color: {{ item.quality_color }}; border-color: {{ item.quality_color }};"
-     data-item='{{ item|tojson|safe }}'>
+     data-item='{{ item|tojson|safe }}'
+     data-craftable="{{ 'true' if item.craftable else 'false' }}">
   <div class="item-badges">
     {% if item.paint_hex %}
       <span class="paint-dot" style="background-color: {{ item.paint_hex }};" title="Paint: {{ item.paint_name }}"></span>

--- a/tests/test_item_modal_template.py
+++ b/tests/test_item_modal_template.py
@@ -34,3 +34,19 @@ def test_killstreak_badge_color(app):
     assert badge is not None
     assert badge.text.strip() == "Professional Killstreak"
     assert "#8847ff" in badge.get("style", "")
+
+
+def test_craftable_text_shown(app):
+    item = {"craftable": True}
+    with app.app_context():
+        html = render_template("_modal.html", item=item)
+    soup = BeautifulSoup(html, "html.parser")
+    assert "Craftable" in soup.text
+
+
+def test_uncraftable_text_shown(app):
+    item = {"craftable": False}
+    with app.app_context():
+        html = render_template("_modal.html", item=item)
+    soup = BeautifulSoup(html, "html.parser")
+    assert "Uncraftable" in soup.text


### PR DESCRIPTION
## Summary
- add `data-craftable` attr to item cards
- display Craftable/Uncraftable text in item modal
- expose craftable flag in `_modal.html`
- test for craftable status rendering

## Testing
- `pre-commit run --files templates/item_card.html static/modal.js templates/_modal.html tests/test_item_modal_template.py`

------
https://chatgpt.com/codex/tasks/task_e_6870f16ec96c8326a75f0458ddfcdb17