### PR TITLE
Restore full stacking logic with unstackable exceptions

### DIFF
--- a/tests/test_quantity_badge.py
+++ b/tests/test_quantity_badge.py
@@ -46,11 +46,19 @@ def test_stack_items_ignores_ids(monkeypatch):
     assert result[0]["quantity"] == 2
 
 
-def test_stack_items_respects_none_stack_key():
+def test_stack_items_excludes_unstackable_names():
     mod = importlib.import_module("app")
     items = [
-        {"name": "Kit", "image_url": "", "quality_color": "#fff", "stack_key": None},
-        {"name": "Kit", "image_url": "", "quality_color": "#fff", "stack_key": None},
+        {
+            "name": "Professional Killstreak Kit",
+            "image_url": "",
+            "quality_color": "#fff",
+        },
+        {
+            "name": "Professional Killstreak Kit",
+            "image_url": "",
+            "quality_color": "#fff",
+        },
     ]
     result = mod.stack_items(items)
     assert len(result) == 2


### PR DESCRIPTION
## Summary
- add list of item names that should never stack
- ignore `stack_key` field and stack by all item attributes except those in `IGNORED_STACK_KEYS`
- don't stack Killstreak Kits or Fabricators
- update unit tests for new behavior

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files app.py tests/test_quantity_badge.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687843d17dfc8326b5644d19494701ee