### PR TITLE
Add pytest-asyncio and update pre-commit setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,12 +11,12 @@ repos:
     hooks:
       - id: validate-attributes
         name: validate attributes
-        entry: bash -c 'PYTHONPATH=. python scripts/validate_attributes.py'
+        entry: bash -c 'pip install -q -r requirements-test.txt && PYTHONPATH=. python scripts/validate_attributes.py'
         language: system
         pass_filenames: false
       - id: pytest
         name: pytest
-        entry: bash -c 'STEAM_API_KEY=test pytest'
+        entry: bash -c 'pip install -q -r requirements-test.txt && STEAM_API_KEY=test pytest'
         language: system
         pass_filenames: false
 # Temporarily disabled due to network blocks

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ See the [docs](docs/) directory for a full workflow description.
 
 ## Quick Start
 
-1. Install dependencies
+1. Install test dependencies (required for `pre-commit` and `pytest`)
    ```bash
    pip install -r requirements-test.txt
    pre-commit install
@@ -36,6 +36,17 @@ python run_hypercorn.py
 ```
 
 Open `http://localhost:5000` and submit Steam IDs to inspect.
+
+## Contributing
+
+Install the test dependencies to ensure `pre-commit` and `pytest` work:
+
+```bash
+pip install -r requirements-test.txt
+pre-commit install
+```
+
+Run `pre-commit run --all-files` and `pytest` before opening a pull request.
 
 ## License
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,5 @@
 pytest==8.4.0
+pytest-asyncio==0.23.7
 pytest-cov==6.2.1
 responses==0.25.0
 Flask[async]==3.1.1


### PR DESCRIPTION
## Summary
- include pytest-asyncio in test dependencies
- install test requirements for local pre-commit hooks
- explain installing test dependencies in README

## Testing
- `pre-commit run --files README.md requirements-test.txt .pre-commit-config.yaml` *(fails: 1 failed, 183 passed, 8 errors)*
- `SKIP=pytest pre-commit run --files README.md requirements-test.txt .pre-commit-config.yaml`
- `pytest -q` *(fails: 1 failed, 183 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6871bf23461883269ef9810bac7a5498