### PR TITLE
Fix warpaint item card names

### DIFF
--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -66,7 +66,8 @@
   {% elif item.unusual_effect_id %}
     {% set base = item.display_name %}
   {% else %}
-    {% set base = item.composite_name or item.base_name or item.display_name or item.name %}
+    {# Prefer resolved or composite names, fallback to base/display name #}
+    {% set base = item.resolved_name or item.composite_name or item.base_name or item.display_name or item.name %}
   {% endif %}
   {% if item.is_australium %}
     {% set base = 'Australium ' ~ base %}


### PR DESCRIPTION
## Summary
- prefer resolved names when building item card titles

## Testing
- `pre-commit run --files templates/item_card.html`

------
https://chatgpt.com/codex/tasks/task_e_68725a7e13108326a66b6da7f3de5e44