### PR TITLE
Restrict stacking to currency items

### DIFF
--- a/app.py
+++ b/app.py
@@ -83,6 +83,9 @@ IGNORED_STACK_KEYS = {
     "inventory",
 }
 
+# Items eligible for quantity stacking (by defindex)
+STACKABLE_DEFINDEXES = {5000, 5001, 5002, 5021}
+
 
 def kill_process_on_port(port: int) -> None:
     """Terminate any process currently listening on ``port``."""
@@ -115,6 +118,18 @@ def stack_items(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
 
     for itm in items:
         if not isinstance(itm, dict):
+            continue
+
+        defindex_raw = itm.get("defindex")
+        try:
+            defindex = int(defindex_raw)
+        except (TypeError, ValueError):
+            defindex = None
+
+        if defindex not in STACKABLE_DEFINDEXES:
+            new_item = itm.copy()
+            new_item.setdefault("quantity", 1)
+            uniques.append(new_item)
             continue
 
         key_val = itm.get("stack_key", _sentinel)

--- a/tests/test_quantity_badge.py
+++ b/tests/test_quantity_badge.py
@@ -9,8 +9,14 @@ HTML = '{% include "_user.html" %}'
 def test_stack_items_collapses_duplicates():
     mod = importlib.import_module("app")
     items = [
-        {"name": "Key", "image_url": "", "quality_color": "#fff"},
-        {"name": "Key", "image_url": "", "quality_color": "#fff", "level": 10},
+        {"name": "Key", "defindex": 5021, "image_url": "", "quality_color": "#fff"},
+        {
+            "name": "Key",
+            "defindex": 5021,
+            "image_url": "",
+            "quality_color": "#fff",
+            "level": 10,
+        },
     ]
     result = mod.stack_items(items)
     assert len(result) == 1
@@ -38,8 +44,20 @@ def test_stack_items_ignores_ids(monkeypatch):
     mod = importlib.import_module("app")
     importlib.reload(mod)
     items = [
-        {"name": "Crate", "image_url": "", "quality_color": "#fff", "id": 1},
-        {"name": "Crate", "image_url": "", "quality_color": "#fff", "id": 2},
+        {
+            "name": "Key",
+            "defindex": 5021,
+            "image_url": "",
+            "quality_color": "#fff",
+            "id": 1,
+        },
+        {
+            "name": "Key",
+            "defindex": 5021,
+            "image_url": "",
+            "quality_color": "#fff",
+            "id": 2,
+        },
     ]
     result = mod.stack_items(items)
     assert len(result) == 1
@@ -49,8 +67,20 @@ def test_stack_items_ignores_ids(monkeypatch):
 def test_stack_items_respects_none_stack_key():
     mod = importlib.import_module("app")
     items = [
-        {"name": "Kit", "image_url": "", "quality_color": "#fff", "stack_key": None},
-        {"name": "Kit", "image_url": "", "quality_color": "#fff", "stack_key": None},
+        {
+            "name": "Key",
+            "defindex": 5021,
+            "image_url": "",
+            "quality_color": "#fff",
+            "stack_key": None,
+        },
+        {
+            "name": "Key",
+            "defindex": 5021,
+            "image_url": "",
+            "quality_color": "#fff",
+            "stack_key": None,
+        },
     ]
     result = mod.stack_items(items)
     assert len(result) == 2
@@ -76,7 +106,13 @@ def test_quantity_badge_rendered(monkeypatch):
     monkeypatch.setattr("utils.local_data.load_files", lambda *a, **k: ({}, {}))
     mod = importlib.import_module("app")
     importlib.reload(mod)
-    item = {"name": "Key", "image_url": "", "quality_color": "#fff", "quantity": 3}
+    item = {
+        "name": "Key",
+        "defindex": 5021,
+        "image_url": "",
+        "quality_color": "#fff",
+        "quantity": 3,
+    }
     user = {
         "steamid": "1",
         "profile": "",


### PR DESCRIPTION
## Summary
- stack only metal and keys
- update quantity tests for new behavior

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files app.py tests/test_quantity_badge.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878335d55748326bdc37cb844713749