### PR TITLE
Fix item card decorated name rendering

### DIFF
--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -58,17 +58,12 @@
     {% endif %}
   {% endif %}
   {# Match modal title logic exactly #}
-  {% if item.is_war_paint_tool %}
-    {% if item.composite_name %}
-      {% set base = item.composite_name %}
-    {% elif item.warpaint_name and item.target_weapon_name %}
-      {% set base = item.warpaint_name ~ ' ' ~ item.target_weapon_name %}
-    {% else %}
-      {% set base = item.warpaint_name or item.display_name or item.name %}
-    {% endif %}
+  {% if item.composite_name %}
+    {% set base = item.composite_name %}
+  {% elif item.is_war_paint_tool and item.warpaint_name and item.target_weapon_name %}
+    {% set base = item.warpaint_name ~ ' ' ~ item.target_weapon_name %}
   {% else %}
-    {% set base = item.composite_name
-                  or item.display_base
+    {% set base = item.display_base
                   or item.resolved_name
                   or item.base_name
                   or item.display_name


### PR DESCRIPTION
## Summary
- prefer `item.composite_name` for item card titles
- fallback to `warpaint_name + target_weapon_name` for paintkit tools
- otherwise use the normal title chain

## Testing
- `pre-commit run --files templates/item_card.html`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872af43910c8326be558f3c8885e552