### PR TITLE
Add killstreak tool parsing

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -632,3 +632,27 @@ footer {
     color: #ccc;
     margin-top: 2px;
 }
+
+/* ---- Killstreak kit composite images ---- */
+.kit-composite {
+  position: relative;
+  width: 96px;
+  height: 96px;
+}
+
+.kit-bg {
+  width: 100%;
+  height: 100%;
+}
+
+.kit-weapon-overlay {
+  position: absolute;
+  bottom: 8px;
+  right: 8px;
+  width: 48px;
+  height: auto;
+  z-index: 2;
+  border: 1px solid #ccc;
+  background: rgba(0, 0, 0, 0.3);
+  border-radius: 4px;
+}

--- a/templates/_modal.html
+++ b/templates/_modal.html
@@ -13,4 +13,22 @@
   {% if item.craftable is not none %}
     <p><strong>{% if item.craftable %}Craftable{% else %}Uncraftable{% endif %}</strong></p>
   {% endif %}
+  {% if item.killstreak_tool_type %}
+    <h4>{{ item.tier_name or "Killstreak Item" }}</h4>
+    <p><strong>Weapon:</strong> {{ item.target_weapon_name or "Unknown" }}</p>
+    {% if item.sheen_name %}
+      <p><strong>Sheen:</strong> {{ item.sheen_name }}</p>
+    {% endif %}
+    {% if item.killstreak_effect %}
+      <p><strong>Killstreaker:</strong> {{ item.killstreak_effect }}</p>
+    {% endif %}
+    {% if item.fabricator_requirements %}
+      <p><strong>Parts Required:</strong></p>
+      <ul>
+      {% for part in item.fabricator_requirements %}
+        <li>{{ part.part }} × {{ part.qty }}</li>
+      {% endfor %}
+      </ul>
+    {% endif %}
+  {% endif %}
 </div>

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -24,7 +24,12 @@
       alt="effect"
     >
   {% endif %}
-  {% if item.image_url %}
+  {% if item.target_weapon_image %}
+    <div class="kit-composite">
+      <img class="kit-bg" src="{{ item.image_url }}" loading="lazy" width="96" height="96" alt="{{ item.display_name }}">
+      <img class="kit-weapon-overlay" src="{{ item.target_weapon_image }}" loading="lazy" alt="overlay">
+    </div>
+  {% elif item.image_url %}
     <img
       class="item-img"
       loading="lazy"

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -1247,3 +1247,85 @@ def test_uncraftable_flag_absent():
     items = ip.enrich_inventory(data)
     assert items[0]["uncraftable"] is False
     assert items[0]["craftable"] is True
+
+
+def test_killstreak_kit_parsing():
+    data = {
+        "items": [
+            {
+                "defindex": 6526,
+                "quality": 6,
+                "attributes": [
+                    {"defindex": 2012, "float_value": 36},
+                    {"defindex": 2014, "float_value": 2},
+                    {"defindex": 2013, "float_value": 2003},
+                    {"defindex": 2025, "float_value": 3},
+                ],
+            }
+        ]
+    }
+    ld.ITEMS_BY_DEFINDEX = {
+        6526: {"item_name": "Professional Killstreak Kit"},
+        36: {"item_name": "Blutsauger", "image_url": "blut.png"},
+    }
+    ld.QUALITIES_BY_INDEX = {6: "Unique"}
+    ld.KILLSTREAK_EFFECT_NAMES = {"2003": "Cerebral Discharge"}
+    items = ip.enrich_inventory(data)
+    item = items[0]
+    assert item["target_weapon_defindex"] == 36
+    assert item["target_weapon_name"] == "Blutsauger"
+    assert item["sheen_name"] == "Deadly Daffodil"
+    assert item["killstreak_effect"] == "Cerebral Discharge"
+    assert item["killstreak_name"] == "Professional"
+    assert item["killstreak_tool_type"] == "kit"
+    assert item["fabricator_requirements"] is None
+    assert item["stack_key"] is None
+    assert item["target_weapon_image"] == "blut.png"
+
+
+def test_killstreak_fabricator_parsing():
+    data = {
+        "items": [
+            {
+                "defindex": 20003,
+                "quality": 6,
+                "attributes": [
+                    {
+                        "defindex": 2006,
+                        "is_output": True,
+                        "itemdef": 6526,
+                        "attributes": [
+                            {"defindex": 2012, "float_value": 36},
+                            {"defindex": 2014, "float_value": 5},
+                            {"defindex": 2013, "float_value": 2006},
+                            {"defindex": 2025, "float_value": 3},
+                        ],
+                    },
+                    {"defindex": 5706, "itemdef": 5706, "quantity": 3},
+                    {"defindex": 5702, "itemdef": 5702, "quantity": 1},
+                ],
+            }
+        ]
+    }
+    ld.ITEMS_BY_DEFINDEX = {
+        20003: {"item_name": "Professional Fabricator"},
+        36: {"item_name": "Blutsauger", "image_url": "blut.png"},
+        5706: {"item_name": "Battle-Worn Robot KB-808"},
+        5702: {"item_name": "Battle-Worn Robot Money Furnace"},
+    }
+    ld.QUALITIES_BY_INDEX = {6: "Unique"}
+    ld.KILLSTREAK_EFFECT_NAMES = {"2006": "Singularity"}
+    items = ip.enrich_inventory(data)
+    item = items[0]
+    assert item["target_weapon_defindex"] == 36
+    assert item["target_weapon_name"] == "Blutsauger"
+    assert item["sheen_name"] == "Agonizing Emerald"
+    assert item["killstreak_effect"] == "Singularity"
+    assert item["killstreak_name"] == "Professional"
+    assert item["killstreak_tool_type"] == "fabricator"
+    assert item["fabricator_requirements"] == [
+        {"part": "Battle-Worn Robot KB-808", "qty": 3},
+        {"part": "Battle-Worn Robot Money Furnace", "qty": 1},
+    ]
+    assert item["stack_key"] is None
+    assert item["target_weapon_image"] == "blut.png"

--- a/tests/test_quantity_badge.py
+++ b/tests/test_quantity_badge.py
@@ -46,6 +46,16 @@ def test_stack_items_ignores_ids(monkeypatch):
     assert result[0]["quantity"] == 2
 
 
+def test_stack_items_respects_none_stack_key():
+    mod = importlib.import_module("app")
+    items = [
+        {"name": "Kit", "image_url": "", "quality_color": "#fff", "stack_key": None},
+        {"name": "Kit", "image_url": "", "quality_color": "#fff", "stack_key": None},
+    ]
+    result = mod.stack_items(items)
+    assert len(result) == 2
+
+
 def test_quantity_badge_rendered(monkeypatch):
     monkeypatch.setenv("STEAM_API_KEY", "x")
     monkeypatch.setenv("BPTF_API_KEY", "x")


### PR DESCRIPTION
## Summary
- support parsing killstreak kits and fabricators
- expose sheen, killstreaker and target weapon for these items
- record fabricator part requirements
- test killstreak kit/fabricator enrichment
- prevent stacking of killstreak tools
- display composite kit images with weapon overlay in cards
- show detailed killstreak info in item modal

## Testing
- `pre-commit run --files app.py static/style.css templates/_modal.html templates/item_card.html tests/test_inventory_processor.py tests/test_quantity_badge.py utils/inventory_processor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878000d5c4c8326a4dfeb691fbd43db