### PR TITLE
Fix placeholder warpaint item names

### DIFF
--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -1221,6 +1221,8 @@ def _process_item(
             resolved_name = composite_name
         if _is_placeholder(display_name, True):
             display_name = composite_name
+        if _is_placeholder(display_base):
+            display_base = composite_name
 
     item = {
         "id": asset.get("id"),


### PR DESCRIPTION
## Summary
- sanitize `display_base` along with other fallback fields when building a composite name

## Testing
- `pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68730d3bfd108326afcdd04b5920aa83