### PR TITLE
Add crate integration to price map

### DIFF
--- a/tests/test_valuation_service.py
+++ b/tests/test_valuation_service.py
@@ -50,3 +50,33 @@ def test_killstreak_tier_lookup(monkeypatch):
     service = ValuationService(price_map=price_map)
     local_data.CURRENCIES = {"keys": {"price": {"value_raw": 50.0}}}
     assert service.format_price("Item", 6, True, killstreak_tier=2) == "2 Keys"
+
+
+def test_crate_case_prices(monkeypatch):
+    price_map = {
+        (
+            "Summer 2024 Cosmetic Case",
+            6,
+            True,
+            False,
+            0,
+            0,
+        ): {"value_raw": 0.22, "currency": "metal"},
+        (
+            "Mann Co. Supply Crate",
+            6,
+            True,
+            False,
+            0,
+            0,
+        ): {"value_raw": 0.33, "currency": "metal"},
+    }
+    local_data.ITEMS_BY_DEFINDEX = {
+        5959: {"item_name": "Summer 2024 Cosmetic Case"},
+        5022: {"item_name": "Mann Co. Supply Crate"},
+    }
+    local_data.CURRENCIES = {"keys": {"price": {"value_raw": 50.0}}}
+    service = ValuationService(price_map=price_map)
+
+    assert service.get_price(defindex=5959) == "0.22 ref"
+    assert service.get_price(name="Summer 2024 Cosmetic Case") == "0.22 ref"

--- a/utils/price_loader.py
+++ b/utils/price_loader.py
@@ -259,11 +259,14 @@ def build_price_map(
                     entry = entries[0] if isinstance(entries, list) else None
                     effect_entries = {0: entry} if isinstance(entry, dict) else {}
 
+                is_crate_case = (
+                    "crate" in base_name.lower() or "case" in base_name.lower()
+                )
                 for effect_key, entry in effect_entries.items():
                     if not isinstance(entry, dict):
                         continue
 
-                    value_raw = entry.get("value_raw")
+                    value_raw = entry.get("value_raw", entry.get("value"))
                     currency = entry.get("currency")
                     if value_raw is None or currency is None:
                         continue
@@ -273,12 +276,17 @@ def build_price_map(
                     except (TypeError, ValueError):
                         effect_id = 0
 
-                    mapping[
-                        (base_name, qid, craftable, is_australium, effect_id, ks_tier)
-                    ] = {
+                    info = {
                         "value_raw": float(value_raw),
                         "currency": str(currency),
                     }
+                    mapping[
+                        (base_name, qid, craftable, is_australium, effect_id, ks_tier)
+                    ] = info
+                    if is_crate_case and effect_id != 0:
+                        mapping[
+                            (base_name, qid, craftable, is_australium, 0, ks_tier)
+                        ] = info
     return mapping
 
 

--- a/utils/valuation_service.py
+++ b/utils/valuation_service.py
@@ -119,3 +119,35 @@ class ValuationService:
         if currencies is None:
             currencies = local_data.CURRENCIES
         return format_price(value, currencies)
+
+    def get_price(
+        self,
+        *,
+        defindex: int | None = None,
+        name: str | None = None,
+        quality: int = 6,
+        craftable: bool = True,
+        is_australium: bool = False,
+        effect_id: int | None = None,
+        killstreak_tier: int | None = None,
+        currencies: Dict[str, Any] | None = None,
+    ) -> str:
+        """Return formatted price string for ``name`` or ``defindex``."""
+        if name is None and defindex is not None:
+            schema_entry = local_data.ITEMS_BY_DEFINDEX.get(defindex)
+            name = (
+                schema_entry.get("item_name")
+                if isinstance(schema_entry, dict)
+                else None
+            )
+        if not name:
+            return ""
+        return self.format_price(
+            name,
+            quality,
+            craftable,
+            is_australium,
+            effect_id=effect_id,
+            killstreak_tier=killstreak_tier,
+            currencies=currencies,
+        )


### PR DESCRIPTION
## Summary
- remove standalone crate pricing script
- normalize crate/case entries when building price map
- expose `ValuationService.get_price` for lookups by defindex or name
- ensure crates/cases priced via new unit test

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files utils/price_loader.py utils/valuation_service.py tests/test_valuation_service.py`

------
https://chatgpt.com/codex/tasks/task_e_68781da4291883268c2c6de7a979887f