### PR TITLE
Improve Killstreak Sheen Styling in Modal

### DIFF
--- a/static/modal.js
+++ b/static/modal.js
@@ -69,15 +69,6 @@
     const tierName = data.killstreak_tier ? tierMap[data.killstreak_tier] || data.killstreak_tier : null;
     const hasKsInfo = tierName || data.sheen || data.killstreak_effect;
     if (hasKsInfo) {
-      const color = data.sheen_color || '#f97316';
-      if (tierName) {
-        const badge =
-          '<span class="badge killstreak-badge" style="background-color:' +
-          esc(color) + ';">' +
-          esc(tierName) +
-          '</span>';
-        attrs.push('<div>' + badge + '</div>');
-      }
       let info = '<div class="killstreak-info">';
       if (tierName) {
         info += '<span class="killstreak-tier">' + esc(tierName) + '</span>';

--- a/static/modal.js
+++ b/static/modal.js
@@ -65,23 +65,35 @@
     const esc = escapeHtml;
     const attrs = [];
 
-    if (data.killstreak_tier) {
-      const tierMap = { 1: 'Killstreak', 2: 'Specialized', 3: 'Professional' };
-      const tierName = tierMap[data.killstreak_tier] || data.killstreak_tier;
+    const tierMap = { 1: 'Killstreak', 2: 'Specialized', 3: 'Professional' };
+    const tierName = data.killstreak_tier ? tierMap[data.killstreak_tier] || data.killstreak_tier : null;
+    const hasKsInfo = tierName || data.sheen || data.killstreak_effect;
+    if (hasKsInfo) {
       const color = data.sheen_color || '#f97316';
-      let ksHtml =
-        '<div><span class="badge ks-tier" style="background:' +
-        esc(color) + ';">' +
-        esc(tierName) +
-        '</span>';
+      if (tierName) {
+        const badge =
+          '<span class="badge killstreak-badge" style="background-color:' +
+          esc(color) + ';">' +
+          esc(tierName) +
+          '</span>';
+        attrs.push('<div>' + badge + '</div>');
+      }
+      let info = '<div class="killstreak-info">';
+      if (tierName) {
+        info += '<span class="killstreak-tier">' + esc(tierName) + '</span>';
+      }
       if (data.sheen) {
-        ksHtml += ' ' + esc(data.sheen);
+        info +=
+          '<span class="sheen"><span class="sheen-dot" style="background-color:' +
+          esc(data.sheen_color || '#ccc') + '"></span>' +
+          esc(data.sheen) +
+          '</span>';
       }
       if (data.killstreak_effect) {
-        ksHtml += ', <span class="ks-effect">' + esc(data.killstreak_effect) + '</span>';
+        info += '<span class="killstreaker">| ' + esc(data.killstreak_effect) + '</span>';
       }
-      ksHtml += '</div>';
-      attrs.push(ksHtml);
+      info += '</div>';
+      attrs.push(info);
     }
 
     if (data.unusual_effect) {

--- a/static/style.css
+++ b/static/style.css
@@ -409,6 +409,7 @@ button {
 .killstreak-info {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 8px;
   margin-top: 6px;
   font-size: 0.95rem;

--- a/static/style.css
+++ b/static/style.css
@@ -406,6 +406,39 @@ button {
   vertical-align: middle;
 }
 
+.killstreak-info {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 6px;
+  font-size: 0.95rem;
+}
+
+.killstreak-tier {
+  font-weight: bold;
+  text-transform: uppercase;
+  color: #fff;
+}
+
+.sheen {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-weight: bold;
+}
+
+.sheen-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.killstreaker {
+  font-style: italic;
+  color: #f28c38;
+}
+
 .tf2-hours {
   margin: 0.25rem 0 0;
   font-size: 0.9em;

--- a/templates/_modal.html
+++ b/templates/_modal.html
@@ -20,7 +20,7 @@
   {% if item.killstreak_tier %}
     <!-- Killstreak styling updated -->
     <div class="killstreak-info">
-      <span class="killstreak-tier">{{ item.killstreak_name or item.tier_name }}</span>
+      <span class="killstreak-tier">{{ item.tier_name }}</span>
       {% if item.sheen_name %}
         <span class="sheen">
           <span class="sheen-dot" style="background-color: {{ item.sheen_color or '#f97316' }}"></span>

--- a/templates/_modal.html
+++ b/templates/_modal.html
@@ -1,10 +1,4 @@
 <div class="modal-content">
-  {% if item.killstreak_name %}
-    <span class="badge killstreak-badge"
-          style="background-color: {{ item.sheen_color or '#f97316' }};">
-      {{ item.killstreak_name }}
-    </span>
-  {% endif %}
   {% if item.unusual_effect_name %}
     <p><strong>Unusual Effect:</strong>
       <span class="unusual-effect">{{ item.unusual_effect_name }}</span>

--- a/templates/_modal.html
+++ b/templates/_modal.html
@@ -13,10 +13,6 @@
   {% if item.craftable is not none %}
     <p><strong>{% if item.craftable %}Craftable{% else %}Uncraftable{% endif %}</strong></p>
   {% endif %}
-  {% if item.killstreak_tool_type %}
-    <h4>{{ item.tier_name or "Killstreak Item" }}</h4>
-    <p><strong>Weapon:</strong> {{ item.target_weapon_name or "Unknown" }}</p>
-  {% endif %}
   {% if item.killstreak_name or item.tier_name or item.sheen_name or item.killstreak_effect %}
     <!-- Killstreak styling updated -->
     <div class="killstreak-info">
@@ -33,7 +29,11 @@
         <span class="killstreaker">| {{ item.killstreak_effect }}</span>
       {% endif %}
     </div>
-    {% if item.killstreak_tool_type and item.fabricator_requirements %}
+  {% endif %}
+  {% if item.killstreak_tool_type %}
+    <h4>{{ item.tier_name or "Killstreak Item" }}</h4>
+    <p><strong>Weapon:</strong> {{ item.target_weapon_name or "Unknown" }}</p>
+    {% if item.fabricator_requirements %}
       <p><strong>Parts Required:</strong></p>
       <ul>
       {% for part in item.fabricator_requirements %}

--- a/templates/_modal.html
+++ b/templates/_modal.html
@@ -16,13 +16,22 @@
   {% if item.killstreak_tool_type %}
     <h4>{{ item.tier_name or "Killstreak Item" }}</h4>
     <p><strong>Weapon:</strong> {{ item.target_weapon_name or "Unknown" }}</p>
-    {% if item.sheen_name %}
-      <p><strong>Sheen:</strong> {{ item.sheen_name }}</p>
-    {% endif %}
-    {% if item.killstreak_effect %}
-      <p><strong>Killstreaker:</strong> {{ item.killstreak_effect }}</p>
-    {% endif %}
-    {% if item.fabricator_requirements %}
+  {% endif %}
+  {% if item.killstreak_tier %}
+    <!-- Killstreak styling updated -->
+    <div class="killstreak-info">
+      <span class="killstreak-tier">{{ item.killstreak_name or item.killstreak_tier }}</span>
+      {% if item.sheen_name %}
+        <span class="sheen">
+          <span class="sheen-dot" style="background-color: {{ item.sheen_hex }}"></span>
+          {{ item.sheen_name }}
+        </span>
+      {% endif %}
+      {% if item.killstreak_effect %}
+        <span class="killstreaker">| {{ item.killstreak_effect }}</span>
+      {% endif %}
+    </div>
+    {% if item.killstreak_tool_type and item.fabricator_requirements %}
       <p><strong>Parts Required:</strong></p>
       <ul>
       {% for part in item.fabricator_requirements %}

--- a/templates/_modal.html
+++ b/templates/_modal.html
@@ -20,10 +20,10 @@
   {% if item.killstreak_tier %}
     <!-- Killstreak styling updated -->
     <div class="killstreak-info">
-      <span class="killstreak-tier">{{ item.killstreak_name or item.killstreak_tier }}</span>
+      <span class="killstreak-tier">{{ item.killstreak_name or item.tier_name }}</span>
       {% if item.sheen_name %}
         <span class="sheen">
-          <span class="sheen-dot" style="background-color: {{ item.sheen_hex }}"></span>
+          <span class="sheen-dot" style="background-color: {{ item.sheen_color or '#f97316' }}"></span>
           {{ item.sheen_name }}
         </span>
       {% endif %}

--- a/templates/_modal.html
+++ b/templates/_modal.html
@@ -17,13 +17,15 @@
     <h4>{{ item.tier_name or "Killstreak Item" }}</h4>
     <p><strong>Weapon:</strong> {{ item.target_weapon_name or "Unknown" }}</p>
   {% endif %}
-  {% if item.killstreak_tier %}
+  {% if item.killstreak_name or item.tier_name or item.sheen_name or item.killstreak_effect %}
     <!-- Killstreak styling updated -->
     <div class="killstreak-info">
-      <span class="killstreak-tier">{{ item.tier_name }}</span>
+      {% if item.tier_name or item.killstreak_name %}
+        <span class="killstreak-tier">{{ item.tier_name or item.killstreak_name }}</span>
+      {% endif %}
       {% if item.sheen_name %}
         <span class="sheen">
-          <span class="sheen-dot" style="background-color: {{ item.sheen_color or '#f97316' }}"></span>
+          <span class="sheen-dot" style="background-color: {{ item.sheen_color or '#ccc' }}"></span>
           {{ item.sheen_name }}
         </span>
       {% endif %}

--- a/tests/test_item_modal_template.py
+++ b/tests/test_item_modal_template.py
@@ -30,15 +30,24 @@ def app(monkeypatch):
     return mod.app
 
 
-def test_killstreak_badge_color(app):
-    item = {"killstreak_name": "Professional Killstreak", "sheen_color": "#8847ff"}
+def test_killstreak_info_block(app):
+    item = {
+        "killstreak_name": "Professional Killstreak",
+        "sheen_name": "Hot Rod",
+        "sheen_color": "#8847ff",
+        "killstreak_effect": "Fire Horns",
+    }
     with app.app_context():
         html = render_template("_modal.html", item=item)
     soup = BeautifulSoup(html, "html.parser")
-    badge = soup.find("span", class_="killstreak-badge")
-    assert badge is not None
-    assert badge.text.strip() == "Professional Killstreak"
-    assert "#8847ff" in badge.get("style", "")
+    info = soup.find("div", class_="killstreak-info")
+    assert info is not None
+    assert "Professional Killstreak" in info.text
+    assert "Hot Rod" in info.text
+    assert "Fire Horns" in info.text
+    dot = info.find("span", class_="sheen-dot")
+    assert dot is not None
+    assert "#8847ff" in dot.get("style", "")
 
 
 def test_craftable_text_shown(app):


### PR DESCRIPTION
## Summary
- update modal template to better display killstreak details
- add CSS classes for new killstreak styling

## Testing
- `pre-commit run --files templates/_modal.html static/style.css`

------
https://chatgpt.com/codex/tasks/task_e_68784b7e8cbc8326888675395058c5ae