### PR TITLE
Fix placeholder cleanup for warpaint items

### DIFF
--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -1381,6 +1381,27 @@ def _process_item(
     return item
 
 
+def _replace_placeholder_fields(item: Dict[str, Any]) -> None:
+    """Replace placeholder names with the composite name if available."""
+
+    comp = item.get("composite_name")
+    if not comp:
+        return
+    for key in (
+        "base_name",
+        "display_name",
+        "resolved_name",
+        "display_base",
+    ):
+        val = item.get(key)
+        if isinstance(val, str) and (
+            val.lower().startswith(("paintkitweapon", "paintkittool"))
+            or _is_placeholder_name(val)
+            or val.startswith("Item #")
+        ):
+            item[key] = comp
+
+
 def enrich_inventory(
     data: Dict[str, Any],
     valuation_service: ValuationService | None = None,
@@ -1420,21 +1441,7 @@ def enrich_inventory(
                 f"{pk} {item['target_weapon_name']} ({item['wear_name']})"
             )
 
-        comp = item.get("composite_name")
-        if comp:
-            for key in (
-                "base_name",
-                "display_name",
-                "resolved_name",
-                "display_base",
-            ):
-                val = item.get(key)
-                if isinstance(val, str) and (
-                    val.lower().startswith(("paintkitweapon", "paintkittool"))
-                    or _is_placeholder_name(val)
-                    or val.startswith("Item #")
-                ):
-                    item[key] = comp
+        _replace_placeholder_fields(item)
 
         quality_flag = item.get("quality")
         if (


### PR DESCRIPTION
## Summary
- centralize cleanup of placeholder names for decorated weapons

## Testing
- `pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68730d3bfd108326afcdd04b5920aa83