### PR TITLE
Fix composite_name for war paint tools

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -1313,6 +1313,31 @@ def test_war_paint_tool_attributes(monkeypatch):
     assert item["resolved_name"] == "War Paint: Warhawk (Field-Tested)"
 
 
+def test_composite_name_for_war_paint_tool(monkeypatch):
+    data = {
+        "items": [
+            {
+                "defindex": 5681,
+                "quality": 6,
+                "attributes": [
+                    {"defindex": 134, "value": 350},
+                    {"defindex": 725, "float_value": 0.2},
+                    {"defindex": 2014, "value": 222},
+                ],
+            }
+        ]
+    }
+    ld.ITEMS_BY_DEFINDEX = {
+        5681: {"item_name": "War Paint", "item_class": "tool"},
+        222: {"item_name": "Rocket Launcher"},
+    }
+    monkeypatch.setattr(ld, "PAINTKIT_NAMES_BY_ID", {"350": "Warhawk"}, False)
+    ld.QUALITIES_BY_INDEX = {6: "Unique"}
+    items = ip.enrich_inventory(data)
+    item = items[0]
+    assert item["composite_name"] == "Warhawk Rocket Launcher (Field-Tested)"
+
+
 def test_skin_detection(monkeypatch):
     data = {
         "items": [

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -1241,15 +1241,14 @@ def _process_item(
     }
 
     # Build composite name for decorated weapons and paint tools
-    if item.get("is_war_paint_tool"):
-        warpaint = item.get("warpaint_name")
-        target = item.get("target_weapon_name")
-        wear = item.get("wear_name")
-        if warpaint and target:
-            suffix = f" ({wear})" if wear else ""
-            item["composite_name"] = f"{warpaint} {target}{suffix}"
-        elif warpaint:
-            item["composite_name"] = warpaint
+    if item.get("warpaint_name") and item.get("target_weapon_name"):
+        wear = item.get("wear_name") or ""
+        suffix = f" ({wear})" if wear else ""
+        item["composite_name"] = (
+            f"{item['warpaint_name']} {item['target_weapon_name']}{suffix}"
+        )
+    elif item.get("is_war_paint_tool") and item.get("warpaint_name"):
+        item["composite_name"] = item["warpaint_name"]
     elif item.get("paintkit_name") and item.get("base_weapon"):
         warpaint = item["paintkit_name"]
         base = item["base_weapon"] or base_weapon


### PR DESCRIPTION
## Summary
- ensure `composite_name` is set for war paint tools
- cover decorated tools in inventory processor tests

## Testing
- `pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py`

------
https://chatgpt.com/codex/tasks/task_e_6872b80f5f488326bc957838667daae6