### PR TITLE
Handle crate price by craftability

### DIFF
--- a/tests/test_valuation_service.py
+++ b/tests/test_valuation_service.py
@@ -70,6 +70,22 @@ def test_crate_case_prices(monkeypatch):
             0,
             0,
         ): {"value_raw": 0.33, "currency": "metal"},
+        (
+            "Summer 2024 Cosmetic Case",
+            6,
+            False,
+            False,
+            0,
+            0,
+        ): {"value_raw": 0.22, "currency": "metal"},
+        (
+            "Mann Co. Supply Crate",
+            6,
+            False,
+            False,
+            0,
+            0,
+        ): {"value_raw": 0.33, "currency": "metal"},
     }
     local_data.ITEMS_BY_DEFINDEX = {
         5959: {"item_name": "Summer 2024 Cosmetic Case"},
@@ -80,3 +96,9 @@ def test_crate_case_prices(monkeypatch):
 
     assert service.get_price(defindex=5959) == "0.22 ref"
     assert service.get_price(name="Summer 2024 Cosmetic Case") == "0.22 ref"
+    assert service.get_price(defindex=5959, craftable=False) == "0.22 ref"
+    assert (
+        service.get_price(name="Summer 2024 Cosmetic Case", craftable=False)
+        == "0.22 ref"
+    )
+    assert service.get_price(defindex=5022, craftable=False) == "0.33 ref"

--- a/utils/price_loader.py
+++ b/utils/price_loader.py
@@ -280,13 +280,58 @@ def build_price_map(
                         "value_raw": float(value_raw),
                         "currency": str(currency),
                     }
-                    mapping[
-                        (base_name, qid, craftable, is_australium, effect_id, ks_tier)
-                    ] = info
+                    key = (
+                        base_name,
+                        qid,
+                        craftable,
+                        is_australium,
+                        effect_id,
+                        ks_tier,
+                    )
+                    if key not in mapping:
+                        mapping[key] = info
+                        logger.debug("Added price entry %s", key)
                     if is_crate_case and effect_id != 0:
-                        mapping[
-                            (base_name, qid, craftable, is_australium, 0, ks_tier)
-                        ] = info
+                        zero_key = (
+                            base_name,
+                            qid,
+                            craftable,
+                            is_australium,
+                            0,
+                            ks_tier,
+                        )
+                        if zero_key not in mapping:
+                            mapping[zero_key] = info
+                            logger.debug("Added crate effect fallback %s", zero_key)
+                    if is_crate_case:
+                        alt_key = (
+                            base_name,
+                            qid,
+                            not craftable,
+                            is_australium,
+                            effect_id,
+                            ks_tier,
+                        )
+                        if alt_key not in mapping:
+                            mapping[alt_key] = info
+                            logger.debug(
+                                "Added crate craftability fallback %s", alt_key
+                            )
+                        if effect_id != 0:
+                            alt_zero_key = (
+                                base_name,
+                                qid,
+                                not craftable,
+                                is_australium,
+                                0,
+                                ks_tier,
+                            )
+                            if alt_zero_key not in mapping:
+                                mapping[alt_zero_key] = info
+                                logger.debug(
+                                    "Added crate craftability/effect fallback %s",
+                                    alt_zero_key,
+                                )
     return mapping
 
 


### PR DESCRIPTION
## Summary
- prevent duplicate overwrites when building price map
- map crate/case prices to both craftable and non-craftable variants
- test crate pricing across craftability

## Testing
- `pre-commit run --files utils/price_loader.py tests/test_price_loader.py tests/test_valuation_service.py`

------
https://chatgpt.com/codex/tasks/task_e_68782bc65bfc83268e19174b71fe10f3