### PR TITLE
Fix Modal Styling and Title

### DIFF
--- a/static/modal.js
+++ b/static/modal.js
@@ -172,7 +172,14 @@
     const title = document.getElementById('modal-title');
     const custom = document.getElementById('modal-custom-name');
     const effectBox = document.getElementById('modal-effect');
-    if (title) title.textContent = data.composite_name || data.name || '';
+    if (title) {
+      let text = '';
+      if (data.killstreak_name) {
+        text += data.killstreak_name + ' ';
+      }
+      text += data.display_name || data.composite_name || data.name || '';
+      title.textContent = text.trim();
+    }
     if (custom) custom.textContent = data.custom_name || '';
     let effectText = '';
     if (data.unusual_effect) {

--- a/static/style.css
+++ b/static/style.css
@@ -444,8 +444,8 @@ button {
 }
 
 .killstreaker {
-  font-style: italic;
-  color: #f28c38;
+  font-style: normal;
+  color: #fff;
 }
 
 .tf2-hours {

--- a/templates/_modal.html
+++ b/templates/_modal.html
@@ -1,4 +1,5 @@
 <div class="modal-content">
+  <h3>{{ item.display_name }}</h3>
   {% if item.unusual_effect_name %}
     <p><strong>Unusual Effect:</strong>
       <span class="unusual-effect">{{ item.unusual_effect_name }}</span>


### PR DESCRIPTION
## Summary
- update killstreaker CSS style
- adjust modal header logic to exclude sheen
- ensure modal template title is plain display name

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files static/style.css static/modal.js templates/_modal.html`


------
https://chatgpt.com/codex/tasks/task_e_6878d8d73b6c832695c72c51e86914a1