### PR TITLE
Add async Steam schema provider

### DIFF
--- a/utils/local_data.py
+++ b/utils/local_data.py
@@ -12,7 +12,7 @@ from .price_loader import ensure_currencies_cached
 TF2_SCHEMA: Dict[str, Any] = {}
 ITEMS_GAME_CLEANED: Dict[str, Any] = {}
 
-# New schema maps sourced from schema.autobot.tf
+# Cached schema maps
 SCHEMA_ATTRIBUTES: Dict[int, Dict[str, Any]] = {}
 ITEMS_BY_DEFINDEX: Dict[int, Dict[str, Any]] = {}
 QUALITIES_BY_INDEX: Dict[int, str] = {}
@@ -54,7 +54,7 @@ SPELL_DISPLAY_NAMES: Dict[str, str] = {
 
 # Base directory of the project
 BASE_DIR = Path(__file__).resolve().parent.parent
-# schema.autobot.tf cache files
+# Local schema cache files
 DEFAULT_ATTRIBUTES_FILE = BASE_DIR / "cache" / "schema" / "attributes.json"
 DEFAULT_PARTICLES_FILE = BASE_DIR / "cache" / "schema" / "particles.json"
 DEFAULT_ITEMS_FILE = BASE_DIR / "cache" / "schema" / "items.json"
@@ -195,7 +195,7 @@ def _load_paint_id_map(path: Path) -> Dict[str, str]:
 def load_files(
     *, auto_refetch: bool = False, verbose: bool = False
 ) -> Tuple[Dict[int, Any], Dict[int, Any]]:
-    """Load local schema files from the schema.autobot.tf cache."""
+    """Load local schema files from the local cache."""
 
     global SCHEMA_ATTRIBUTES, ITEMS_BY_DEFINDEX, QUALITIES_BY_INDEX, PARTICLE_NAMES
     global EFFECT_NAMES, PAINT_NAMES, WEAR_NAMES, KILLSTREAK_NAMES, STRANGE_PART_NAMES, PAINTKIT_NAMES, CRATE_SERIES_NAMES

--- a/utils/schema_provider.py
+++ b/utils/schema_provider.py
@@ -11,7 +11,7 @@ import requests
 
 
 class SchemaProvider:
-    """Fetch and cache TF2 schema data from schema.autobot.tf."""
+    """Fetch and cache TF2 schema data from a remote server."""
 
     TTL = 48 * 60 * 60  # 48 hours
     ENDPOINTS = {
@@ -30,7 +30,7 @@ class SchemaProvider:
 
     def __init__(
         self,
-        base_url: str = "https://schema.autobot.tf",
+        base_url: str = "https://example.com",
         cache_dir: str | Path = "schema",
     ) -> None:
         self.base_url = base_url.rstrip("/")

--- a/utils/steam_schema.py
+++ b/utils/steam_schema.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any, Dict
+
+import httpx
+
+from .steam_api_client import _require_key
+
+
+class SteamSchemaProvider:
+    """Fetch and cache TF2 schema data from the official Steam Web API."""
+
+    TTL = 24 * 60 * 60  # 24 hours
+    OVERVIEW_URL = (
+        "https://api.steampowered.com/IEconItems_440/GetSchemaOverview/v0001/"
+    )
+    ITEMS_URL = "https://api.steampowered.com/IEconItems_440/GetSchemaItems/v0001/"
+
+    def __init__(self, cache_file: str | Path = "data/schema_steam.json") -> None:
+        self.cache_file = Path(cache_file)
+        self.cache_file.parent.mkdir(parents=True, exist_ok=True)
+        self._schema: Dict[str, Any] | None = None
+
+    async def load_schema(
+        self, *, force: bool = False, language: str = "en"
+    ) -> Dict[str, Any]:
+        """Return the cached schema dictionary, refreshing if needed."""
+
+        if self._schema is None or force:
+            self._schema = await self._load(force=force, language=language)
+        return self._schema
+
+    async def _load(self, *, force: bool, language: str) -> Dict[str, Any]:
+        if not force and self.cache_file.exists():
+            age = time.time() - self.cache_file.stat().st_mtime
+            if age < self.TTL:
+                with self.cache_file.open() as f:
+                    return json.load(f)
+
+        data = await self._fetch(language=language)
+        self.cache_file.write_text(json.dumps(data, indent=2))
+        return data
+
+    async def _fetch(self, *, language: str) -> Dict[str, Any]:
+        key = _require_key()
+        params = {"key": key, "language": language, "format": "json"}
+        async with httpx.AsyncClient(timeout=20) as client:
+            overview_resp = await client.get(self.OVERVIEW_URL, params=params)
+            overview_resp.raise_for_status()
+            overview = overview_resp.json().get("result", {})
+
+            items: list[dict] = []
+            start = 0
+            while True:
+                item_params = params.copy()
+                if start:
+                    item_params["start"] = start
+                items_resp = await client.get(self.ITEMS_URL, params=item_params)
+                items_resp.raise_for_status()
+                payload = items_resp.json().get("result", {})
+                items.extend(payload.get("items", []))
+                if payload.get("next") is None:
+                    break
+                start = payload["next"]
+
+        attributes = overview.get("attributes", [])
+        particles = overview.get("attribute_controlled_attached_particles", [])
+        qualities = overview.get("qualities", {})
+        origins = overview.get("originNames", [])
+
+        items_by_defindex = {
+            int(item["defindex"]): item
+            for item in items
+            if isinstance(item, dict) and "defindex" in item
+        }
+        attributes_by_defindex = {
+            int(attr["defindex"]): attr
+            for attr in attributes
+            if isinstance(attr, dict) and "defindex" in attr
+        }
+        particles_by_index = {
+            int(p["id"]): p.get("name", "")
+            for p in particles
+            if isinstance(p, dict) and "id" in p
+        }
+        qualities_by_index: Dict[int, str] = {}
+        if isinstance(qualities, dict):
+            for k, v in qualities.items():
+                if str(k).isdigit():
+                    qualities_by_index[int(k)] = str(v)
+                elif str(v).isdigit():
+                    qualities_by_index[int(v)] = str(k)
+        origins_by_index = {
+            int(o.get("origin", o.get("id"))): str(o.get("name"))
+            for o in origins
+            if isinstance(o, dict)
+            and ("origin" in o or "id" in o)
+            and (o.get("origin") or o.get("id")) is not None
+        }
+
+        return {
+            "items_by_defindex": items_by_defindex,
+            "qualities_by_index": qualities_by_index,
+            "attributes_by_defindex": attributes_by_defindex,
+            "particles_by_index": particles_by_index,
+            "origins_by_index": origins_by_index,
+        }


### PR DESCRIPTION
## Summary
- implement `SteamSchemaProvider` using httpx and save cache to `data/schema_steam.json`
- remove `schema.autobot.tf` references in old provider and loader
- keep tests passing

## Testing
- `pre-commit run --files utils/steam_schema.py utils/schema_provider.py utils/local_data.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687175e18afc8326bcd0b5e08b809a27