### PR TITLE
Tweak killstreak kit overlay CSS

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -647,17 +647,17 @@ footer {
 
 .kit-weapon-overlay {
   position: absolute;
-  bottom: 4px;
-  right: 4px;
+  bottom: 2px;
+  right: 2px;
   width: 50%;
   max-width: 48px;
   height: auto;
   z-index: 2;
   opacity: 0.8;
   pointer-events: none;
+  transition: transform 0.2s ease-in-out;
 }
 
 .kit-composite:hover .kit-weapon-overlay {
-  transform: scale(1.05);
-  transition: transform 0.2s ease-in-out;
+  transform: scale(1.08);
 }


### PR DESCRIPTION
## Summary
- adjust `.kit-weapon-overlay` so the weapon sprite sits closer to bottom-right
- keep opacity and pointer-events unchanged
- bump hover zoom effect slightly

## Testing
- `pre-commit run --files static/style.css`

------
https://chatgpt.com/codex/tasks/task_e_687815461f008326a086a2e3594d275e