### PR TITLE
Update workflow docs for paintkit names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,5 @@ All notable changes to this project will be documented in this file.
   such items are hidden without price data.
 - Untradable timed-drop items are now marked as hidden.
 - Fixed warpaint schema slugs that prefixed names with `paintkitweapon`.
+- `Paintkitweapon` and `Paintkittool` schema names are ignored when a
+  `composite_name` or target weapon name is available.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -50,3 +50,11 @@ Decorated weapons and war‑paint tools often set a `composite_name` combining
 paintkit and weapon name. This field always takes priority when present so
 skins display their full painted name. War‑paint tools follow the same rule,
 showing `Warhawk Rocket Launcher`-style names whenever possible.
+
+## Paintkit Schema Names
+
+Steam's schema occasionally lists decorated weapons or war-paint tools with
+placeholder names such as `"Paintkitweapon"` or `"Paintkittool"`. The scanner
+skips these placeholders. When detected, it uses the item's `composite_name` if
+present or falls back to the target weapon name so skins display the correct
+weapon title.


### PR DESCRIPTION
## Summary
- document ignoring of Paintkitweapon/Paintkittool names in workflow guide
- mention name override behaviour in changelog

## Testing
- `pre-commit run --files docs/workflow.md CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_6872dd5658148326ad2c2efc175e35c7