### PR TITLE
Update docs for new Steam schema

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,8 +66,8 @@ Use `ResolveVanityURL` or manual conversion logic as needed.
   - Return values in refined metal (e.g., `5.33 ref`)
 
 ### 📜 Steam Item Schema API:
-- `https://schema.autobot.tf/raw/schema/items`
-  - Used by `SchemaProvider` to cache item metadata
+- `IEconItems_440/GetSchemaOverview` and `IEconItems_440/GetSchemaItems`
+  - Official Steam Web API endpoints used by `SteamSchemaProvider` to cache item metadata
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ A lightweight Flask web app for exploring Team Fortress 2 inventories.
 - Resolves usernames and avatars via the Steam API
 - Enriches items with backpack.tf prices
 - Displays playtime and item details
-- Refreshes local schema and price caches with a command-line flag
+- Schema file stored at `data/schema_steam.json` (auto-refreshed every 24 hours)
+- Price caches can be updated manually with a command-line flag
 
 See the [docs](docs/) directory for a full workflow description.
 
@@ -18,13 +19,13 @@ See the [docs](docs/) directory for a full workflow description.
 
 1. Install dependencies
 2. Copy `.env.example` to `.env` and set the API keys
-3. (Optional) Refresh item schema and prices:
+3. (Optional) Force refresh of schema and price caches:
 
 ```bash
 python app.py --refresh --verbose
 ```
 
-4. Run the server:
+4. Run the server (the schema will auto-refresh if older than 24 hours):
 
 ```bash
 python run_hypercorn.py

--- a/docs/refresh.md
+++ b/docs/refresh.md
@@ -1,15 +1,17 @@
 # Refreshing Data
 
-Item schema and price information is cached under `cache/` so the application can
-start quickly and work offline. These files can get stale over time. Use the
-`--refresh` flag to download the latest versions before running the server.
+Item schema data is saved to `data/schema_steam.json` while price files live
+under `cache/`. The schema is refreshed automatically if the file is older than
+24 hours whenever the server starts. Use the `--refresh` flag to force a manual
+download before running the server.
 
 ```bash
 python app.py --refresh --verbose
 ```
 
-The command downloads all TF2 schema files, backpack.tf prices and currency data
-into the `cache/` directory. After it completes, start the server normally:
+The command downloads the latest schema file to `data/schema_steam.json` and
+updates backpack.tf prices and currency data in the `cache/` directory. After it
+completes, start the server normally:
 
 ```bash
 python run_hypercorn.py

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -27,7 +27,9 @@ fetch multiple users in parallel.
 
 ## Refreshing Data
 
-Cached schema and price files live under the `cache/` directory. Run
+The combined Steam schema is stored at `data/schema_steam.json` and is refreshed
+automatically if older than 24 hours. Price files remain under the `cache/`
+directory. Run
 
 ```bash
 python app.py --refresh --verbose


### PR DESCRIPTION
## Summary
- document Steam item schema endpoints in AGENTS.md
- note new schema cache path and auto-refresh logic in docs
- tweak README features and quick start steps

## Testing
- `pre-commit run --files AGENTS.md docs/refresh.md docs/workflow.md README.md`

------
https://chatgpt.com/codex/tasks/task_e_687184bca76c8326ab97c6105fab8f60