### PR TITLE
Increase uncraftable item border width

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -260,6 +260,7 @@ button {
 }
 .item-card.uncraftable {
   border-style: dashed;
+  border-width: 2px;
 }
 
 .particle-overlay {


### PR DESCRIPTION
## Summary
- tweak `.item-card.uncraftable` styles so dashed border is thicker

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files static/style.css`
- `SKIP_VALIDATE=1 STEAM_API_KEY=test pytest`

------
https://chatgpt.com/codex/tasks/task_e_6870f739454c832693fd0411dc453798