### PR TITLE
Add voice badge icon

### DIFF
--- a/static/modal.js
+++ b/static/modal.js
@@ -202,6 +202,8 @@
     box.innerHTML = '';
     (badges || []).forEach(b => {
       const span = document.createElement('span');
+      span.className = 'badge';
+      span.dataset.icon = b.icon;
       span.textContent = b.icon;
       span.title = b.title || '';
       span.addEventListener('click', () => {

--- a/static/style.css
+++ b/static/style.css
@@ -345,6 +345,7 @@ button {
 .badge[data-icon="🖌"],
 .badge[data-icon="👣"],
 .badge[data-icon="🎤"],
+.badge[data-icon="🗣️"],
 .badge[data-icon="🔥"],
 .badge[data-icon="👻"],
 .badge[data-icon="🎃"]{

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -533,6 +533,8 @@ def _spell_icon(name: str) -> str:
         )
     ):
         return "🖌"
+    if "voices from below" in lname:
+        return "🗣️"
     if any(
         word in lname
         for word in (


### PR DESCRIPTION
## Summary
- show 🗣️ icon for Voices From Below spell
- style the new badge color
- display badges correctly in item modal

## Testing
- `pre-commit run --files static/modal.js static/style.css utils/inventory_processor.py`
- `python scripts/check_legacy.py`


------
https://chatgpt.com/codex/tasks/task_e_68793aa1b310832698c163b01fd12333