### PR TITLE
Normalize schema quality names

### DIFF
--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -1031,9 +1031,9 @@ def _process_item(
         display_base = f"Australium {clean_base}"
 
     quality_id = asset.get("quality", 0)
-    q_name = local_data.QUALITIES_BY_INDEX.get(quality_id)
-    if not q_name:
-        q_name = QUALITY_MAP.get(quality_id, ("Unknown",))[0]
+    q_name = local_data.QUALITIES_BY_INDEX.get(
+        quality_id, QUALITY_MAP.get(quality_id, ("Unknown",))[0]
+    )
     q_col = QUALITY_MAP.get(quality_id, ("", "#B2B2B2"))[1]
     name = _build_item_name(display_base, q_name, asset)
 

--- a/utils/local_data.py
+++ b/utils/local_data.py
@@ -295,9 +295,8 @@ def load_files(
             "rarity4": "Unusual",
         }
         for idx, name in list(QUALITIES_BY_INDEX.items()):
-            canon = rarity_map.get(name)
-            if canon:
-                QUALITIES_BY_INDEX[idx] = canon
+            mapped = rarity_map.get(name.lower(), name)
+            QUALITIES_BY_INDEX[idx] = mapped.title()
     if verbose:
         logging.info(
             "\N{CHECK MARK} Loaded %d qualities from %s",


### PR DESCRIPTION
## Summary
- normalize item quality names when loading schema files
- clean up quality lookup in inventory processor

## Testing
- `pre-commit run --files utils/local_data.py utils/inventory_processor.py`

------
https://chatgpt.com/codex/tasks/task_e_6871b62741cc832686ff64bb62923199