### PR TITLE
Fix decorated weapon name slugs

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -863,6 +863,35 @@ def test_warpaint_schema_prefix_paintkitweapon(monkeypatch):
     assert item["resolved_name"] == "Hypergon Brass Beast"
 
 
+def test_warpaint_schema_paintkitweapon_only(monkeypatch):
+    data = {
+        "items": [
+            {
+                "defindex": 15159,
+                "quality": 15,
+                "attributes": [],
+            }
+        ]
+    }
+    ld.ITEMS_BY_DEFINDEX = {
+        15159: {
+            "name": "paintkitweapon_macabre_web_mk_ii",
+            "item_name": "Iron Bomber",
+            "craft_class": "weapon",
+        }
+    }
+    monkeypatch.setattr(ld, "PAINTKIT_NAMES", {"Macabre Web Mk.II": 163}, False)
+    monkeypatch.setattr(ld, "PAINTKIT_NAMES_BY_ID", {"163": "Macabre Web Mk.II"}, False)
+    ld.QUALITIES_BY_INDEX = {15: "Decorated Weapon"}
+    items = ip.enrich_inventory(data)
+    item = items[0]
+    assert item["warpaint_id"] == 163
+    assert item["warpaint_name"] == "Macabre Web Mk.II"
+    assert item["skin_name"] == "Macabre Web Mk.II"
+    assert item["base_weapon"] == "Iron Bomber"
+    assert item["resolved_name"] == "Macabre Web Mk.II Iron Bomber"
+
+
 def test_kill_eater_fields(monkeypatch):
     data = {
         "items": [

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -424,6 +424,7 @@ def _extract_paintkit(
             "concealedkiller_",
             "craftsmann_",
         )
+        paint_slug = None
         for prefix in prefixes:
             if schema_name.startswith(prefix):
                 suffix = schema_name[len(prefix) :]
@@ -432,22 +433,27 @@ def _extract_paintkit(
                         suffix = suffix[len(pfx) :]
                         break
                 parts = suffix.split("_", 1)
-                if len(parts) == 2:
-                    paint_slug = parts[1]
-                else:
-                    paint_slug = suffix
-                warpaint_name = _slug_to_paintkit_name(paint_slug)
-                warpaint_id = local_data.PAINTKIT_NAMES.get(warpaint_name)
-                if warpaint_id is None:
-                    match = best_match_from_keys(
-                        warpaint_name, local_data.PAINTKIT_NAMES.keys()
-                    )
-                    if match:
-                        warpaint_id = local_data.PAINTKIT_NAMES.get(match)
-                        warpaint_name = match
-                if warpaint_id is not None:
-                    return warpaint_id, warpaint_name
+                paint_slug = parts[1] if len(parts) == 2 else suffix
                 break
+
+        if paint_slug is None:
+            for pfx in ("paintkitweapon_", "paintkit_weapon_"):
+                if schema_name.startswith(pfx):
+                    paint_slug = schema_name[len(pfx) :]
+                    break
+
+        if paint_slug:
+            warpaint_name = _slug_to_paintkit_name(paint_slug)
+            warpaint_id = local_data.PAINTKIT_NAMES.get(warpaint_name)
+            if warpaint_id is None:
+                match = best_match_from_keys(
+                    warpaint_name, local_data.PAINTKIT_NAMES.keys()
+                )
+                if match:
+                    warpaint_id = local_data.PAINTKIT_NAMES.get(match)
+                    warpaint_name = match
+            if warpaint_id is not None:
+                return warpaint_id, warpaint_name
 
     return None, None
 


### PR DESCRIPTION
## Summary
- parse `paintkitweapon_*` names from Steam schema
- test plain `paintkitweapon_*` slug case

## Testing
- `pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687265d894208326ac56432867aea4eb