### PR TITLE
Remove legacy string_lookups path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing
+
+Run `pre-commit` and the legacy cache check before pushing changes.
+
+```bash
+pre-commit run --files <files>
+python scripts/check_legacy.py
+```
+
+CI pipelines should execute `python scripts/check_legacy.py` and fail if any old cache files remain.

--- a/docs/cache_structure.md
+++ b/docs/cache_structure.md
@@ -1,0 +1,9 @@
+# Cache Structure
+
+All schema files are stored under `cache/schema/`. When new versions are downloaded, outdated files from older paths are removed automatically.
+
+Legacy files such as `cache/string_lookups.json` are deleted when `utils.local_data.cleanup_legacy_files()` runs. You can also enforce this in CI with `scripts/check_legacy.py`.
+
+```bash
+python scripts/check_legacy.py
+```

--- a/scripts/check_legacy.py
+++ b/scripts/check_legacy.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""Fail CI if legacy cache files exist."""
+from pathlib import Path
+
+LEGACY_PATHS = [Path("cache/string_lookups.json")]
+
+
+def main() -> int:
+    found = [p for p in LEGACY_PATHS if p.exists()]
+    if found:
+        print("Legacy cache files detected:")
+        for p in found:
+            print(f"- {p}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_local_data.py
+++ b/tests/test_local_data.py
@@ -9,7 +9,8 @@ def test_load_files_success(tmp_path, monkeypatch, caplog):
     particles_file = tmp_path / "particles.json"
     items_file = tmp_path / "items.json"
     qual_file = tmp_path / "qualities.json"
-    lookups_file = tmp_path / "string_lookups.json"
+    lookups_file = tmp_path / "schema" / "string_lookups.json"
+    lookups_file.parent.mkdir(parents=True, exist_ok=True)
     currencies_file = tmp_path / "currencies.json"
 
     attr_file.write_text(json.dumps([{"defindex": 1, "name": "Attr"}]))
@@ -66,7 +67,8 @@ def test_load_files_auto_refetch(tmp_path, monkeypatch, caplog):
     items_file = tmp_path / "items.json"
     particles_file = tmp_path / "particles.json"
     qual_file = tmp_path / "qualities.json"
-    lookups_file = tmp_path / "string_lookups.json"
+    lookups_file = tmp_path / "schema" / "string_lookups.json"
+    lookups_file.parent.mkdir(parents=True, exist_ok=True)
     currencies_file = tmp_path / "currencies.json"
 
     monkeypatch.setattr(ld, "ATTRIBUTES_FILE", attr_file)
@@ -168,7 +170,8 @@ def test_load_files_string_lookups(tmp_path, monkeypatch):
     particles_file = tmp_path / "particles.json"
     items_file = tmp_path / "items.json"
     qual_file = tmp_path / "qualities.json"
-    lookups_file = tmp_path / "string_lookups.json"
+    lookups_file = tmp_path / "schema" / "string_lookups.json"
+    lookups_file.parent.mkdir(parents=True, exist_ok=True)
     currencies_file = tmp_path / "currencies.json"
 
     for f in (attr_file, particles_file, items_file, qual_file):
@@ -274,3 +277,13 @@ def test_load_exclusions(tmp_path, monkeypatch):
 
     loaded = ld.load_exclusions()
     assert loaded == data
+
+
+def test_cleanup_legacy_files(tmp_path, monkeypatch, capsys):
+    legacy = tmp_path / "string_lookups.json"
+    legacy.write_text("{}")
+    monkeypatch.setattr(ld, "LEGACY_STRING_LOOKUPS_FILE", legacy)
+    ld.cleanup_legacy_files(verbose=True)
+    captured = capsys.readouterr().out
+    assert not legacy.exists()
+    assert "Removing legacy file" in captured

--- a/utils/local_data.py
+++ b/utils/local_data.py
@@ -75,7 +75,20 @@ DEFAULT_STRANGE_PART_FILE = BASE_DIR / "cache" / "strange_part_names.json"
 # Cached warpaint names from the paintkits endpoint
 DEFAULT_PAINTKIT_FILE = BASE_DIR / "cache" / "schema" / "warpaints.json"
 DEFAULT_CRATE_SERIES_FILE = BASE_DIR / "cache" / "crate_series_names.json"
-DEFAULT_STRING_LOOKUPS_FILE = BASE_DIR / "cache" / "string_lookups.json"
+DEFAULT_STRING_LOOKUPS_FILE = BASE_DIR / "cache" / "schema" / "string_lookups.json"
+LEGACY_STRING_LOOKUPS_FILE = BASE_DIR / "cache" / "string_lookups.json"
+
+
+def cleanup_legacy_files(verbose: bool = False) -> None:
+    """Remove old cache files replaced by new schema paths."""
+
+    old_path = LEGACY_STRING_LOOKUPS_FILE
+    if old_path.exists():
+        if verbose or os.getenv("FLASK_DEBUG"):
+            print(f"🧹 Removing legacy file: {old_path}")
+        old_path.unlink()
+
+
 EFFECT_FILE = Path(os.getenv("TF2_EFFECT_FILE", DEFAULT_EFFECT_FILE))
 DEFAULT_EFFECT_NAMES_FILE = BASE_DIR / "data" / "effect_names.json"
 EFFECT_NAMES_FILE = Path(os.getenv("TF2_EFFECT_NAMES_FILE", DEFAULT_EFFECT_NAMES_FILE))
@@ -200,6 +213,8 @@ def load_files(
     global SCHEMA_ATTRIBUTES, ITEMS_BY_DEFINDEX, QUALITIES_BY_INDEX, PARTICLE_NAMES
     global EFFECT_NAMES, PAINT_NAMES, WEAR_NAMES, KILLSTREAK_NAMES, STRANGE_PART_NAMES, PAINTKIT_NAMES, CRATE_SERIES_NAMES
     global FOOTPRINT_SPELL_MAP, PAINT_SPELL_MAP
+
+    cleanup_legacy_files(verbose)
 
     required = {
         "attributes": ATTRIBUTES_FILE.resolve(),


### PR DESCRIPTION
## Summary
- point string lookups to `cache/schema`
- clean up old `cache/string_lookups.json`
- adjust tests to new location
- add `cleanup_legacy_files` helper
- add CI guard to detect stale cache files

## Testing
- `pre-commit run --files utils/local_data.py tests/test_local_data.py scripts/check_legacy.py docs/cache_structure.md CONTRIBUTING.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877b418d2e88326a0875cc3223ded56