### PR TITLE
Fix Australium item names

### DIFF
--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -48,11 +48,13 @@
     {% endif %}
   {% endif %}
   {% set quality = item.quality %}
-  {% if item.strange or quality == 'Strange' %}
-    {% set _ = title_parts.append('Strange') %}
-  {% elif quality and quality not in ('Unique', 'Normal', 'Decorated Weapon') %}
-    {% if not (quality == 'Unusual' and item.unusual_effect_id) %}
-      {% set _ = title_parts.append(quality) %}
+  {% if not item.is_australium %}
+    {% if item.strange or quality == 'Strange' %}
+      {% set _ = title_parts.append('Strange') %}
+    {% elif quality and quality not in ('Unique', 'Normal', 'Decorated Weapon') %}
+      {% if not (quality == 'Unusual' and item.unusual_effect_id) %}
+        {% set _ = title_parts.append(quality) %}
+      {% endif %}
     {% endif %}
   {% endif %}
   {% if item.is_war_paint_tool %}
@@ -65,6 +67,9 @@
     {% set base = item.display_name %}
   {% else %}
     {% set base = item.composite_name or item.base_name or item.display_name or item.name %}
+  {% endif %}
+  {% if item.is_australium %}
+    {% set base = 'Australium ' ~ base %}
   {% endif %}
   {% set _ = title_parts.append(base) %}
   <h2 class="item-title">{{ title_parts | join(' ') }}</h2>

--- a/tests/test_user_template.py
+++ b/tests/test_user_template.py
@@ -250,3 +250,29 @@ def test_uncraftable_class_rendered(app):
     assert card is not None
     classes = card.get("class", [])
     assert "uncraftable" in classes
+
+
+def test_australium_name_omits_strange_prefix(app):
+    context = {
+        "user": {
+            "items": [
+                {
+                    "name": "Strange Australium Scattergun",
+                    "display_name": "Australium Scattergun",
+                    "base_name": "Scattergun",
+                    "is_australium": True,
+                    "quality": "Strange",
+                    "image_url": "",
+                    "quality_color": "#fff",
+                }
+            ]
+        }
+    }
+    with app.test_request_context():
+        app_module = importlib.import_module("app")
+        context["user"] = app_module.normalize_user_payload(context["user"])
+        html = render_template_string(HTML, **context)
+    soup = BeautifulSoup(html, "html.parser")
+    title = soup.find("h2", class_="item-title")
+    assert title is not None
+    assert title.text.strip() == "Australium Scattergun"


### PR DESCRIPTION
## Summary
- avoid prefacing Australium items with 'Strange'
- always prefix the item base name with 'Australium' on item cards
- test that Australium names omit the Strange prefix

## Testing
- `pre-commit run --files templates/item_card.html tests/test_user_template.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687100f7c7b8832689c9df5e4388ae8b