### PR TITLE
Fix newline handling in price map

### DIFF
--- a/utils/price_loader.py
+++ b/utils/price_loader.py
@@ -181,6 +181,7 @@ def build_price_map(
         base_name = (
             name.replace("Australium ", "") if name.startswith("Australium ") else name
         )
+        base_name = base_name.replace("\n", " ")
         base_name, ks_tier = _extract_killstreak(base_name)
         prices = item.get("prices", {})
         for quality, qdata in prices.items():


### PR DESCRIPTION
## Summary
- sanitize newline characters when building price map names
- cover newline names with unit tests

## Testing
- `pre-commit run --files utils/price_loader.py tests/test_price_loader.py`

------
https://chatgpt.com/codex/tasks/task_e_68710be3b1a0832681191be4f01e9e34