### PR TITLE
Fix paintkitweapon prefix stripping

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -839,6 +839,11 @@ def test_warpaint_schema_prefix_paintkitweapon(monkeypatch):
     assert item["resolved_name"] == "Hypergon Brass Beast"
 
 
+def test_slug_to_paintkit_name_prefix_removed():
+    name = ip._slug_to_paintkit_name("paintkitweapon_brassbeast_hypergon")
+    assert name == "Hypergon"
+
+
 def test_kill_eater_fields(monkeypatch):
     data = {
         "items": [

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -364,9 +364,15 @@ def _slug_to_paintkit_name(slug: str) -> str:
             break
 
     parts = slug.split("_")
-    if len(parts) > 1:
+    if len(parts) > 1 and not lower.endswith("_mk_ii"):
         slug = "_".join(parts[1:])
         lower = "_".join(lower.split("_")[1:])
+
+    for prefix in ("paintkitweapon_", "paintkit_weapon_"):
+        if lower.startswith(prefix):
+            slug = slug[len(prefix) :]
+            lower = lower[len(prefix) :]
+            break
 
     if lower.endswith("_mk_ii"):
         base = slug[:-6]


### PR DESCRIPTION
## Summary
- handle `paintkitweapon_` and `paintkit_weapon_` prefixes appearing after the first underscore
- test that `_slug_to_paintkit_name` strips `paintkitweapon_` at the start of a slug

## Testing
- `pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6871bf1b806c83268ba01ba4d9765c18