### PR TITLE
Add docs for exclusions config

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,3 +6,4 @@ This directory contains extended information about TF2 Inventory Scanner.
 - [Refreshing Data](refresh.md) – how to update schema and price caches.
 - [Test Mode](test_mode.md) – capturing API data for offline use.
 - [Docker Usage](docker.md) – running the app inside a container.
+- [Exclusions](exclusions.md) – edit rules for hidden item origins.

--- a/docs/exclusions.md
+++ b/docs/exclusions.md
@@ -1,0 +1,28 @@
+# Exclusions File
+
+The application loads a small JSON configuration to hide item origins and tweak craft weapon detection.
+
+## Location
+
+The file lives at `static/exclusions.json` and is parsed by `utils.local_data.load_exclusions()` when the server starts.
+
+## Format
+
+```json
+{
+  "hidden_origins": [0, 1, 5, 14],
+  "craft_weapon_exclusions": [1, 5, 9, 14]
+}
+```
+
+- **hidden_origins** – origins in this list are ignored completely.
+- **craft_weapon_exclusions** – items from these origins will not be flagged as plain craft weapons.
+
+## Modifying Rules
+
+1. Open `static/exclusions.json` in your editor.
+2. Add origin IDs to a list to enable the rule.
+3. Remove IDs from a list to disable the rule.
+4. Save the file and restart the app for changes to take effect.
+
+Ensure the file remains valid JSON and run `pre-commit` after editing.


### PR DESCRIPTION
## Summary
- document `static/exclusions.json` usage
- add new `docs/exclusions.md`
- link from docs README

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files docs/README.md docs/exclusions.md`

------
https://chatgpt.com/codex/tasks/task_e_6873d04faeb08326951a08d7e3f71146