### PR TITLE
Update docs to cover data refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A lightweight Flask web app for exploring Team Fortress 2 inventories.
 - Resolves usernames and avatars via the Steam API
 - Enriches items with backpack.tf prices
 - Displays playtime and item details
+- Refreshes local schema and price caches with a command-line flag
 
 See the [docs](docs/) directory for a full workflow description.
 
@@ -17,7 +18,13 @@ See the [docs](docs/) directory for a full workflow description.
 
 1. Install dependencies
 2. Copy `.env.example` to `.env` and set the API keys
-3. Run the server:
+3. (Optional) Refresh item schema and prices:
+
+```bash
+python app.py --refresh --verbose
+```
+
+4. Run the server:
 
 ```bash
 python run_hypercorn.py

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,3 +3,4 @@
 This directory contains extended information about TF2 Inventory Scanner.
 
 - [Workflow](workflow.md) – detailed explanation of how the scanner processes users.
+- [Refreshing Data](refresh.md) – how to update schema and price caches.

--- a/docs/refresh.md
+++ b/docs/refresh.md
@@ -1,0 +1,18 @@
+# Refreshing Data
+
+Item schema and price information is cached under `cache/` so the application can
+start quickly and work offline. These files can get stale over time. Use the
+`--refresh` flag to download the latest versions before running the server.
+
+```bash
+python app.py --refresh --verbose
+```
+
+The command downloads all TF2 schema files, backpack.tf prices and currency data
+into the `cache/` directory. After it completes, start the server normally:
+
+```bash
+python run_hypercorn.py
+```
+
+Run the refresh step whenever you want to update your local data.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -24,3 +24,13 @@ This document explains how the TF2 Inventory Scanner processes each request.
 
 All network calls are performed asynchronously with `httpx.AsyncClient` to
 fetch multiple users in parallel.
+
+## Refreshing Data
+
+Cached schema and price files live under the `cache/` directory. Run
+
+```bash
+python app.py --refresh --verbose
+```
+
+to update these files before starting the server.


### PR DESCRIPTION
## Summary
- document new `--refresh` flag for schema and price data
- add docs page explaining how to update cached data

## Testing
- `pre-commit run --files README.md docs/README.md docs/refresh.md docs/workflow.md`

------
https://chatgpt.com/codex/tasks/task_e_68715d9281508326bf4990092ba2589a