### PR TITLE
Fix warpaint name fallback in item card

### DIFF
--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -60,12 +60,11 @@
   {% if item.is_war_paint_tool %}
   {% set base = item.composite_name or item.warpaint_name or item.display_name or item.name %}
   {% elif item.unusual_effect_id %}
-    {% set base = item.display_name %}
+    {% set base = item.composite_name or item.display_name or item.name %}
   {% else %}
-    {# Prefer resolved or composite names, fallback to base/display name #}
-    {% set base = item.display_base or item.resolved_name
-                   or item.composite_name or item.base_name
-                   or item.display_name or item.name %}
+    {# Prefer composite or resolved names, fallback to base/display name #}
+    {% set base = item.composite_name or item.display_base or item.resolved_name
+                   or item.base_name or item.display_name or item.name %}
   {% endif %}
   {% if item.is_australium %}
     {% set base = 'Australium ' ~ base %}


### PR DESCRIPTION
## Summary
- ensure unusual or decorated items show `composite_name` if available

## Testing
- `pre-commit run --files templates/item_card.html`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68727443d50c8326b806a5702be1ecab