### PR TITLE
Use image for Pumpkin Bomb spell icon

### DIFF
--- a/static/modal.js
+++ b/static/modal.js
@@ -183,7 +183,8 @@
         }
       }
       text += data.display_name || data.composite_name || data.name || '';
-      title.textContent = text.trim();
+      text = text.replace(/IMG:[^\s]+/g, '').trim();
+      title.textContent = text;
     }
 
     if (custom) custom.textContent = data.custom_name || '';
@@ -202,8 +203,20 @@
     box.innerHTML = '';
     (badges || []).forEach(b => {
       const span = document.createElement('span');
-      span.textContent = b.icon;
+      span.className = 'badge';
       span.title = b.title || '';
+      if (typeof b.icon === 'string' && b.icon.startsWith('IMG:')) {
+        const path = b.icon.slice(4);
+        span.dataset.type = 'image';
+        span.innerHTML =
+          '<img src="/static/images/logos/' +
+          path +
+          '" class="spell-icon" alt="' +
+          (b.title || 'Spell Icon') +
+          '">';
+      } else {
+        span.textContent = b.icon;
+      }
       span.addEventListener('click', () => {
         const sec = document.getElementById('modal-spells');
         if (sec) sec.scrollIntoView({ behavior: 'smooth' });

--- a/static/style.css
+++ b/static/style.css
@@ -298,10 +298,17 @@ button {
   right:2px;
   bottom:2px;
   display:flex;
-  gap:2px;
+  align-items:center;
+  gap:4px;
   pointer-events:none;
   font-size:14px;
   z-index:3;
+}
+
+#modal-badges{
+  display:flex;
+  align-items:center;
+  gap:4px;
 }
 .item-qty{
   position:absolute;
@@ -315,6 +322,12 @@ button {
   pointer-events:none;
   z-index:3;
 }
+.badge {
+  display:flex;
+  align-items:center;
+  justify-content:center;
+}
+
 .item-badges .badge{
   filter:drop-shadow(0 0 2px #0008);
 }
@@ -710,4 +723,28 @@ footer {
   filter: brightness(0) saturate(100%) invert(84%) sepia(43%) saturate(750%) hue-rotate(10deg) brightness(110%);
   margin-left: 4px;
   vertical-align: middle;
+}
+
+.spell-icon {
+  width: 24px;
+  height: 24px;
+  margin-left: 2px;
+  vertical-align: middle;
+  object-fit: contain;
+  filter: drop-shadow(0 0 2px #A156D6);
+  transition: transform 0.1s ease-in-out;
+}
+
+.badge img.spell-icon {
+  width: 24px;
+  height: 24px;
+  vertical-align: middle;
+  object-fit: contain;
+  transform-origin: center;
+  filter: drop-shadow(0 0 2px #A156D6);
+  transition: transform 0.1s ease-in-out;
+}
+
+.badge img.spell-icon:hover {
+  transform: scale(1.1);
 }

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -11,7 +11,12 @@
     {% endif %}
       {% for badge in item.badges %}
         {% if badge.icon != '🎨' %}
-          {% if badge.type == 'killstreak' %}
+          {% if badge.icon.startswith('IMG:') %}
+            {% set path = badge.icon[4:] %}
+            <span class="badge" data-type="image" title="{{ badge.title }}">
+              <img src="/static/images/logos/{{ path }}" class="spell-icon" alt="{{ badge.title }}">
+            </span>
+          {% elif badge.type == 'killstreak' %}
             <span class="badge" data-icon="{{ badge.icon }}" title="{{ badge.title }}">
               <span class="chevron-icon"
                 {% if item.sheen_gradient_css %}

--- a/tests/test_spells.py
+++ b/tests/test_spells.py
@@ -19,3 +19,10 @@ def test_unknown_spell_value():
     badges, names = _extract_spells(asset)
     assert badges == []
     assert names == []
+
+
+def test_pumpkin_bomb_icon():
+    asset = {"attributes": [{"defindex": 1007, "value": 1}]}
+    badges, names = _extract_spells(asset)
+    assert "Pumpkin Bombs" in names
+    assert any(b["icon"] == "IMG:pb.png" for b in badges)

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -513,7 +513,13 @@ def _compute_sheen_colors(sheen_id: int | None) -> list[str]:
 
 
 def _spell_icon(name: str) -> str:
-    """Return an emoji icon for the given spell name."""
+    """Return an icon identifier for the given spell name.
+
+    The returned string may be a literal emoji or a token of the form
+    ``"IMG:<filename>"`` which indicates a 24×24 PNG located under
+    ``static/images/logos``. New PNG assets should also be 24×24 and
+    optimized for size. Additional mappings can be appended here as needed.
+    """
 
     lname = name.lower()
     if "foot" in lname:
@@ -548,7 +554,7 @@ def _spell_icon(name: str) -> str:
     ):
         return "🎤"
     if "pumpkin" in lname or "gourd" in lname or "squash" in lname:
-        return "🎃"
+        return "IMG:pb.png"
     if "exorcism" in lname or "ghost" in lname:
         return "👻"
     if "fire" in lname:


### PR DESCRIPTION
## Summary
- show PNG icon for Pumpkin Bombs instead of 🎃 emoji
- render IMG: badges in HTML item card and modal
- style spell badges with 24×24 icons and spacing
- align badges inside flex containers for even layout

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files static/style.css static/modal.js templates/item_card.html utils/inventory_processor.py tests/test_spells.py`

------
https://chatgpt.com/codex/tasks/task_e_6878f15c91c48326b4b9ca3699f38914