### PR TITLE
Improve paintkit placeholder logic

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -523,6 +523,34 @@ def test_paintkittool_item_name_cleaned(monkeypatch):
     assert item["item_name"] is None
 
 
+def test_paintkit_placeholders_use_composite(monkeypatch):
+    data = {
+        "items": [
+            {
+                "defindex": 15141,
+                "quality": 15,
+                "attributes": [{"defindex": 834, "float_value": 350}],
+            }
+        ]
+    }
+    ld.ITEMS_BY_DEFINDEX = {
+        15141: {
+            "item_name": "Paintkitweapon 999",
+            "name": "Paintkitweapon 999",
+            "craft_class": "weapon",
+        }
+    }
+    monkeypatch.setattr(ld, "PAINTKIT_NAMES", {"Warhawk": 350}, False)
+    monkeypatch.setattr(ld, "PAINTKIT_NAMES_BY_ID", {"350": "Warhawk"}, False)
+    ld.QUALITIES_BY_INDEX = {15: "Decorated Weapon"}
+    item = ip.enrich_inventory(data)[0]
+    comp = item["composite_name"]
+    assert comp == "Warhawk Item #15141"
+    assert item["base_name"] == comp
+    assert item["display_name"] == comp
+    assert item["resolved_name"] == comp
+
+
 def test_warpaint_unknown_defaults_unknown(monkeypatch):
     data = {
         "items": [


### PR DESCRIPTION
## Summary
- clean base names with `_schema_item_name` and ignore paintkit placeholders
- when building item data, replace placeholder fields with `composite_name`
- test paintkit placeholder override

## Testing
- `pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py`

------
https://chatgpt.com/codex/tasks/task_e_6872e0242b74832694ae1b5b3bbec2d5