### PR TITLE
Fix item card border layering

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -234,14 +234,29 @@ button {
   height: 112px;
   padding: 4px;
   margin: 0;
-  border: 2px solid #FFDD00;
+  border: none; /* border drawn via pseudo-element */
   border-radius: 8px;
   overflow: hidden;
   background-color: var(--quality-color, #1e1e1e);
   position: relative; /* ensure badges overlay */
+  border-color: #FFDD00;
+  border-style: solid;
+  border-width: 2px;
+}
+
+.item-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-color: inherit;
+  border-style: inherit;
+  border-width: inherit;
+  border-radius: inherit;
+  pointer-events: none;
+  z-index: 2; /* above particle overlays */
 }
 .item-card.trade-hold {
-  border: 2px solid #ff4040;
+  border-color: #ff4040;
 }
 .item-card.uncraftable {
   border-style: dashed;


### PR DESCRIPTION
## Summary
- tweak `.item-card` so its border appears above effect overlays

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files static/style.css`

------
https://chatgpt.com/codex/tasks/task_e_6870f2e7fe308326990fc3af6302a608