### PR TITLE
Add australium icon on item displays

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -703,3 +703,11 @@ footer {
   transform: scale(1.05);
   transition: transform 0.2s ease-in-out;
 }
+
+.australium-icon {
+  width: 16px;
+  height: 16px;
+  filter: brightness(0) saturate(100%) invert(84%) sepia(43%) saturate(750%) hue-rotate(10deg) brightness(110%);
+  margin-left: 4px;
+  vertical-align: middle;
+}

--- a/templates/_modal.html
+++ b/templates/_modal.html
@@ -1,5 +1,10 @@
 <div class="modal-content">
-  <h3>{{ item.display_name }}</h3>
+  <h3>
+    {{ item.display_name }}
+    {% if item.is_australium %}
+      <img src="/static/images/logos/australium.png" class="australium-icon" alt="Australium">
+    {% endif %}
+  </h3>
   {% if item.unusual_effect_name %}
     <p><strong>Unusual Effect:</strong>
       <span class="unusual-effect">{{ item.unusual_effect_name }}</span>

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -3,6 +3,9 @@
      data-item='{{ item|tojson|safe }}'
      data-craftable="{{ 'true' if item.craftable else 'false' }}">
   <div class="item-badges">
+    {% if item.is_australium %}
+      <img src="/static/images/logos/australium.png" class="australium-icon" alt="Australium">
+    {% endif %}
     {% if item.paint_hex %}
       <span class="paint-dot" style="background-color: {{ item.paint_hex }};" title="Paint: {{ item.paint_name }}"></span>
     {% endif %}


### PR DESCRIPTION
## Summary
- show australium icon on item cards and modal headers when applicable
- style the new icon with a gold tint

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files templates/item_card.html templates/_modal.html static/style.css utils/inventory_processor.py`
- `SKIP_VALIDATE=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878e14f53648326ace0fab113510dc9