### PR TITLE
Add cache check and robust port kill

### DIFF
--- a/tests/test_kill_process.py
+++ b/tests/test_kill_process.py
@@ -2,10 +2,23 @@ import os
 import types
 import psutil
 import importlib
+from pathlib import Path
 
 
 def test_kill_process_terminates_listening_process(monkeypatch):
-    called = {"terminated": False}
+    monkeypatch.setenv("SKIP_CACHE_INIT", "1")
+    monkeypatch.setenv("STEAM_API_KEY", "x")
+    monkeypatch.setenv("BPTF_API_KEY", "x")
+    monkeypatch.setattr("utils.local_data.load_files", lambda *a, **k: ({}, {}))
+    monkeypatch.setattr(
+        "utils.price_loader.ensure_prices_cached",
+        lambda refresh=False: Path("prices.json"),
+    )
+    monkeypatch.setattr(
+        "utils.price_loader.ensure_currencies_cached",
+        lambda refresh=False: Path("currencies.json"),
+    )
+    called = {"terminated": False, "waited": False, "killed": False}
 
     class DummyLaddr:
         def __init__(self, port):
@@ -25,7 +38,9 @@ def test_kill_process_terminates_listening_process(monkeypatch):
     def fake_process(pid):
         assert pid == 9999
         proc = types.SimpleNamespace(
-            terminate=lambda: called.__setitem__("terminated", True)
+            terminate=lambda: called.__setitem__("terminated", True),
+            wait=lambda timeout=5: called.__setitem__("waited", True),
+            kill=lambda: called.__setitem__("killed", True),
         )
         return proc
 
@@ -35,3 +50,4 @@ def test_kill_process_terminates_listening_process(monkeypatch):
     mod.kill_process_on_port(1234)
 
     assert called["terminated"] is True
+    assert called["waited"] is True


### PR DESCRIPTION
## Summary
- initialize TF2 schema and backpack cache on startup if missing
- skip automatic cache fetch when `SKIP_CACHE_INIT` is set
- harden `kill_process_on_port` to wait for termination
- update unit test for new behaviour

## Testing
- `pytest tests/test_kill_process.py -q`
- `ruff check app.py tests/test_kill_process.py run.py`
- `black app.py tests/test_kill_process.py run.py`


------
https://chatgpt.com/codex/tasks/task_e_6876c428bbec83268b7a107198c8d5b4