### PR TITLE
Fix decorated weapon placeholder names

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -435,6 +435,42 @@ def test_paintkit_appended_to_name(monkeypatch):
     assert item["paintkit_name"] == "Warhawk"
 
 
+def test_paintkitweapon_base_name_from_schema(monkeypatch):
+    data = {
+        "items": [
+            {
+                "defindex": 15141,
+                "quality": 15,
+                "attributes": [{"defindex": 834, "float_value": 350}],
+            }
+        ]
+    }
+    ld.ITEMS_BY_DEFINDEX = {
+        15141: {
+            "item_name": "Paintkitweapon 999",
+            "name": "Flamethrower",
+            "craft_class": "weapon",
+        }
+    }
+    monkeypatch.setattr(ld, "PAINTKIT_NAMES", {"Warhawk": 350}, False)
+    monkeypatch.setattr(ld, "PAINTKIT_NAMES_BY_ID", {"350": "Warhawk"}, False)
+    ld.QUALITIES_BY_INDEX = {15: "Decorated Weapon"}
+    items = ip.enrich_inventory(data)
+    item = items[0]
+    assert item["base_weapon"] == "Flamethrower"
+    assert not item["base_weapon"].startswith("Paintkitweapon")
+    assert item["resolved_name"] == "Warhawk Flamethrower"
+
+
+def test_paintkittool_base_name(monkeypatch):
+    entry = {
+        "item_name": "Paintkittool 5",
+        "name": "War Paint",
+        "item_class": "tool",
+    }
+    assert ip._preferred_base_name("5681", entry) == "War Paint"
+
+
 def test_warpaint_unknown_defaults_unknown(monkeypatch):
     data = {
         "items": [

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -723,11 +723,18 @@ def _is_placeholder_name(name: str) -> bool:
 def _preferred_base_name(defindex: str, schema_entry: Dict[str, Any]) -> str:
     """Return human readable base item name."""
 
-    name = schema_entry.get("item_name") or schema_entry.get("name")
-    if name and not _is_placeholder_name(name):
-        return name
+    item_name = schema_entry.get("item_name")
+    schema_name = schema_entry.get("name")
 
-    return name or f"Item #{defindex}"
+    if item_name and item_name.lower().startswith(("paintkitweapon", "paintkittool")):
+        item_name = None
+
+    if item_name and not _is_placeholder_name(item_name):
+        return item_name
+    if schema_name and not _is_placeholder_name(schema_name):
+        return schema_name
+
+    return schema_name or item_name or f"Item #{defindex}"
 
 
 def _is_warpaintable(schema_entry: Dict[str, Any]) -> bool:


### PR DESCRIPTION
## Summary
- handle Paintkitweapon/Paintkittool placeholders when resolving base item names
- test decorated weapon base names using schema name instead of placeholder

## Testing
- `pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py`

------
https://chatgpt.com/codex/tasks/task_e_6872d13601a48326bb895774d47d2743