### PR TITLE
Add progress and retries for cache fetch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,5 @@
 STEAM_API_KEY=your_steam_key_here
 BPTF_API_KEY=your_backpack_key_here
+CACHE_RETRIES=2  # Number of times to retry cache refresh if files missing
+CACHE_DELAY=2    # Delay in seconds between retry attempts
+SKIP_CACHE_INIT=0 # Set to 1 to bypass cache validation on startup

--- a/run.py
+++ b/run.py
@@ -1,13 +1,23 @@
 import asyncio
 import os
+import sys
 
 from hypercorn.asyncio import serve
 from hypercorn.config import Config
 
 from app import app, kill_process_on_port, _setup_test_mode, ARGS
+from utils.cache_manager import fetch_missing_cache_files
+
+
+async def ensure_cache_ready() -> None:
+    """Ensure cache files exist before starting the server."""
+    ok = await fetch_missing_cache_files()
+    if not ok:
+        sys.exit(1)
 
 
 async def main() -> None:
+    await ensure_cache_ready()
     port = int(os.getenv("PORT", 5000))
     kill_process_on_port(port)
     if ARGS.test:

--- a/tests/test_cache_manager.py
+++ b/tests/test_cache_manager.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+
+import pytest
+
+import utils.cache_manager as cm
+
+
+def test_missing_cache_files(tmp_path, monkeypatch):
+    f1 = tmp_path / "a.json"
+    f2 = tmp_path / "b.json"
+    f1.write_text("{}")
+    monkeypatch.setattr(cm, "REQUIRED_FILES", [f1, f2])
+    missing = cm.missing_cache_files()
+    assert missing == [f2]
+
+
+@pytest.mark.asyncio
+async def test_fetch_missing_success(monkeypatch, capsys):
+    calls = {"refresh": 0}
+    missing = [Path("x")]
+
+    monkeypatch.setenv("CACHE_RETRIES", "3")
+    monkeypatch.setenv("CACHE_DELAY", "0")
+    monkeypatch.setattr(cm, "REQUIRED_FILES", missing)
+
+    def fake_missing():
+        return missing
+
+    async def fake_refresh():
+        calls["refresh"] += 1
+        missing.clear()
+
+    monkeypatch.setattr(cm, "missing_cache_files", fake_missing)
+    monkeypatch.setattr(cm, "_do_refresh", fake_refresh)
+
+    ok = await cm.fetch_missing_cache_files()
+    out = capsys.readouterr().out
+    assert "\x1b[33m🟡 [1/1] Fetching x...\x1b[0m" in out
+    assert "\x1b[32m✅ [1/1] x downloaded successfully\x1b[0m" in out
+    assert ok is True
+    assert calls["refresh"] == 1
+
+
+@pytest.mark.asyncio
+async def test_fetch_missing_failure(monkeypatch, capsys):
+    calls = {"refresh": 0}
+    missing = [Path("x")]
+
+    monkeypatch.setenv("CACHE_RETRIES", "3")
+    monkeypatch.setenv("CACHE_DELAY", "0")
+    monkeypatch.setattr(cm, "REQUIRED_FILES", missing)
+
+    def fake_missing():
+        return missing
+
+    async def fake_refresh():
+        calls["refresh"] += 1
+
+    monkeypatch.setattr(cm, "missing_cache_files", fake_missing)
+    monkeypatch.setattr(cm, "_do_refresh", fake_refresh)
+
+    ok = await cm.fetch_missing_cache_files()
+    out = capsys.readouterr().out
+    assert "\x1b[31m" in out
+    assert "Failed after 3 retries" in out
+    assert ok is False
+    assert calls["refresh"] == 3

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -12,6 +12,11 @@ from .local_data import FOOTPRINT_SPELL_MAP, PAINT_SPELL_MAP
 from .wear_helpers import _wear_tier, _decode_seed_info
 from .valuation_service import ValuationService, get_valuation_service
 from .helpers import best_match_from_keys
+from .cache_manager import (
+    missing_cache_files,
+    validate_cache_files,
+    fetch_missing_cache_files,
+)
 from .steam_api_client import (
     get_player_summaries_async,
     fetch_inventory_async,
@@ -39,4 +44,7 @@ __all__ = [
     "fetch_inventory_async",
     "get_tf2_playtime_hours_async",
     "extract_steam_ids",
+    "missing_cache_files",
+    "validate_cache_files",
+    "fetch_missing_cache_files",
 ]

--- a/utils/cache_manager.py
+++ b/utils/cache_manager.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+from typing import List
+
+from .price_loader import ensure_prices_cached_async, ensure_currencies_cached_async
+from .schema_provider import SchemaProvider
+
+# Environment configuration
+CACHE_RETRIES_DEFAULT = int(os.getenv("CACHE_RETRIES", "2"))
+CACHE_DELAY_DEFAULT = int(os.getenv("CACHE_DELAY", "2"))
+SKIP_CACHE_INIT_DEFAULT = os.getenv("SKIP_CACHE_INIT", "0") == "1"
+
+# ANSI color codes
+COLOR_YELLOW = "\033[33m"
+COLOR_GREEN = "\033[32m"
+COLOR_RED = "\033[31m"
+COLOR_RESET = "\033[0m"
+
+# List of files required for the application to run
+REQUIRED_FILES: List[Path] = [
+    Path("cache/schema/items.json"),
+    Path("cache/schema/attributes.json"),
+    Path("cache/schema/particles.json"),
+    Path("cache/schema/effects.json"),
+    Path("cache/schema/paints.json"),
+    Path("cache/schema/parts.json"),
+    Path("cache/schema/warpaints.json"),
+    Path("cache/schema/qualities.json"),
+    Path("cache/schema/defindexes.json"),
+    Path("cache/schema/string_lookups.json"),
+    Path("cache/prices.json"),
+    Path("cache/currencies.json"),
+]
+
+
+async def _save_json_atomic(path: Path, data: object) -> None:
+    """Write ``data`` to ``path`` atomically."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(data, indent=2))
+    tmp.replace(path)
+
+
+async def _download_schema_section(
+    client, provider: SchemaProvider, key: str, endpoint: str
+) -> None:
+    data = await provider._fetch_async(client, endpoint)
+    if isinstance(data, dict) and "value" in data:
+        data = data["value"]
+    if (
+        key == "effects"
+        and isinstance(data, dict)
+        and not any(str(k).isdigit() for k in data)
+        and all(str(v).isdigit() for v in data.values())
+    ):
+        data = {int(v): k for k, v in data.items()}
+    path = provider._cache_file(key)
+    await _save_json_atomic(path, data)
+    count = len(data) if hasattr(data, "__len__") else 0
+    print(f"\N{CHECK MARK} Saved {path} ({count} entries)")
+
+
+async def _refresh_schema_concurrent() -> None:
+    provider = SchemaProvider(cache_dir="cache/schema")
+    async with __import__("httpx").AsyncClient() as client:
+        tasks = [
+            _download_schema_section(client, provider, k, ep)
+            for k, ep in provider.ENDPOINTS.items()
+        ]
+        await asyncio.gather(*tasks)
+
+
+async def _do_refresh() -> None:
+    """Fetch all schema and price data in parallel."""
+    print("\N{ANTICLOCKWISE OPEN CIRCLE ARROW} Refreshing TF2 schema...", flush=True)
+    await _refresh_schema_concurrent()
+
+    price_task = asyncio.create_task(ensure_prices_cached_async(refresh=True))
+    curr_task = asyncio.create_task(ensure_currencies_cached_async(refresh=True))
+    price_path, curr_path = await asyncio.gather(price_task, curr_task)
+
+    print(f"\N{CHECK MARK} Saved {price_path}")
+    print(f"\N{CHECK MARK} Saved {curr_path}")
+    print(
+        "\N{CHECK MARK} Refresh complete. Restart app normally without --refresh to start server.",
+        flush=True,
+    )
+
+
+def missing_cache_files() -> List[Path]:
+    """Return list of required cache files that are missing or empty."""
+    return [p for p in REQUIRED_FILES if not p.exists() or p.stat().st_size == 0]
+
+
+def validate_cache_files() -> bool:
+    """Return ``True`` if all required files exist and are non-empty."""
+    return not missing_cache_files()
+
+
+async def fetch_missing_cache_files() -> bool:
+    """Download any missing cache files with progress and retries."""
+
+    if os.getenv("SKIP_CACHE_INIT", "1" if SKIP_CACHE_INIT_DEFAULT else "0") == "1":
+        print(
+            f"{COLOR_YELLOW}Skipping cache validation (SKIP_CACHE_INIT=1){COLOR_RESET}"
+        )
+        return True
+
+    retries = int(os.getenv("CACHE_RETRIES", str(CACHE_RETRIES_DEFAULT)))
+    delay = int(os.getenv("CACHE_DELAY", str(CACHE_DELAY_DEFAULT)))
+
+    for attempt in range(1, retries + 1):
+        missing = missing_cache_files()
+        if not missing:
+            print(f"{COLOR_GREEN}✅ Cache verified. Starting server...{COLOR_RESET}")
+            return True
+
+        initial_missing = list(missing)
+        total = len(initial_missing)
+        for i, path in enumerate(initial_missing, 1):
+            print(f"{COLOR_YELLOW}🟡 [{i}/{total}] Fetching {path}...{COLOR_RESET}")
+
+        try:
+            await _do_refresh()
+        except Exception as exc:  # pragma: no cover - network failures logged
+            print(f"{COLOR_RED}❌ Refresh attempt {attempt} failed: {exc}{COLOR_RESET}")
+
+        remaining = missing_cache_files()
+        for i, path in enumerate(initial_missing, 1):
+            if path not in remaining:
+                print(
+                    f"{COLOR_GREEN}✅ [{i}/{total}] {path} downloaded successfully{COLOR_RESET}"
+                )
+
+        if not remaining:
+            print(f"{COLOR_GREEN}✅ Cache verified. Starting server...{COLOR_RESET}")
+            return True
+
+        if attempt < retries:
+            await asyncio.sleep(delay)
+
+    final_missing = missing_cache_files()
+    if final_missing:
+        paths = ", ".join(map(str, final_missing))
+        print(f"{COLOR_RED}❌ Failed after {retries} retries: {paths}{COLOR_RESET}")
+        return False
+
+    print(f"{COLOR_GREEN}✅ Cache verified. Starting server...{COLOR_RESET}")
+    return True
+
+
+__all__ = [
+    "REQUIRED_FILES",
+    "missing_cache_files",
+    "validate_cache_files",
+    "fetch_missing_cache_files",
+    "_do_refresh",
+]


### PR DESCRIPTION
## Summary
- improve cache initialization with per-file progress and colored statuses
- retry individual cache fetches with environment overrides
- exit with clear failure summary if files still missing
- adjust tests for new progress output and env vars
- document CACHE_RETRIES, CACHE_DELAY and SKIP_CACHE_INIT in `.env.example`
- ensure failure output includes ANSI codes in tests

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files .env.example utils/cache_manager.py app.py run.py tests/test_cache_manager.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6876d54bce548326bef2be07f536ba42