### PR TITLE
Add display_base support for warpaint items

### DIFF
--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -67,7 +67,9 @@
     {% set base = item.display_name %}
   {% else %}
     {# Prefer resolved or composite names, fallback to base/display name #}
-    {% set base = item.resolved_name or item.composite_name or item.base_name or item.display_name or item.name %}
+    {% set base = item.display_base or item.resolved_name
+                   or item.composite_name or item.base_name
+                   or item.display_name or item.name %}
   {% endif %}
   {% if item.is_australium %}
     {% set base = 'Australium ' ~ base %}

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -573,6 +573,29 @@ def test_composite_name_set_for_skin(monkeypatch):
     assert item["composite_name"] == "Warhawk Flamethrower"
 
 
+def test_warpaint_display_base(monkeypatch):
+    data = {
+        "items": [
+            {
+                "defindex": 15141,
+                "quality": 15,
+                "attributes": [{"defindex": 834, "float_value": 350}],
+            }
+        ]
+    }
+    ld.ITEMS_BY_DEFINDEX = {
+        15141: {"item_name": "Flamethrower", "craft_class": "weapon"}
+    }
+    monkeypatch.setattr(ld, "PAINTKIT_NAMES", {"Warhawk": 350}, False)
+    monkeypatch.setattr(ld, "PAINTKIT_NAMES_BY_ID", {"350": "Warhawk"}, False)
+    ld.QUALITIES_BY_INDEX = {15: "Decorated Weapon"}
+    items = ip.enrich_inventory(data)
+    item = items[0]
+    assert item["composite_name"] == "Warhawk Flamethrower"
+    assert item["resolved_name"] == item["composite_name"]
+    assert item["display_base"] == item["composite_name"]
+
+
 def test_warpaint_tool_resolved(monkeypatch):
     data = {
         "items": [

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -1145,6 +1145,7 @@ def _process_item(
         "name": name,
         "original_name": original_name,
         "base_name": base_name,
+        "display_base": display_base,
         "display_name": display_name,
         "is_australium": bool(is_australium),
         "quality": q_name,


### PR DESCRIPTION
## Summary
- surface `display_base` in inventory processing
- prefer `display_base` in item card template
- add a unit test verifying warpaint uses composite name

## Testing
- `pre-commit run --files utils/inventory_processor.py templates/item_card.html tests/test_inventory_processor.py`
- `pytest tests/test_inventory_processor.py::test_warpaint_display_base -q`

------
https://chatgpt.com/codex/tasks/task_e_68725eb3085883269e88fa09b1b93a53