### PR TITLE
Add cached price map support

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ effect_id, killstreak_tier)` as the key. Example:
 ("Mann Co. Supply Crate Key", 6, True, False, 0, 0)
 ```
 
+The resulting map is serialized to `cache/price_map.json` on first use so
+subsequent startups skip the expensive conversion step. If `prices.json` is
+newer than the map, a fresh mapping is built automatically.
+
 Use `ensure_prices_cached(refresh=True)` or run the app with `--refresh` to
 redownload `prices.json` when backpack.tf updates.
 

--- a/tests/test_app_import.py
+++ b/tests/test_app_import.py
@@ -29,5 +29,13 @@ def test_app_uses_mock_schema(monkeypatch):
         "utils.price_loader.build_price_map",
         lambda path: {},
     )
+    monkeypatch.setattr(
+        "utils.price_loader.PRICE_MAP_FILE",
+        Path("price_map.json"),
+    )
+    monkeypatch.setattr(
+        "utils.price_loader.dump_price_map",
+        lambda mapping, path=Path("price_map.json"): path,
+    )
     app = importlib.import_module("app")
     assert hasattr(app, "app")

--- a/tests/test_env_loading.py
+++ b/tests/test_env_loading.py
@@ -25,6 +25,14 @@ def test_env_present_allows_import(monkeypatch):
         lambda refresh=False: Path("currencies.json"),
     )
     monkeypatch.setattr("utils.price_loader.build_price_map", lambda path: {})
+    monkeypatch.setattr(
+        "utils.price_loader.PRICE_MAP_FILE",
+        Path("price_map.json"),
+    )
+    monkeypatch.setattr(
+        "utils.price_loader.dump_price_map",
+        lambda mapping, path=Path("price_map.json"): path,
+    )
     monkeypatch.setattr("utils.local_data.load_files", lambda *a, **k: ({}, {}))
     sys.modules.pop("app", None)
     importlib.import_module("app")

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -323,6 +323,14 @@ def test_user_template_safe(monkeypatch, status):
         lambda refresh=False: Path("currencies.json"),
     )
     monkeypatch.setattr("utils.price_loader.build_price_map", lambda path: {})
+    monkeypatch.setattr(
+        "utils.price_loader.PRICE_MAP_FILE",
+        Path("price_map.json"),
+    )
+    monkeypatch.setattr(
+        "utils.price_loader.dump_price_map",
+        lambda mapping, path=Path("price_map.json"): path,
+    )
     monkeypatch.setattr("utils.local_data.load_files", lambda *a, **k: ({}, {}))
     import importlib
 

--- a/tests/test_item_modal_template.py
+++ b/tests/test_item_modal_template.py
@@ -20,6 +20,11 @@ def app(monkeypatch):
         lambda refresh=False: Path("currencies.json"),
     )
     monkeypatch.setattr("utils.price_loader.build_price_map", lambda path: {})
+    monkeypatch.setattr("utils.price_loader.PRICE_MAP_FILE", Path("price_map.json"))
+    monkeypatch.setattr(
+        "utils.price_loader.dump_price_map",
+        lambda mapping, path=Path("price_map.json"): path,
+    )
     mod = importlib.import_module("app")
     importlib.reload(mod)
     return mod.app

--- a/tests/test_price_loader.py
+++ b/tests/test_price_loader.py
@@ -274,3 +274,11 @@ def test_missing_api_key(monkeypatch):
     monkeypatch.delenv("BPTF_API_KEY", raising=False)
     with pytest.raises(RuntimeError):
         price_loader.ensure_prices_cached(refresh=True)
+
+
+def test_dump_and_load_price_map(tmp_path):
+    mapping = {("A", 6, True, False, 0, 0): {"value_raw": 1, "currency": "metal"}}
+    path = tmp_path / "map.json"
+    price_loader.dump_price_map(mapping, path)
+    loaded = price_loader.load_price_map(path)
+    assert loaded == mapping

--- a/tests/test_quantity_badge.py
+++ b/tests/test_quantity_badge.py
@@ -21,13 +21,19 @@ def test_stack_items_ignores_ids(monkeypatch):
     monkeypatch.setenv("STEAM_API_KEY", "x")
     monkeypatch.setenv("BPTF_API_KEY", "x")
     monkeypatch.setattr(
-        "utils.price_loader.ensure_prices_cached", lambda refresh=False: Path("prices.json")
+        "utils.price_loader.ensure_prices_cached",
+        lambda refresh=False: Path("prices.json"),
     )
     monkeypatch.setattr(
         "utils.price_loader.ensure_currencies_cached",
         lambda refresh=False: Path("currencies.json"),
     )
     monkeypatch.setattr("utils.price_loader.build_price_map", lambda path: {})
+    monkeypatch.setattr("utils.price_loader.PRICE_MAP_FILE", Path("price_map.json"))
+    monkeypatch.setattr(
+        "utils.price_loader.dump_price_map",
+        lambda mapping, path=Path("price_map.json"): path,
+    )
     monkeypatch.setattr("utils.local_data.load_files", lambda *a, **k: ({}, {}))
     mod = importlib.import_module("app")
     importlib.reload(mod)
@@ -52,6 +58,11 @@ def test_quantity_badge_rendered(monkeypatch):
         lambda refresh=False: Path("currencies.json"),
     )
     monkeypatch.setattr("utils.price_loader.build_price_map", lambda path: {})
+    monkeypatch.setattr("utils.price_loader.PRICE_MAP_FILE", Path("price_map.json"))
+    monkeypatch.setattr(
+        "utils.price_loader.dump_price_map",
+        lambda mapping, path=Path("price_map.json"): path,
+    )
     monkeypatch.setattr("utils.local_data.load_files", lambda *a, **k: ({}, {}))
     mod = importlib.import_module("app")
     importlib.reload(mod)

--- a/tests/test_run_hypercorn.py
+++ b/tests/test_run_hypercorn.py
@@ -18,6 +18,11 @@ def _mock_app_import(monkeypatch):
         lambda refresh=False: Path("currencies.json"),
     )
     monkeypatch.setattr("utils.price_loader.build_price_map", lambda path: {})
+    monkeypatch.setattr("utils.price_loader.PRICE_MAP_FILE", Path("price_map.json"))
+    monkeypatch.setattr(
+        "utils.price_loader.dump_price_map",
+        lambda mapping, path=Path("price_map.json"): path,
+    )
     sys.modules.pop("app", None)
     sys.modules.pop("run_hypercorn", None)
     sys.modules.pop("app", None)

--- a/tests/test_valuation_service.py
+++ b/tests/test_valuation_service.py
@@ -1,5 +1,9 @@
 from utils.valuation_service import ValuationService
 from utils import local_data
+from utils import price_loader
+from utils import valuation_service as vs
+import os
+import time
 
 
 def test_get_price_info():
@@ -50,3 +54,77 @@ def test_killstreak_tier_lookup(monkeypatch):
     service = ValuationService(price_map=price_map)
     local_data.CURRENCIES = {"keys": {"price": {"value_raw": 50.0}}}
     assert service.format_price("Item", 6, True, killstreak_tier=2) == "2 Keys"
+
+
+def test_cached_map_used_when_up_to_date(tmp_path, monkeypatch):
+    price_file = tmp_path / "prices.json"
+    price_file.write_text("{}")
+    map_file = tmp_path / "map.json"
+    price_loader.dump_price_map({"cached": True}, map_file)
+    now = time.time()
+    os.utime(price_file, (now, now))
+    os.utime(map_file, (now + 5, now + 5))
+    monkeypatch.setattr(price_loader, "PRICES_FILE", price_file)
+    monkeypatch.setattr(price_loader, "PRICE_MAP_FILE", map_file)
+    monkeypatch.setattr(vs, "PRICE_MAP_FILE", map_file)
+    monkeypatch.setattr(
+        price_loader, "ensure_prices_cached", lambda refresh=False: price_file
+    )
+    monkeypatch.setattr(vs, "ensure_prices_cached", lambda refresh=False: price_file)
+    monkeypatch.setattr(
+        price_loader, "dump_price_map", lambda mapping, path=map_file: path
+    )
+    monkeypatch.setattr(vs, "dump_price_map", lambda mapping, path=map_file: path)
+    called = {"build": False}
+
+    def fake_build(path):
+        called["build"] = True
+        return {"built": True}
+
+    monkeypatch.setattr(price_loader, "build_price_map", fake_build)
+    monkeypatch.setattr(vs, "build_price_map", fake_build)
+    monkeypatch.setattr(price_loader, "load_price_map", lambda path: {"cached": True})
+    monkeypatch.setattr(vs, "load_price_map", lambda path: {"cached": True})
+
+    service = ValuationService()
+    assert called["build"] is False
+    assert service.price_map == {"cached": True}
+
+
+def test_price_map_rebuilt_if_prices_newer(tmp_path, monkeypatch):
+    price_file = tmp_path / "prices.json"
+    price_file.write_text("{}")
+    map_file = tmp_path / "map.json"
+    price_loader.dump_price_map({"cached": True}, map_file)
+    now = time.time()
+    os.utime(map_file, (now, now))
+    os.utime(price_file, (now + 10, now + 10))
+    monkeypatch.setattr(price_loader, "PRICES_FILE", price_file)
+    monkeypatch.setattr(price_loader, "PRICE_MAP_FILE", map_file)
+    monkeypatch.setattr(vs, "PRICE_MAP_FILE", map_file)
+    monkeypatch.setattr(
+        price_loader, "ensure_prices_cached", lambda refresh=False: price_file
+    )
+    monkeypatch.setattr(vs, "ensure_prices_cached", lambda refresh=False: price_file)
+    monkeypatch.setattr(
+        price_loader, "dump_price_map", lambda mapping, path=map_file: path
+    )
+    monkeypatch.setattr(vs, "dump_price_map", lambda mapping, path=map_file: path)
+    called = {"build": False}
+
+    def fake_build(path):
+        called["build"] = True
+        return {"built": True}
+
+    monkeypatch.setattr(price_loader, "build_price_map", fake_build)
+    monkeypatch.setattr(vs, "build_price_map", fake_build)
+
+    def fail_load(path):
+        raise AssertionError("load should not be called")
+
+    monkeypatch.setattr(price_loader, "load_price_map", fail_load)
+    monkeypatch.setattr(vs, "load_price_map", fail_load)
+
+    service = ValuationService()
+    assert called["build"] is True
+    assert service.price_map == {"built": True}

--- a/utils/price_loader.py
+++ b/utils/price_loader.py
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 
 PRICES_FILE = Path("cache/prices.json")
 CURRENCIES_FILE = Path("cache/currencies.json")
+PRICE_MAP_FILE = Path("cache/price_map.json")
 
 
 QUALITY_PREFIXES = (
@@ -221,4 +222,42 @@ def build_price_map(
                         "value_raw": float(value_raw),
                         "currency": str(currency),
                     }
+    return mapping
+
+
+def dump_price_map(
+    price_map: dict[tuple[str, int, bool, bool, int, int], dict],
+    path: Path = PRICE_MAP_FILE,
+) -> Path:
+    """Serialize ``price_map`` to ``path``."""
+
+    data = [[list(key), value] for key, value in price_map.items()]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data))
+    return path
+
+
+def load_price_map(
+    path: Path = PRICE_MAP_FILE,
+) -> dict[tuple[str, int, bool, bool, int, int], dict]:
+    """Load mapping previously saved by :func:`dump_price_map`."""
+
+    with path.open() as f:
+        data = json.load(f)
+
+    mapping: dict[tuple[str, int, bool, bool, int, int], dict] = {}
+    if isinstance(data, list):
+        for key, value in data:
+            if not isinstance(key, list) or len(key) != 6:
+                continue
+            mapping[
+                (
+                    str(key[0]),
+                    int(key[1]),
+                    bool(key[2]),
+                    bool(key[3]),
+                    int(key[4]),
+                    int(key[5]),
+                )
+            ] = value
     return mapping


### PR DESCRIPTION
## Summary
- dump and load price maps via `utils.price_loader`
- load cached map in `ValuationService`
- document the new price map cache in README
- test price map serialization and patch tests to use it
- rebuild price map when `prices.json` is newer

## Testing
- `pre-commit run --files README.md utils/valuation_service.py tests/test_valuation_service.py`

------
https://chatgpt.com/codex/tasks/task_e_68710cdb2b808326bbe3ab2225484457