### PR TITLE
Switch to SteamSchemaProvider refresh

### DIFF
--- a/app.py
+++ b/app.py
@@ -37,16 +37,17 @@ parser.add_argument("--test", action="store_true")
 ARGS, _ = parser.parse_known_args()
 
 if ARGS.refresh:
-    from utils.schema_provider import SchemaProvider
+    from utils.steam_schema import SteamSchemaProvider
 
     async def _do_refresh() -> None:
         print(
             "\N{ANTICLOCKWISE OPEN CIRCLE ARROW} Refresh requested: refetching TF2 schema..."
         )
-        provider = SchemaProvider(cache_dir="cache/schema")
-        await provider.refresh_all_async(verbose=True)
+        provider = SteamSchemaProvider(cache_file="data/schema_steam.json")
+        await provider.load_schema(force=True)
         price_path = await ensure_prices_cached_async(refresh=True)
         curr_path = await ensure_currencies_cached_async(refresh=True)
+        print(f"\N{CHECK MARK} Saved {provider.cache_file}")
         print(f"\N{CHECK MARK} Saved {price_path}")
         print(f"\N{CHECK MARK} Saved {curr_path}")
         print(

--- a/tests/test_app_refresh.py
+++ b/tests/test_app_refresh.py
@@ -15,20 +15,12 @@ def test_refresh_flag_triggers_update(monkeypatch, capsys):
         "pathlib.Path.mkdir", lambda self, parents=True, exist_ok=True: None
     )
 
-    def fake_refresh(self, verbose: bool = False):
-        called["schema"] = verbose
-        if verbose:
-            print("Fetching items...")
-            print("\N{CHECK MARK} Saved cache/schema/items.json (0 entries)")
-
-    async def fake_refresh_async(self, verbose: bool = False):
-        fake_refresh(self, verbose)
+    async def fake_load_schema(self, force: bool = False, language: str = "en"):
+        called["schema"] = force
+        print("\N{CHECK MARK} Saved data/schema_steam.json")
 
     monkeypatch.setattr(
-        "utils.schema_provider.SchemaProvider.refresh_all", fake_refresh
-    )
-    monkeypatch.setattr(
-        "utils.schema_provider.SchemaProvider.refresh_all_async", fake_refresh_async
+        "utils.steam_schema.SteamSchemaProvider.load_schema", fake_load_schema
     )
 
     async def fake_prices_async(refresh=True):
@@ -60,8 +52,8 @@ def test_refresh_flag_triggers_update(monkeypatch, capsys):
     with pytest.raises(SystemExit):
         importlib.import_module("app")
     out = capsys.readouterr().out
-    assert "Fetching items..." in out
-    assert "✓ Saved cache/schema/items.json (0 entries)" in out
+    assert "refetching TF2 schema" in out
+    assert "✓ Saved data/schema_steam.json" in out
     assert called["schema"] is True
     assert called["prices"] is True
     assert called["curr"] is True

--- a/tests/test_run_hypercorn.py
+++ b/tests/test_run_hypercorn.py
@@ -85,20 +85,12 @@ def test_refresh_flag_triggers_update(monkeypatch, capsys):
         "pathlib.Path.mkdir", lambda self, parents=True, exist_ok=True: None
     )
 
-    def fake_refresh(self, verbose: bool = False):
-        called["schema"] = verbose
-        if verbose:
-            print("Fetching items...")
-            print("\N{CHECK MARK} Saved cache/schema/items.json (0 entries)")
-
-    async def fake_refresh_async(self, verbose: bool = False):
-        fake_refresh(self, verbose)
+    async def fake_load_schema(self, force: bool = False, language: str = "en"):
+        called["schema"] = force
+        print("\N{CHECK MARK} Saved data/schema_steam.json")
 
     monkeypatch.setattr(
-        "utils.schema_provider.SchemaProvider.refresh_all", fake_refresh
-    )
-    monkeypatch.setattr(
-        "utils.schema_provider.SchemaProvider.refresh_all_async", fake_refresh_async
+        "utils.steam_schema.SteamSchemaProvider.load_schema", fake_load_schema
     )
 
     monkeypatch.setattr(
@@ -136,7 +128,7 @@ def test_refresh_flag_triggers_update(monkeypatch, capsys):
         exited = True
     assert exited is True
     out = capsys.readouterr().out
-    assert "Fetching items..." in out
-    assert "✓ Saved cache/schema/items.json (0 entries)" in out
+    assert "refetching TF2 schema" in out
+    assert "✓ Saved data/schema_steam.json" in out
     assert called["schema"] is True
     assert called["prices"] is True


### PR DESCRIPTION
## Summary
- refresh uses SteamSchemaProvider
- update tests for new refresh call

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files app.py tests/test_app_refresh.py tests/test_run_hypercorn.py`

------
https://chatgpt.com/codex/tasks/task_e_68718d3435688326a03746211ef4e37d