### PR TITLE
Improve cache auto-fetch logging

### DIFF
--- a/tests/test_cache_manager.py
+++ b/tests/test_cache_manager.py
@@ -29,6 +29,7 @@ async def test_fetch_missing_success(monkeypatch, capsys):
     async def fake_refresh():
         calls["refresh"] += 1
         missing.clear()
+        return 5
 
     monkeypatch.setattr(cm, "missing_cache_files", fake_missing)
     monkeypatch.setattr(cm, "_do_refresh", fake_refresh)
@@ -37,6 +38,8 @@ async def test_fetch_missing_success(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "\x1b[33m🟡 [1/1] Fetching x...\x1b[0m" in out
     assert "\x1b[32m✅ [1/1] x downloaded successfully\x1b[0m" in out
+    assert "1 missing files fetched" in out
+    assert "4 extra schema" in out
     assert ok is True
     assert calls["refresh"] == 1
 
@@ -65,3 +68,25 @@ async def test_fetch_missing_failure(monkeypatch, capsys):
     assert "Failed after 3 retries" in out
     assert ok is False
     assert calls["refresh"] == 3
+
+
+@pytest.mark.asyncio
+async def test_skip_cache(monkeypatch, capsys):
+    monkeypatch.setenv("SKIP_CACHE_INIT", "1")
+    ok = await cm.fetch_missing_cache_files()
+    out = capsys.readouterr().out
+    assert "\u26A0" in out
+    assert ok is True
+
+
+@pytest.mark.asyncio
+async def test_retry_note(monkeypatch, capsys):
+    monkeypatch.setenv("CACHE_RETRIES", "4")
+    monkeypatch.setenv("CACHE_DELAY", "1")
+
+    monkeypatch.setattr(cm, "missing_cache_files", lambda: [])
+
+    ok = await cm.fetch_missing_cache_files()
+    out = capsys.readouterr().out
+    assert "Retrying up to 4 times with 1 sec delay" in out
+    assert ok is True


### PR DESCRIPTION
## Summary
- track schema file refresh count in cache manager
- display missing/extra file counts in summary line
- show retry note and skip message as needed
- test new progress logging

## Testing
- `pre-commit run --files utils/cache_manager.py tests/test_cache_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_6876f2371aa083269cda45498b82a0e1