### PR TITLE
Add killstreak australium title test

### DIFF
--- a/tests/test_user_template.py
+++ b/tests/test_user_template.py
@@ -276,3 +276,30 @@ def test_australium_name_omits_strange_prefix(app):
     title = soup.find("h2", class_="item-title")
     assert title is not None
     assert title.text.strip() == "Australium Scattergun"
+
+
+def test_professional_killstreak_australium_title(app):
+    context = {
+        "user": {
+            "items": [
+                {
+                    "name": "Professional Killstreak Australium Scattergun",
+                    "display_name": "Australium Scattergun",
+                    "base_name": "Scattergun",
+                    "killstreak_name": "Professional",
+                    "is_australium": True,
+                    "quality": "Strange",
+                    "image_url": "",
+                    "quality_color": "#fff",
+                }
+            ]
+        }
+    }
+    with app.test_request_context():
+        app_module = importlib.import_module("app")
+        context["user"] = app_module.normalize_user_payload(context["user"])
+        html = render_template_string(HTML, **context)
+    soup = BeautifulSoup(html, "html.parser")
+    title = soup.find("h2", class_="item-title")
+    assert title is not None
+    assert title.text.strip() == "Professional Killstreak Australium Scattergun"


### PR DESCRIPTION
## Summary
- verify professional killstreak australium naming in user template

## Testing
- `pre-commit run --files tests/test_user_template.py`

------
https://chatgpt.com/codex/tasks/task_e_68711faa9afc832688a6466496153681