### PR TITLE
Fix pricing display for crates

### DIFF
--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -43,6 +43,9 @@
   {% else %}
     <div class="missing-icon"></div>
   {% endif %}
+  {% if item.price_str %}
+    <div class="item-price">{{ item.price_str }}</div>
+  {% endif %}
   {% set title_parts = [] %}
   {% if item.killstreak_name %}
     {% if item.killstreak_name == 'Killstreak' %}


### PR DESCRIPTION
## Summary
- always call valuation service when processing items
- surface price info as `price_str` and `price_raw`
- render item price inside `item_card.html`

## Testing
- `pre-commit run --files utils/inventory_processor.py templates/item_card.html templates/_user.html`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_687827486b808326bcf2a594d89feffd