### PR TITLE
Use image for Pumpkin Bomb spell icon

### DIFF
--- a/static/modal.js
+++ b/static/modal.js
@@ -183,7 +183,8 @@
         }
       }
       text += data.display_name || data.composite_name || data.name || '';
-      title.textContent = text.trim();
+      text = text.replace(/IMG:[^\s]+/g, '').trim();
+      title.textContent = text;
     }
 
     if (custom) custom.textContent = data.custom_name || '';
@@ -202,8 +203,19 @@
     box.innerHTML = '';
     (badges || []).forEach(b => {
       const span = document.createElement('span');
-      span.textContent = b.icon;
+      span.className = 'badge';
       span.title = b.title || '';
+      if (typeof b.icon === 'string' && b.icon.startsWith('IMG:')) {
+        const path = b.icon.slice(4);
+        span.innerHTML =
+          '<img src="/static/images/logos/' +
+          path +
+          '" class="spell-icon" alt="' +
+          (b.title || 'Spell Icon') +
+          '">';
+      } else {
+        span.textContent = b.icon;
+      }
       span.addEventListener('click', () => {
         const sec = document.getElementById('modal-spells');
         if (sec) sec.scrollIntoView({ behavior: 'smooth' });

--- a/static/style.css
+++ b/static/style.css
@@ -719,3 +719,10 @@ footer {
   vertical-align: middle;
   filter: drop-shadow(0 0 2px #A156D6);
 }
+
+.badge img.spell-icon {
+  width: 16px;
+  height: 16px;
+  vertical-align: middle;
+  filter: drop-shadow(0 0 2px #A156D6);
+}

--- a/static/style.css
+++ b/static/style.css
@@ -711,3 +711,11 @@ footer {
   margin-left: 4px;
   vertical-align: middle;
 }
+
+.spell-icon {
+  width: 16px;
+  height: 16px;
+  margin-left: 2px;
+  vertical-align: middle;
+  filter: drop-shadow(0 0 2px #A156D6);
+}

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -13,7 +13,9 @@
         {% if badge.icon != '🎨' %}
           {% if badge.icon.startswith('IMG:') %}
             {% set path = badge.icon[4:] %}
-            <img src="/static/images/logos/{{ path }}" class="spell-icon" alt="{{ badge.title }} Spell">
+            <span class="badge" title="{{ badge.title }}">
+              <img src="/static/images/logos/{{ path }}" class="spell-icon" alt="{{ badge.title }}">
+            </span>
           {% elif badge.type == 'killstreak' %}
             <span class="badge" data-icon="{{ badge.icon }}" title="{{ badge.title }}">
               <span class="chevron-icon"

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -11,7 +11,10 @@
     {% endif %}
       {% for badge in item.badges %}
         {% if badge.icon != '🎨' %}
-          {% if badge.type == 'killstreak' %}
+          {% if badge.icon.startswith('IMG:') %}
+            {% set path = badge.icon[4:] %}
+            <img src="/static/images/logos/{{ path }}" class="spell-icon" alt="{{ badge.title }} Spell">
+          {% elif badge.type == 'killstreak' %}
             <span class="badge" data-icon="{{ badge.icon }}" title="{{ badge.title }}">
               <span class="chevron-icon"
                 {% if item.sheen_gradient_css %}

--- a/tests/test_spells.py
+++ b/tests/test_spells.py
@@ -19,3 +19,10 @@ def test_unknown_spell_value():
     badges, names = _extract_spells(asset)
     assert badges == []
     assert names == []
+
+
+def test_pumpkin_bomb_icon():
+    asset = {"attributes": [{"defindex": 1007, "value": 1}]}
+    badges, names = _extract_spells(asset)
+    assert "Pumpkin Bombs" in names
+    assert any(b["icon"] == "IMG:pb.png" for b in badges)

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -548,7 +548,7 @@ def _spell_icon(name: str) -> str:
     ):
         return "🎤"
     if "pumpkin" in lname or "gourd" in lname or "squash" in lname:
-        return "🎃"
+        return "IMG:pb.png"
     if "exorcism" in lname or "ghost" in lname:
         return "👻"
     if "fire" in lname:


### PR DESCRIPTION
## Summary
- show PNG icon for Pumpkin Bombs instead of 🎃 emoji
- render IMG: badges in HTML item card
- style new `.spell-icon` class
- test that Pumpkin Bomb spells use PNG

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files utils/inventory_processor.py templates/item_card.html static/style.css tests/test_spells.py`

------
https://chatgpt.com/codex/tasks/task_e_6878f15c91c48326b4b9ca3699f38914