### PR TITLE
Improve killstreak kit overlay style

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -647,12 +647,17 @@ footer {
 
 .kit-weapon-overlay {
   position: absolute;
-  bottom: 8px;
-  right: 8px;
-  width: 48px;
+  bottom: 4px;
+  right: 4px;
+  width: 50%;
+  max-width: 48px;
   height: auto;
   z-index: 2;
-  border: 1px solid #ccc;
-  background: rgba(0, 0, 0, 0.3);
-  border-radius: 4px;
+  opacity: 0.8;
+  pointer-events: none;
+}
+
+.kit-composite:hover .kit-weapon-overlay {
+  transform: scale(1.05);
+  transition: transform 0.2s ease-in-out;
 }


### PR DESCRIPTION
## Summary
- tweak overlay positioning for killstreak kit composite images
- add subtle hover zoom to overlay

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files static/style.css templates/item_card.html`
- `SKIP_VALIDATE=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687812e4d8108326b5bb20e68af99fd1