### PR TITLE
Limit item stacking to TF2 currency items

### DIFF
--- a/tests/test_quantity_badge.py
+++ b/tests/test_quantity_badge.py
@@ -38,8 +38,8 @@ def test_stack_items_ignores_ids(monkeypatch):
     mod = importlib.import_module("app")
     importlib.reload(mod)
     items = [
-        {"name": "Crate", "image_url": "", "quality_color": "#fff", "id": 1},
-        {"name": "Crate", "image_url": "", "quality_color": "#fff", "id": 2},
+        {"name": "Key", "image_url": "", "quality_color": "#fff", "id": 1},
+        {"name": "Key", "image_url": "", "quality_color": "#fff", "id": 2},
     ]
     result = mod.stack_items(items)
     assert len(result) == 1


### PR DESCRIPTION
## Summary
- only stack keys and metal currencies
- adjust tests for restricted stacking

## Testing
- `pre-commit run --files app.py tests/test_quantity_badge.py`

------
https://chatgpt.com/codex/tasks/task_e_6878335d55748326bdc37cb844713749