### PR TITLE
Add per-file cache size thresholds

### DIFF
--- a/tests/test_cache_manager.py
+++ b/tests/test_cache_manager.py
@@ -100,6 +100,22 @@ def test_incomplete_file_marked_missing(tmp_path, monkeypatch):
     assert missing == [file]
 
 
+def test_small_qualities_not_flagged(tmp_path, monkeypatch):
+    qual = tmp_path / "qualities.json"
+    qual.write_bytes(b"x" * 200)
+    monkeypatch.setattr(cm, "REQUIRED_FILES", [qual])
+    missing = cm.missing_cache_files()
+    assert missing == []
+
+
+def test_small_items_flagged(tmp_path, monkeypatch):
+    item = tmp_path / "items.json"
+    item.write_bytes(b"x" * 200)
+    monkeypatch.setattr(cm, "REQUIRED_FILES", [item])
+    missing = cm.missing_cache_files()
+    assert missing == [item]
+
+
 @pytest.mark.asyncio
 async def test_incomplete_file_refetched(monkeypatch, tmp_path, capsys):
     monkeypatch.setattr(cm, "MIN_SCHEMA_FILE_SIZE", 10)

--- a/utils/cache_manager.py
+++ b/utils/cache_manager.py
@@ -159,6 +159,8 @@ def _size_threshold(path: Path) -> int:
         return MIN_PRICES_FILE_SIZE
     if path.name == "currencies.json":
         return MIN_CURRENCIES_FILE_SIZE
+    if path.name == "qualities.json":
+        return 100
     return MIN_SCHEMA_FILE_SIZE
 
 


### PR DESCRIPTION
## Summary
- extend `_size_threshold` helper with special rule for `qualities.json`
- add tests covering small schema file validation

## Testing
- `pre-commit run --files utils/cache_manager.py tests/test_cache_manager.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68778c74cae88326849db8e50bbad9cd