### PR TITLE
Add schema refresh restart to run.py

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -10,6 +10,10 @@ This document provides a high-level summary of the TF2 Inventory Scanner codebas
 ```python
 # run.py
 async def main() -> None:
+    schema_refreshed = await ensure_cache_ready()
+    if schema_refreshed and not ARGS.test:
+        print(f"{COLOR_YELLOW}🔄 Restarting to load updated schema...{COLOR_RESET}")
+        os.execv(sys.executable, [sys.executable] + sys.argv)
     port = int(os.getenv("PORT", 5000))
     kill_process_on_port(port)
     if ARGS.test:

--- a/run.py
+++ b/run.py
@@ -6,18 +6,32 @@ from hypercorn.asyncio import serve
 from hypercorn.config import Config
 
 from app import app, kill_process_on_port, _setup_test_mode, ARGS
-from utils.cache_manager import fetch_missing_cache_files
+from utils.cache_manager import (
+    fetch_missing_cache_files,
+    COLOR_YELLOW,
+    COLOR_RESET,
+)
 
 
-async def ensure_cache_ready() -> None:
-    """Ensure cache files exist before starting the server."""
-    ok, _, _ = await fetch_missing_cache_files()
+async def ensure_cache_ready() -> bool:
+    """Ensure cache files exist before starting the server.
+
+    Returns ``True`` if the schema was refreshed and a restart is needed.
+    """
+    ok, _, schema_refreshed = await fetch_missing_cache_files()
     if not ok:
         sys.exit(1)
+    return schema_refreshed
 
 
 async def main() -> None:
-    await ensure_cache_ready()
+    schema_refreshed = await ensure_cache_ready()
+    if schema_refreshed and not ARGS.test:
+        print(
+            f"{COLOR_YELLOW}🔄 Restarting to load updated schema...{COLOR_RESET}",
+            flush=True,
+        )
+        os.execv(sys.executable, [sys.executable] + sys.argv)
     port = int(os.getenv("PORT", 5000))
     kill_process_on_port(port)
     if ARGS.test:


### PR DESCRIPTION
## Summary
- restart process from `run.py` when schema cache updates
- document startup flow in `docs/overview.md`
- test restart logic in `test_run.py`

## Testing
- `pre-commit run --files run.py tests/test_run.py docs/overview.md`

------
https://chatgpt.com/codex/tasks/task_e_6877a8ec46a08326bca72a9f4d70d0ce