### PR TITLE
Normalize schema quality names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,4 @@ All notable changes to this project will be documented in this file.
 - Plain craft weapons from achievements or promotions are no longer filtered and
   such items are hidden without price data.
 - Untradable timed-drop items are now marked as hidden.
+- Fixed warpaint schema slugs that prefixed names with `paintkitweapon`.

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -810,6 +810,35 @@ def test_warpaint_resolved_with_best_match(monkeypatch):
     assert item["warpaint_name"] == "Warhawk"
 
 
+def test_warpaint_schema_prefix_paintkitweapon(monkeypatch):
+    data = {
+        "items": [
+            {
+                "defindex": 15158,
+                "quality": 15,
+                "attributes": [],
+            }
+        ]
+    }
+    ld.ITEMS_BY_DEFINDEX = {
+        15158: {
+            "name": "warbird_paintkitweapon_brassbeast_hypergon",
+            "item_name": "Brass Beast",
+            "craft_class": "weapon",
+        }
+    }
+    monkeypatch.setattr(ld, "PAINTKIT_NAMES", {"Hypergon": 408}, False)
+    monkeypatch.setattr(ld, "PAINTKIT_NAMES_BY_ID", {"408": "Hypergon"}, False)
+    ld.QUALITIES_BY_INDEX = {15: "Decorated Weapon"}
+    items = ip.enrich_inventory(data)
+    item = items[0]
+    assert item["warpaint_id"] == 408
+    assert item["warpaint_name"] == "Hypergon"
+    assert item["skin_name"] == "Hypergon"
+    assert item["base_weapon"] == "Brass Beast"
+    assert item["resolved_name"] == "Hypergon Brass Beast"
+
+
 def test_kill_eater_fields(monkeypatch):
     data = {
         "items": [

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -356,7 +356,19 @@ def _extract_wear_float(asset: Dict[str, Any]) -> float | None:
 def _slug_to_paintkit_name(slug: str) -> str:
     """Return a human readable paintkit name from schema slug."""
 
-    if slug.endswith("_mk_ii"):
+    lower = slug.lower()
+    for prefix in ("paintkitweapon_", "paintkit_weapon_"):
+        if lower.startswith(prefix):
+            slug = slug[len(prefix) :]
+            lower = lower[len(prefix) :]
+            break
+
+    parts = slug.split("_")
+    if len(parts) > 1:
+        slug = "_".join(parts[1:])
+        lower = "_".join(lower.split("_")[1:])
+
+    if lower.endswith("_mk_ii"):
         base = slug[:-6]
         return base.replace("_", " ").title() + " Mk.II"
     return slug.replace("_", " ").title()
@@ -1031,9 +1043,9 @@ def _process_item(
         display_base = f"Australium {clean_base}"
 
     quality_id = asset.get("quality", 0)
-    q_name = local_data.QUALITIES_BY_INDEX.get(quality_id)
-    if not q_name:
-        q_name = QUALITY_MAP.get(quality_id, ("Unknown",))[0]
+    q_name = local_data.QUALITIES_BY_INDEX.get(
+        quality_id, QUALITY_MAP.get(quality_id, ("Unknown",))[0]
+    )
     q_col = QUALITY_MAP.get(quality_id, ("", "#B2B2B2"))[1]
     name = _build_item_name(display_base, q_name, asset)
 

--- a/utils/local_data.py
+++ b/utils/local_data.py
@@ -295,9 +295,8 @@ def load_files(
             "rarity4": "Unusual",
         }
         for idx, name in list(QUALITIES_BY_INDEX.items()):
-            canon = rarity_map.get(name)
-            if canon:
-                QUALITIES_BY_INDEX[idx] = canon
+            mapped = rarity_map.get(name.lower(), name)
+            QUALITIES_BY_INDEX[idx] = mapped.title()
     if verbose:
         logging.info(
             "\N{CHECK MARK} Loaded %d qualities from %s",


### PR DESCRIPTION
## Summary
- normalize item quality names when loading schema files
- clean up quality lookup in inventory processor
- strip paintkitweapon prefix from schema warpaint slugs
- test warpaint slug parsing

## Testing
- `pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py CHANGELOG.md` *(fails: command not found)*
- `pytest -q tests/test_inventory_processor.py::test_warpaint_schema_prefix_paintkitweapon` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*


------
https://chatgpt.com/codex/tasks/task_e_6871b62741cc832686ff64bb62923199