### PR TITLE
Add docs for refresh/test flags and Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR /app
 COPY . .
 RUN pip install --no-cache-dir -r requirements.txt
 EXPOSE 5000
-CMD ["python", "app.py"]
+CMD ["python", "run_hypercorn.py"]

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A lightweight Flask web app for exploring Team Fortress 2 inventories.
 - Enriches items with backpack.tf prices
 - Displays playtime and item details
 - Refreshes local schema and price caches with a command-line flag
+- Capture API data to disk with `--test` for offline development
 
 See the [docs](docs/) directory for a full workflow description.
 
@@ -24,13 +25,26 @@ See the [docs](docs/) directory for a full workflow description.
 python app.py --refresh --verbose
 ```
 
-4. Run the server:
+4. (Optional) Start in test mode to reuse cached API data:
+
+```bash
+python run_hypercorn.py --test
+```
+
+5. Run the server:
 
 ```bash
 python run_hypercorn.py
 ```
 
 Open `http://localhost:5000` and submit Steam IDs to inspect.
+
+## Docker
+
+```bash
+docker build -t tf2scanner .
+docker run --env-file .env -p 5000:5000 tf2scanner
+```
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,3 +4,5 @@ This directory contains extended information about TF2 Inventory Scanner.
 
 - [Workflow](workflow.md) – detailed explanation of how the scanner processes users.
 - [Refreshing Data](refresh.md) – how to update schema and price caches.
+- [Test Mode](test_mode.md) – capturing API data for offline use.
+- [Docker Usage](docker.md) – running the app inside a container.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,15 @@
+# Docker Usage
+
+Build the image from the project root:
+
+```bash
+docker build -t tf2scanner .
+```
+
+Run the container, passing your `.env` file for API keys:
+
+```bash
+docker run --env-file .env -p 5000:5000 tf2scanner
+```
+
+The app will be available at `http://localhost:5000`.

--- a/docs/test_mode.md
+++ b/docs/test_mode.md
@@ -1,0 +1,12 @@
+# Test Mode
+
+The optional `--test` flag saves API responses to `cached_inventories/` so you can work offline.
+When you run:
+
+```bash
+python run_hypercorn.py --test
+```
+
+The server prompts for a SteamID64. It downloads that user's inventory,
+player summary and playtime, storing the data under a subdirectory matching the SteamID.
+Subsequent runs reuse these files and no network calls are made unless you delete them.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -34,3 +34,20 @@ python app.py --refresh --verbose
 ```
 
 to update these files before starting the server.
+
+## APIs Used
+
+- **ISteamUser/ResolveVanityURL** – convert vanity names to SteamID64
+- **ISteamUser/GetPlayerSummaries** – fetch username and avatar
+- **IPlayerService/GetOwnedGames** – obtain TF2 playtime
+- **IEconItems_440/GetPlayerItems** – retrieve inventory contents
+- **backpack.tf/IGetPrices** – map item names to prices
+- **schema.autobot.tf** – download item schema information
+
+## Data Pipeline
+
+1. Input IDs are normalised to SteamID64.
+2. Profile and playtime information is fetched using the Steam Web API.
+3. The inventory API returns raw item data.
+4. Item attributes are enriched using the cached schema and prices.
+5. The resulting items are rendered in the browser with images and values.


### PR DESCRIPTION
## Summary
- describe `--test` flag and add Docker instructions in README
- link new docs in docs/README
- document API pipeline and how to use Docker
- document optional test mode
- use run_hypercorn entrypoint in Dockerfile

## Testing
- `pre-commit run --files README.md docs/README.md docs/workflow.md docs/test_mode.md docs/docker.md Dockerfile`

------
https://chatgpt.com/codex/tasks/task_e_6873af50894c8326a2be8d07af13d828