### PR TITLE
Fix schema validation on startup

### DIFF
--- a/app.py
+++ b/app.py
@@ -456,8 +456,16 @@ async def index():
 if __name__ == "__main__":
 
     async def _main() -> None:
-        if not await fetch_missing_cache_files():
+        print(
+            "\N{LEFT-POINTING MAGNIFYING GLASS} Validating schema and pricing cache..."
+        )
+        ok = await fetch_missing_cache_files()
+        if not ok:
+            print("\N{CROSS MARK} Could not fetch required schema. Exiting.")
             raise SystemExit(1)
+        # Reload schema now that it's guaranteed to exist
+        local_data.load_files(auto_refetch=False)
+
         port = int(os.getenv("PORT", 5000))
         kill_process_on_port(port)
         if TEST_MODE:

--- a/tests/test_cache_manager.py
+++ b/tests/test_cache_manager.py
@@ -11,7 +11,7 @@ def test_missing_cache_files(tmp_path, monkeypatch):
     f1.write_text("{}")
     monkeypatch.setattr(cm, "REQUIRED_FILES", [f1, f2])
     missing = cm.missing_cache_files()
-    assert missing == [f2]
+    assert missing == [f1, f2]
 
 
 @pytest.mark.asyncio
@@ -75,7 +75,7 @@ async def test_skip_cache(monkeypatch, capsys):
     monkeypatch.setenv("SKIP_CACHE_INIT", "1")
     ok = await cm.fetch_missing_cache_files()
     out = capsys.readouterr().out
-    assert "\u26A0" in out
+    assert "\u26a0" in out
     assert ok is True
 
 
@@ -89,4 +89,43 @@ async def test_retry_note(monkeypatch, capsys):
     ok = await cm.fetch_missing_cache_files()
     out = capsys.readouterr().out
     assert "Retrying up to 4 times with 1 sec delay" in out
+    assert ok is True
+
+
+def test_incomplete_file_marked_missing(tmp_path, monkeypatch):
+    file = tmp_path / "items.json"
+    file.write_text("{}")
+    monkeypatch.setattr(cm, "REQUIRED_FILES", [file])
+    missing = cm.missing_cache_files()
+    assert missing == [file]
+
+
+@pytest.mark.asyncio
+async def test_incomplete_file_refetched(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(cm, "MIN_SCHEMA_FILE_SIZE", 10)
+
+    class FakeProvider(cm.SchemaProvider):
+        def __init__(self, *a, **k):
+            self.ENDPOINTS = {"items": "items"}
+            self.cache_dir = tmp_path
+
+        def _cache_file(self, key: str) -> Path:
+            return self.cache_dir / f"{key}.json"
+
+    monkeypatch.setattr(cm, "SchemaProvider", FakeProvider)
+
+    async def fake_refresh_concurrent(save_func=cm._save_json_atomic):
+        provider = FakeProvider()
+        await save_func(provider._cache_file("items"), "x" * 20)
+
+    monkeypatch.setattr(cm, "_refresh_schema_concurrent", fake_refresh_concurrent)
+
+    incomplete = tmp_path / "items.json"
+    incomplete.write_text("{}")
+    monkeypatch.setattr(cm, "REQUIRED_FILES", [incomplete])
+
+    ok = await cm.fetch_missing_cache_files()
+    out = capsys.readouterr().out
+    assert "Detected incomplete schema cache" in out
+    assert "downloaded successfully" in out
     assert ok is True

--- a/utils/cache_manager.py
+++ b/utils/cache_manager.py
@@ -14,6 +14,9 @@ CACHE_RETRIES_DEFAULT = int(os.getenv("CACHE_RETRIES", "2"))
 CACHE_DELAY_DEFAULT = int(os.getenv("CACHE_DELAY", "2"))
 SKIP_CACHE_INIT_DEFAULT = os.getenv("SKIP_CACHE_INIT", "0") == "1"
 
+# Minimum acceptable size for schema files in bytes
+MIN_SCHEMA_FILE_SIZE = 4096  # 4 KB
+
 # ANSI color codes
 COLOR_YELLOW = "\033[33m"
 COLOR_GREEN = "\033[32m"
@@ -87,6 +90,20 @@ async def _do_refresh() -> int:
 
     count = 0
 
+    provider = SchemaProvider(cache_dir="cache/schema")
+    for key in provider.ENDPOINTS:
+        path = provider._cache_file(key)
+        if path.exists():
+            size = path.stat().st_size
+            if size < MIN_SCHEMA_FILE_SIZE:
+                print(
+                    f"{COLOR_YELLOW}⚠ Detected incomplete schema cache ({size} bytes). Re-fetching...{COLOR_RESET}"
+                )
+                try:
+                    path.unlink()
+                except FileNotFoundError:
+                    pass
+
     async def counting_save(path: Path, data: object) -> None:
         nonlocal count
         await _save_json_atomic(path, data)
@@ -112,8 +129,12 @@ async def _do_refresh() -> int:
 
 
 def missing_cache_files() -> List[Path]:
-    """Return list of required cache files that are missing or empty."""
-    return [p for p in REQUIRED_FILES if not p.exists() or p.stat().st_size == 0]
+    """Return list of required cache files that are missing or incomplete."""
+    return [
+        p
+        for p in REQUIRED_FILES
+        if not p.exists() or p.stat().st_size < MIN_SCHEMA_FILE_SIZE
+    ]
 
 
 def validate_cache_files() -> bool:
@@ -144,7 +165,9 @@ async def fetch_missing_cache_files() -> bool:
     for attempt in range(1, retries + 1):
         missing = missing_cache_files()
         if not missing:
-            print(f"{COLOR_GREEN}✅ Cache verified. Starting server...{COLOR_RESET}")
+            print(
+                f"{COLOR_GREEN}✅ All schema files verified. Starting server.{COLOR_RESET}"
+            )
             return True
 
         initial_missing = list(missing)


### PR DESCRIPTION
## Summary
- detect incomplete schema files using size threshold
- retry schema download after deleting incomplete cache
- block Flask startup until schema and pricing cache validated
- test incomplete schema handling

## Testing
- `pre-commit run --files utils/cache_manager.py app.py tests/test_cache_manager.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68777a9ab2a48326a6304466f85f4616