### PR TITLE
Fix war paint tool title fallback

### DIFF
--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -62,6 +62,8 @@
     {% set base = item.composite_name %}
   {% elif item.is_war_paint_tool and item.warpaint_name and item.target_weapon_name %}
     {% set base = item.warpaint_name ~ ' ' ~ item.target_weapon_name %}
+  {% elif item.is_war_paint_tool %}
+    {% set base = item.warpaint_name or item.display_name or item.name %}
   {% else %}
     {% set base = item.display_base
                   or item.resolved_name

--- a/tests/test_user_template.py
+++ b/tests/test_user_template.py
@@ -332,6 +332,31 @@ def test_war_paint_tool_composite_name_title(app):
     assert title.text.strip() == "Warhawk Rocket Launcher"
 
 
+def test_war_paint_tool_title_without_target(app):
+    context = {
+        "user": {
+            "items": [
+                {
+                    "name": "War Paint",
+                    "display_name": "War Paint: Warhawk (Field-Tested)",
+                    "warpaint_name": "Warhawk",
+                    "image_url": "",
+                    "is_war_paint_tool": True,
+                    "quality_color": "#fff",
+                }
+            ]
+        }
+    }
+    with app.test_request_context():
+        app_module = importlib.import_module("app")
+        context["user"] = app_module.normalize_user_payload(context["user"])
+        html = render_template_string(HTML, **context)
+    soup = BeautifulSoup(html, "html.parser")
+    title = soup.find("h2", class_="item-title")
+    assert title is not None
+    assert title.text.strip() == "Warhawk"
+
+
 def test_paintkitweapon_title_cleaned(app, monkeypatch):
     data = {
         "items": [


### PR DESCRIPTION
## Summary
- handle war paint tool naming in `item_card.html`
- add regression test for war paint tool title fallback

## Testing
- `pre-commit run --files templates/item_card.html tests/test_user_template.py`

------
https://chatgpt.com/codex/tasks/task_e_6872e67164a08326992315cb3bd1e987