### PR TITLE
Implement price map caching

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,7 +18,7 @@ from utils import steam_api_client as sac
 from utils import local_data
 from utils import constants as consts
 from utils.price_loader import (
-    ensure_prices_cached,
+    ensure_price_map_cached,
     ensure_currencies_cached,
 )
 
@@ -42,7 +42,7 @@ if ARGS.refresh:
     )
     provider = SchemaProvider(cache_dir="cache/schema")
     provider.refresh_all(verbose=True)
-    price_path = ensure_prices_cached(refresh=True)
+    price_path = ensure_price_map_cached(refresh=True)
     curr_path = ensure_currencies_cached(refresh=True)
     print(f"\N{CHECK MARK} Saved {price_path}")
     print(f"\N{CHECK MARK} Saved {curr_path}")
@@ -62,7 +62,7 @@ app = Flask(__name__)
 
 MAX_MERGE_MS = 0
 local_data.load_files(auto_refetch=True, verbose=ARGS.verbose)
-_prices_path = ensure_prices_cached(refresh=ARGS.refresh)
+_prices_path = ensure_price_map_cached(refresh=ARGS.refresh)
 _currencies_path = ensure_currencies_cached(refresh=ARGS.refresh)
 try:
     with open(_currencies_path) as f:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,15 +15,15 @@ def app(monkeypatch):
     monkeypatch.setenv("BPTF_API_KEY", "x")
     monkeypatch.setattr("utils.local_data.load_files", lambda *a, **k: ({}, {}))
     monkeypatch.setattr(
-        "utils.price_loader.ensure_prices_cached",
-        lambda refresh=False: Path("prices.json"),
+        "utils.price_loader.ensure_price_map_cached",
+        lambda refresh=False: Path("price_map.json"),
     )
     monkeypatch.setattr(
         "utils.price_loader.ensure_currencies_cached",
         lambda refresh=False: Path("currencies.json"),
     )
     monkeypatch.setattr(
-        "utils.price_loader.build_price_map",
+        "utils.price_loader.load_price_map",
         lambda path: {},
     )
 

--- a/tests/test_app_import.py
+++ b/tests/test_app_import.py
@@ -18,15 +18,15 @@ def test_app_uses_mock_schema(monkeypatch):
     monkeypatch.setenv("STEAM_API_KEY", "x")
     monkeypatch.setenv("BPTF_API_KEY", "x")
     monkeypatch.setattr(
-        "utils.price_loader.ensure_prices_cached",
-        lambda refresh=False: Path("prices.json"),
+        "utils.price_loader.ensure_price_map_cached",
+        lambda refresh=False: Path("price_map.json"),
     )
     monkeypatch.setattr(
         "utils.price_loader.ensure_currencies_cached",
         lambda refresh=False: Path("currencies.json"),
     )
     monkeypatch.setattr(
-        "utils.price_loader.build_price_map",
+        "utils.price_loader.load_price_map",
         lambda path: {},
     )
     app = importlib.import_module("app")

--- a/tests/test_app_refresh.py
+++ b/tests/test_app_refresh.py
@@ -25,8 +25,9 @@ def test_refresh_flag_triggers_update(monkeypatch, capsys):
         "utils.schema_provider.SchemaProvider.refresh_all", fake_refresh
     )
     monkeypatch.setattr(
-        "utils.price_loader.ensure_prices_cached",
-        lambda refresh=True: called.__setitem__("prices", True) or Path("prices.json"),
+        "utils.price_loader.ensure_price_map_cached",
+        lambda refresh=True: called.__setitem__("prices", True)
+        or Path("price_map.json"),
     )
     monkeypatch.setattr(
         "utils.price_loader.ensure_currencies_cached",

--- a/tests/test_env_loading.py
+++ b/tests/test_env_loading.py
@@ -17,14 +17,14 @@ def test_env_present_allows_import(monkeypatch):
     monkeypatch.setenv("STEAM_API_KEY", "x")
     monkeypatch.setenv("BPTF_API_KEY", "x")
     monkeypatch.setattr(
-        "utils.price_loader.ensure_prices_cached",
-        lambda refresh=False: Path("prices.json"),
+        "utils.price_loader.ensure_price_map_cached",
+        lambda refresh=False: Path("price_map.json"),
     )
     monkeypatch.setattr(
         "utils.price_loader.ensure_currencies_cached",
         lambda refresh=False: Path("currencies.json"),
     )
-    monkeypatch.setattr("utils.price_loader.build_price_map", lambda path: {})
+    monkeypatch.setattr("utils.price_loader.load_price_map", lambda path: {})
     monkeypatch.setattr("utils.local_data.load_files", lambda *a, **k: ({}, {}))
     sys.modules.pop("app", None)
     importlib.import_module("app")

--- a/tests/test_quantity_badge.py
+++ b/tests/test_quantity_badge.py
@@ -21,14 +21,14 @@ def test_quantity_badge_rendered(monkeypatch):
     monkeypatch.setenv("STEAM_API_KEY", "x")
     monkeypatch.setenv("BPTF_API_KEY", "x")
     monkeypatch.setattr(
-        "utils.price_loader.ensure_prices_cached",
-        lambda refresh=False: Path("prices.json"),
+        "utils.price_loader.ensure_price_map_cached",
+        lambda refresh=False: Path("price_map.json"),
     )
     monkeypatch.setattr(
         "utils.price_loader.ensure_currencies_cached",
         lambda refresh=False: Path("currencies.json"),
     )
-    monkeypatch.setattr("utils.price_loader.build_price_map", lambda path: {})
+    monkeypatch.setattr("utils.price_loader.load_price_map", lambda path: {})
     monkeypatch.setattr("utils.local_data.load_files", lambda *a, **k: ({}, {}))
     mod = importlib.import_module("app")
     importlib.reload(mod)

--- a/tests/test_user_template.py
+++ b/tests/test_user_template.py
@@ -14,15 +14,15 @@ def app(monkeypatch):
     monkeypatch.setenv("BPTF_API_KEY", "x")
     monkeypatch.setattr("utils.local_data.load_files", lambda *a, **k: ({}, {}))
     monkeypatch.setattr(
-        "utils.price_loader.ensure_prices_cached",
-        lambda refresh=False: Path("prices.json"),
+        "utils.price_loader.ensure_price_map_cached",
+        lambda refresh=False: Path("price_map.json"),
     )
     monkeypatch.setattr(
         "utils.price_loader.ensure_currencies_cached",
         lambda refresh=False: Path("currencies.json"),
     )
     monkeypatch.setattr(
-        "utils.price_loader.build_price_map",
+        "utils.price_loader.load_price_map",
         lambda path: {},
     )
     mod = importlib.import_module("app")

--- a/utils/valuation_service.py
+++ b/utils/valuation_service.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from typing import Any, Dict, Tuple
 
 from . import local_data
-from .price_loader import ensure_prices_cached, build_price_map
+from .price_loader import (
+    ensure_price_map_cached,
+    load_price_map,
+)
 from .price_service import format_price
 
 
@@ -29,8 +32,8 @@ class ValuationService:
         price_map: Dict[Tuple[str, int, bool, int, int], Dict[str, Any]] | None = None,
     ) -> None:
         if price_map is None:
-            path = ensure_prices_cached()
-            price_map = build_price_map(path)
+            path = ensure_price_map_cached()
+            price_map = load_price_map(path)
         self.price_map = price_map
 
     def get_price_info(


### PR DESCRIPTION
## Summary
- store price map JSON to `cache/price_map.json`
- rebuild the map only when prices.json is newer
- load cached map in `ValuationService`
- update app startup and tests for new helpers

## Testing
- `pre-commit run --files utils/price_loader.py utils/valuation_service.py app.py tests/conftest.py tests/test_env_loading.py tests/test_app_refresh.py tests/test_app_import.py tests/test_quantity_badge.py tests/test_user_template.py` *(fails: ModuleNotFoundError: No module named 'vdf')*


------
https://chatgpt.com/codex/tasks/task_e_687113db3aa88326b155e1ad90091f70