### PR TITLE
Improve cache summary logging

### DIFF
--- a/tests/test_cache_manager.py
+++ b/tests/test_cache_manager.py
@@ -38,8 +38,8 @@ async def test_fetch_missing_success(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "\x1b[33m🟡 [1/1] Fetching x...\x1b[0m" in out
     assert "\x1b[32m✅ [1/1] x downloaded successfully\x1b[0m" in out
-    assert "1 missing files fetched" in out
-    assert "4 extra schema" in out
+    assert "Full schema refresh updated" in out
+    assert "1 missing files downloaded" in out
     assert ok is True
     assert calls["refresh"] == 1
 

--- a/utils/cache_manager.py
+++ b/utils/cache_manager.py
@@ -164,9 +164,9 @@ async def fetch_missing_cache_files() -> bool:
                 )
 
         if not remaining:
-            extra_count = max(0, refreshed_count - missing_count)
+            total_updated = refreshed_count
             print(
-                f"{COLOR_GREEN}✅ Cache verified. {missing_count} missing files fetched, {extra_count} extra schema files refreshed, prices and currencies updated.{COLOR_RESET}"
+                f"{COLOR_GREEN}✅ Cache verified. {missing_count} missing files downloaded. Full schema refresh updated {total_updated} files total, including prices and currencies.{COLOR_RESET}"
             )
             return True
 
@@ -179,9 +179,9 @@ async def fetch_missing_cache_files() -> bool:
         print(f"{COLOR_RED}❌ Failed after {retries} retries: {paths}{COLOR_RESET}")
         return False
 
-    extra_count = max(0, refreshed_count - missing_count)
+    total_updated = refreshed_count
     print(
-        f"{COLOR_GREEN}✅ Cache verified. {missing_count} missing files fetched, {extra_count} extra schema files refreshed, prices and currencies updated.{COLOR_RESET}"
+        f"{COLOR_GREEN}✅ Cache verified. {missing_count} missing files downloaded. Full schema refresh updated {total_updated} files total, including prices and currencies.{COLOR_RESET}"
     )
     return True
 


### PR DESCRIPTION
## Summary
- update cache summary message for clarity
- adjust cache manager tests for new text

## Testing
- `SKIP_VALIDATE=1 .venv/bin/pre-commit run --files utils/cache_manager.py tests/test_cache_manager.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68776073741c8326be336bbe18de2464