### PR TITLE
Add inner border style for uncraftable items

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -261,6 +261,7 @@ button {
 .item-card.uncraftable {
   border-style: dashed;
   border-width: 2px;
+  box-shadow: inset 0 0 0 2px #aaa; /* inner border inside quality color */
 }
 
 .particle-overlay {


### PR DESCRIPTION
## Summary
- show uncraftable class on item cards
- highlight uncraftable items with inner border

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files static/style.css templates/item_card.html utils/inventory_processor.py tests/test_inventory_processor.py`

------
https://chatgpt.com/codex/tasks/task_e_6870fd287d7083268fee3ccabf880770