### PR TITLE
Improve composite name fallback

### DIFF
--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -1307,3 +1307,25 @@ def test_uncraftable_flag_absent():
     items = ip.enrich_inventory(data)
     assert items[0]["uncraftable"] is False
     assert items[0]["craftable"] is True
+
+
+def test_composite_name_fallback(monkeypatch):
+    data = {
+        "items": [
+            {
+                "defindex": 16000,
+                "quality": 15,
+                "attributes": [{"defindex": 834, "float_value": 400}],
+            }
+        ]
+    }
+    ld.ITEMS_BY_DEFINDEX = {
+        16000: {"item_name": "Paintkit Weapon", "craft_class": "weapon"}
+    }
+    monkeypatch.setattr(ld, "PAINTKIT_NAMES_BY_ID", {"400": "Ghoul Blaster"}, False)
+    monkeypatch.setattr(ld, "PAINTKIT_NAMES", {"Ghoul Blaster": 400}, False)
+    ld.QUALITIES_BY_INDEX = {15: "Decorated Weapon"}
+    items = ip.enrich_inventory(data)
+    item = items[0]
+    assert item["composite_name"] == "Ghoul Blaster"
+    assert item["resolved_name"] == "Ghoul Blaster"


### PR DESCRIPTION
## Summary
- detect additional placeholder patterns in item names
- add `_compose_composite_name` helper for robust name composition
- always extract paintkit attributes and build composite names
- test fallback logic for decorated weapons with placeholder base names

## Testing
- `pre-commit run --files utils/inventory_processor.py tests/test_inventory_processor.py`

------
https://chatgpt.com/codex/tasks/task_e_6873132dc6608326b53a6043698b7e4e