### PR TITLE
Update refresh test

### DIFF
--- a/tests/test_app_refresh.py
+++ b/tests/test_app_refresh.py
@@ -6,7 +6,7 @@ import pytest
 
 
 def test_refresh_flag_triggers_update(monkeypatch, capsys):
-    called = {"schema": None, "prices": False}
+    called = {"schema": [], "prices": False}
 
     monkeypatch.setenv("STEAM_API_KEY", "x")
     monkeypatch.setenv("BPTF_API_KEY", "x")
@@ -16,7 +16,7 @@ def test_refresh_flag_triggers_update(monkeypatch, capsys):
     )
 
     async def fake_load_schema(self, force: bool = False, language: str = "en"):
-        called["schema"] = force
+        called["schema"].append(force)
         print("\N{CHECK MARK} Saved data/schema_steam.json")
 
     monkeypatch.setattr(
@@ -54,6 +54,6 @@ def test_refresh_flag_triggers_update(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "refetching TF2 schema" in out
     assert "✓ Saved data/schema_steam.json" in out
-    assert called["schema"] is True
+    assert called["schema"] == [True]
     assert called["prices"] is True
     assert called["curr"] is True


### PR DESCRIPTION
## Summary
- track load_schema calls in tests/test_app_refresh.py
- ensure schema, prices and currencies refresh

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files tests/test_app_refresh.py`

------
https://chatgpt.com/codex/tasks/task_e_68718f24a41c8326a2af47b419d1f3ac