### PR TITLE
Add Pumpkin Bomb icon and integrate image rendering

### DIFF
--- a/static/modal.js
+++ b/static/modal.js
@@ -203,9 +203,14 @@
     (badges || []).forEach(b => {
       const span = document.createElement('span');
       span.className = 'badge';
-      span.dataset.icon = b.icon;
-      span.textContent = b.icon;
       span.title = b.title || '';
+      if (b.icon.startsWith('IMG:')) {
+        const path = b.icon.slice(4);
+        span.innerHTML = `<img src="/static/images/logos/${path}" class="spell-icon" alt="${b.title || 'Spell Icon'}">`;
+      } else {
+        span.dataset.icon = b.icon;
+        span.textContent = b.icon;
+      }
       span.addEventListener('click', () => {
         const sec = document.getElementById('modal-spells');
         if (sec) sec.scrollIntoView({ behavior: 'smooth' });

--- a/static/style.css
+++ b/static/style.css
@@ -298,7 +298,7 @@ button {
   right:2px;
   bottom:2px;
   display:flex;
-  gap:2px;
+  gap:4px;
   pointer-events:none;
   font-size:14px;
   z-index:3;
@@ -317,6 +317,18 @@ button {
 }
 .item-badges .badge{
   filter:drop-shadow(0 0 2px #0008);
+}
+
+.spell-icon {
+  width: 24px;
+  height: 24px;
+  filter: drop-shadow(0 0 2px #A156D6);
+  vertical-align: middle;
+  transition: transform 0.1s ease-in-out;
+}
+
+.badge img.spell-icon:hover {
+  transform: scale(1.1);
 }
 .badge[data-icon="⚔"]{
   color:#ff7e30;

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -11,7 +11,12 @@
     {% endif %}
       {% for badge in item.badges %}
         {% if badge.icon != '🎨' %}
-          {% if badge.type == 'killstreak' %}
+          {% if badge.icon.startswith('IMG:') %}
+            {% set path = badge.icon[4:] %}
+            <span class="badge" title="{{ badge.title }}">
+              <img src="/static/images/logos/{{ path }}" class="spell-icon" alt="{{ badge.title }}">
+            </span>
+          {% elif badge.type == 'killstreak' %}
             <span class="badge" data-icon="{{ badge.icon }}" title="{{ badge.title }}">
               <span class="chevron-icon"
                 {% if item.sheen_gradient_css %}

--- a/tests/test_spells.py
+++ b/tests/test_spells.py
@@ -19,3 +19,10 @@ def test_unknown_spell_value():
     badges, names = _extract_spells(asset)
     assert badges == []
     assert names == []
+
+
+def test_pumpkin_bomb_icon():
+    asset = {"attributes": [{"defindex": 1007, "value": 1}]}
+    badges, names = _extract_spells(asset)
+    assert "Pumpkin Bombs" in names
+    assert any(b["icon"] == "IMG:pb.png" for b in badges)

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -550,7 +550,7 @@ def _spell_icon(name: str) -> str:
     ):
         return "🎤"
     if "pumpkin" in lname or "gourd" in lname or "squash" in lname:
-        return "🎃"
+        return "IMG:pb.png"
     if "exorcism" in lname or "ghost" in lname:
         return "👻"
     if "fire" in lname:


### PR DESCRIPTION
## Summary
- use `pb.png` for pumpkin-related spells
- show image badges on item cards
- render image badges in modals
- add `.spell-icon` styling
- ensure new icon is tested

## Testing
- `pre-commit run --files static/modal.js static/style.css templates/item_card.html tests/test_spells.py utils/inventory_processor.py`


------
https://chatgpt.com/codex/tasks/task_e_68795dcbe5488326b107a495df83649e