### PR TITLE
Sanitize paintkit item names

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -471,6 +471,58 @@ def test_paintkittool_base_name(monkeypatch):
     assert ip._preferred_base_name("5681", entry) == "War Paint"
 
 
+def test_paintkitweapon_item_name_cleaned(monkeypatch):
+    data = {
+        "items": [
+            {
+                "defindex": 15141,
+                "quality": 15,
+                "attributes": [{"defindex": 834, "float_value": 350}],
+            }
+        ]
+    }
+    ld.ITEMS_BY_DEFINDEX = {
+        15141: {
+            "item_name": "Paintkitweapon 999",
+            "name": "Flamethrower",
+            "craft_class": "weapon",
+        }
+    }
+    monkeypatch.setattr(ld, "PAINTKIT_NAMES", {"Warhawk": 350}, False)
+    monkeypatch.setattr(ld, "PAINTKIT_NAMES_BY_ID", {"350": "Warhawk"}, False)
+    ld.QUALITIES_BY_INDEX = {15: "Decorated Weapon"}
+    item = ip.enrich_inventory(data)[0]
+    assert item["item_name"] is None
+
+
+def test_paintkittool_item_name_cleaned(monkeypatch):
+    data = {
+        "items": [
+            {
+                "defindex": 5681,
+                "quality": 6,
+                "attributes": [
+                    {"defindex": 134, "value": 350},
+                    {"defindex": 725, "float_value": 0.2},
+                ],
+            }
+        ]
+    }
+    ld.ITEMS_BY_DEFINDEX = {
+        5681: {
+            "item_name": "Paintkittool 5",
+            "name": "Paintkittool 5",
+            "item_class": "tool",
+            "tool": {"type": "paintkit"},
+        }
+    }
+    ld.SCHEMA_ATTRIBUTES = {725: {"attribute_class": "texture_wear_default"}}
+    monkeypatch.setattr(ld, "PAINTKIT_NAMES_BY_ID", {"350": "Warhawk"}, False)
+    ld.QUALITIES_BY_INDEX = {6: "Unique"}
+    item = ip.enrich_inventory(data)[0]
+    assert item["item_name"] is None
+
+
 def test_warpaint_unknown_defaults_unknown(monkeypatch):
     data = {
         "items": [

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -852,6 +852,22 @@ def _is_warpaint_tool(schema_entry: Dict[str, Any]) -> bool:
     return False
 
 
+def _schema_item_name(schema_entry: Dict[str, Any]) -> str | None:
+    """Return sanitized ``item_name`` from ``schema_entry``."""
+
+    item_name = schema_entry.get("item_name")
+    if not isinstance(item_name, str):
+        return item_name
+
+    lower = item_name.lower()
+    if lower.startswith("paintkit") and (
+        _is_warpaint_tool(schema_entry) or _is_warpaintable(schema_entry)
+    ):
+        return None
+
+    return item_name
+
+
 def _is_plain_craft_weapon(asset: dict, schema_entry: Dict[str, Any]) -> bool:
     """Return True if ``asset`` is a plain craft weapon without special attrs."""
 
@@ -1177,7 +1193,7 @@ def _process_item(
         "quality_color": q_col,
         "image_url": image_url,
         "item_type_name": schema_entry.get("item_type_name"),
-        "item_name": schema_entry.get("name"),
+        "item_name": _schema_item_name(schema_entry),
         "craft_class": schema_entry.get("craft_class"),
         "craft_material_type": schema_entry.get("craft_material_type"),
         "item_set": schema_entry.get("item_set"),


### PR DESCRIPTION
## Summary
- remove paintkit prefixes from schema item names
- return cleaned item_name in inventory data
- test paintkit weapon and tool name sanitization

## Testing
- `pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872d7c8aae48326aa34eed3db361252