### PR TITLE
Handle placeholder names

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -549,6 +549,7 @@ def test_paintkit_placeholders_use_composite(monkeypatch):
     assert item["base_name"] == comp
     assert item["display_name"] == comp
     assert item["resolved_name"] == comp
+    assert item["display_base"] == comp
 
 
 def test_warpaint_unknown_defaults_unknown(monkeypatch):

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -1422,10 +1422,17 @@ def enrich_inventory(
 
         comp = item.get("composite_name")
         if comp:
-            for key in ("base_name", "display_name", "resolved_name"):
+            for key in (
+                "base_name",
+                "display_name",
+                "resolved_name",
+                "display_base",
+            ):
                 val = item.get(key)
-                if isinstance(val, str) and val.lower().startswith(
-                    ("paintkitweapon", "paintkittool")
+                if isinstance(val, str) and (
+                    val.lower().startswith(("paintkitweapon", "paintkittool"))
+                    or _is_placeholder_name(val)
+                    or val.startswith("Item #")
                 ):
                     item[key] = comp
 


### PR DESCRIPTION
## Summary
- update placeholder handling when enriching inventory
- test placeholder logic for display_base

## Testing
- `pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py`
- `pytest tests/test_inventory_processor.py::test_paintkit_placeholders_use_composite -q`


------
https://chatgpt.com/codex/tasks/task_e_68730604ec288326b2f282d5cb32ca1b