### PR TITLE
Improve decorated weapon naming

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -1337,7 +1337,7 @@ def test_skin_detection(monkeypatch):
     assert item["paintkit_id"] == 350
     assert item["paintkit_name"] == "Warhawk"
     assert item["wear_name"] == "Factory New"
-    assert item["resolved_name"] == "Warhawk Flamethrower"
+    assert item["resolved_name"] == "Warhawk Flamethrower (Factory New)"
 
 
 def test_skin_attribute_order(monkeypatch):
@@ -1362,7 +1362,7 @@ def test_skin_attribute_order(monkeypatch):
     item = items[0]
     assert item["paintkit_id"] == 350
     assert item["wear_name"] == "Factory New"
-    assert item["display_name"] == "Warhawk Flamethrower"
+    assert item["display_name"] == "Warhawk Flamethrower (Factory New)"
     assert item["wear_float"] == 0.04
 
 

--- a/tests/test_user_template.py
+++ b/tests/test_user_template.py
@@ -172,8 +172,8 @@ def test_decorated_quality_not_shown(app):
             "items": [
                 {
                     "name": "Decorated Weapon Flamethrower",
-                    "composite_name": "Warhawk Flamethrower",
-                    "display_name": "Warhawk Flamethrower",
+                    "composite_name": "Warhawk Flamethrower (Factory New)",
+                    "display_name": "Warhawk Flamethrower (Factory New)",
                     "image_url": "",
                     "quality": "Decorated Weapon",
                     "quality_color": "#fff",
@@ -188,7 +188,7 @@ def test_decorated_quality_not_shown(app):
     soup = BeautifulSoup(html, "html.parser")
     title = soup.find("h2", class_="item-title")
     assert title is not None
-    assert title.text.strip() == "Warhawk Flamethrower"
+    assert title.text.strip() == "Warhawk Flamethrower (Factory New)"
 
 
 def test_failed_user_has_retry_class(app):
@@ -276,7 +276,6 @@ def test_australium_name_omits_strange_prefix(app):
     title = soup.find("h2", class_="item-title")
     assert title is not None
     assert title.text.strip() == "Australium Scattergun"
-
 
 
 def test_professional_killstreak_australium_title(app):

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -1039,7 +1039,19 @@ def _process_item(
         resolved_name = f"War Paint: {paintkit_name}{suffix}"
     elif warpaintable and paintkit_id is not None:
         skin_name = paintkit_name
-        composite_name = f"{paintkit_name} {base_weapon}"
+
+        # Detect Mk.II from slug or fallback
+        schema_name = schema_entry.get("name", "")
+        mk = (
+            " Mk.II" if "_mk_ii" in schema_name and "Mk.II" not in paintkit_name else ""
+        )
+
+        # Include wear tier if available
+        wear_suffix = f" ({wear_name})" if wear_name else ""
+
+        # Full enriched name
+        composite_name = f"{paintkit_name}{mk} {base_weapon}{wear_suffix}"
+
         resolved_name = composite_name
         display_base = composite_name
 


### PR DESCRIPTION
## Summary
- enrich decorated weapon names with Mk.II detection and wear tier
- update tests for new decorated naming

## Testing
- `pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py tests/test_user_template.py`

------
https://chatgpt.com/codex/tasks/task_e_68726a83c4408326a7f6d5a61c862e5b