### PR TITLE
Fix warpaint display name

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -272,6 +272,7 @@ def test_get_inventories_adds_user_agent(monkeypatch):
         return DummyResp()
 
     monkeypatch.setattr(sac.requests, "get", fake_get)
+    monkeypatch.setattr(sac, "STEAM_API_KEY", "x")
     sac.get_inventories(["1"])
     assert captured["ua"] == "Mozilla/5.0"
 
@@ -837,7 +838,6 @@ def test_warpaint_schema_prefix_paintkitweapon(monkeypatch):
     assert item["skin_name"] == "Hypergon"
     assert item["base_weapon"] == "Brass Beast"
     assert item["resolved_name"] == "Hypergon Brass Beast"
-
 
 
 def test_kill_eater_fields(monkeypatch):

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -363,7 +363,6 @@ def _slug_to_paintkit_name(slug: str) -> str:
             lower = lower[len(prefix) :]
             break
 
-
     # The schema slug may include a "paintkitweapon_" prefix which should be
     # stripped. We otherwise treat the slug as the paintkit name without
     # removing additional segments so values like "nutcracker_mk_ii" remain
@@ -1024,6 +1023,7 @@ def _process_item(
         base_weapon = "Unknown Weapon"
 
     base_name = base_weapon
+    display_base = base_name
     skin_name = None
     composite_name = None
     resolved_name = base_name
@@ -1035,9 +1035,9 @@ def _process_item(
         skin_name = paintkit_name
         composite_name = f"{paintkit_name} {base_weapon}"
         resolved_name = composite_name
+        display_base = composite_name
 
     is_australium = asset.get("is_australium") or _extract_australium(asset)
-    display_base = base_name
     if is_australium:
         clean_base = re.sub(
             r"^(Strange|Unique|Vintage|Haunted|Collector's|Genuine|Unusual)\s+",


### PR DESCRIPTION
## Summary
- show composite name on war-painted weapon cards
- patch unit tests to set an API key

## Testing
- `pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872525b99b88326adc204bdb7b7e2ef