### PR TITLE
Align item title resolution with modal

### DIFF
--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -57,14 +57,22 @@
       {% endif %}
     {% endif %}
   {% endif %}
-  {# Always prefer composite_name like the modal does #}
-  {% if item.composite_name %}
-    {% set base = item.composite_name %}
-  {% elif item.is_war_paint_tool and item.warpaint_name and item.target_weapon_name %}
-    {% set base = item.warpaint_name ~ ' ' ~ item.target_weapon_name %}
+  {# Match modal title logic exactly #}
+  {% if item.is_war_paint_tool %}
+    {% if item.composite_name %}
+      {% set base = item.composite_name %}
+    {% elif item.warpaint_name and item.target_weapon_name %}
+      {% set base = item.warpaint_name ~ ' ' ~ item.target_weapon_name %}
+    {% else %}
+      {% set base = item.warpaint_name or item.display_name or item.name %}
+    {% endif %}
   {% else %}
-    {% set base = item.display_base or item.resolved_name
-                   or item.base_name or item.display_name or item.name %}
+    {% set base = item.composite_name
+                  or item.display_base
+                  or item.resolved_name
+                  or item.base_name
+                  or item.display_name
+                  or item.name %}
   {% endif %}
   {% if item.is_australium %}
     {% set base = 'Australium ' ~ base %}

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -1240,6 +1240,23 @@ def _process_item(
         "_hidden": hide_item,
     }
 
+    # Build composite name for decorated weapons and paint tools
+    if item.get("is_war_paint_tool"):
+        warpaint = item.get("warpaint_name")
+        target = item.get("target_weapon_name")
+        wear = item.get("wear_name")
+        if warpaint and target:
+            suffix = f" ({wear})" if wear else ""
+            item["composite_name"] = f"{warpaint} {target}{suffix}"
+        elif warpaint:
+            item["composite_name"] = warpaint
+    elif item.get("paintkit_name") and item.get("base_weapon"):
+        warpaint = item["paintkit_name"]
+        base = item["base_weapon"] or base_weapon
+        wear = item.get("wear_name")
+        suffix = f" ({wear})" if wear else ""
+        item["composite_name"] = f"{warpaint} {base}{suffix}"
+
     if valuation_service is not None:
         tradable = tradable_val
 


### PR DESCRIPTION
## Summary
- sync item card title logic with modal script
- generate composite names for war paint tools and decorated weapons

## Testing
- `pre-commit run --files templates/item_card.html utils/inventory_processor.py`

------
https://chatgpt.com/codex/tasks/task_e_68728c16c4cc832689fb2ff9f1259306