### PR TITLE
Add strange border for elevated quality items

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -712,3 +712,20 @@ footer {
   margin-left: 4px;
   vertical-align: middle;
 }
+
+.item-card.elevated-strange {
+  position: relative;
+  box-shadow: 0 0 6px rgba(122, 65, 33, 0.7);
+  border-width: 3px;
+  animation: strangePulse 2s infinite ease-in-out;
+}
+
+@keyframes strangePulse {
+  0%,
+  100% {
+    box-shadow: 0 0 6px rgba(122, 65, 33, 0.7);
+  }
+  50% {
+    box-shadow: 0 0 12px rgba(122, 65, 33, 0.9);
+  }
+}

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -1,5 +1,6 @@
-<div class="item-card{% if item.untradable_hold %} trade-hold{% endif %}{% if item.uncraftable %} uncraftable{% endif %}"
-     style="--quality-color: {{ item.quality_color }}; border-color: {{ item.quality_color }};"
+<div class="item-card{% if item.untradable_hold %} trade-hold{% endif %}{% if item.uncraftable %} uncraftable{% endif %}{% if item.border_color and item.border_color != item.quality_color %} elevated-strange{% endif %}"
+     style="--quality-color: {{ item.quality_color }}; border-color: {{ item.border_color or item.quality_color }};"
+     {% if item.border_color and item.border_color != item.quality_color %}title="Has Strange tracking"{% endif %}
      data-item='{{ item|tojson|safe }}'
      data-craftable="{{ 'true' if item.craftable else 'false' }}">
   <div class="item-badges">
@@ -69,7 +70,7 @@
   {% endif %}
   {% set quality = item.quality %}
   {% if not item.is_australium %}
-    {% if item.strange or quality == 'Strange' %}
+    {% if quality == 'Strange' %}
       {% set _ = title_parts.append('Strange') %}
     {% elif quality and quality not in ('Unique', 'Normal', 'Decorated Weapon') %}
       {% if not (quality == 'Unusual' and item.unusual_effect_id) %}

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -776,6 +776,71 @@ def test_kill_eater_fields(monkeypatch):
     assert item["score_type"] == "Kills"
 
 
+def test_border_color_for_elevated_strange(monkeypatch):
+    data = {
+        "items": [
+            {
+                "defindex": 111,
+                "quality": 1,
+                "attributes": [
+                    {"defindex": 214, "value": 5},
+                ],
+            }
+        ]
+    }
+    ld.ITEMS_BY_DEFINDEX = {111: {"item_name": "Thing", "image_url": ""}}
+    ld.QUALITIES_BY_INDEX = {1: "Genuine", 11: "Strange"}
+    items = ip.enrich_inventory(data)
+    item = items[0]
+    assert item["quality"] == "Genuine"
+    assert item["strange_count"] == 5
+    assert item["border_color"] == ip.QUALITY_MAP[ip.STRANGE_QUALITY_ID][1]
+
+
+def test_border_color_for_strange_unusual(monkeypatch):
+    data = {
+        "items": [
+            {
+                "defindex": 222,
+                "quality": 5,
+                "attributes": [
+                    {"defindex": 214, "value": 3},
+                ],
+            }
+        ]
+    }
+    ld.ITEMS_BY_DEFINDEX = {222: {"item_name": "Oddity", "image_url": ""}}
+    ld.QUALITIES_BY_INDEX = {5: "Unusual", 11: "Strange"}
+    items = ip.enrich_inventory(data)
+    item = items[0]
+    assert item["quality"] == "Unusual"
+    assert item["strange_count"] == 3
+    assert item["border_color"] == ip.QUALITY_MAP[ip.STRANGE_QUALITY_ID][1]
+    assert item["quality_color"] == ip.QUALITY_MAP[5][1]
+
+
+def test_border_color_for_strange_collectors(monkeypatch):
+    data = {
+        "items": [
+            {
+                "defindex": 333,
+                "quality": 14,
+                "attributes": [
+                    {"defindex": 214, "value": 7},
+                ],
+            }
+        ]
+    }
+    ld.ITEMS_BY_DEFINDEX = {333: {"item_name": "Rarity", "image_url": ""}}
+    ld.QUALITIES_BY_INDEX = {14: "Collector's", 11: "Strange"}
+    items = ip.enrich_inventory(data)
+    item = items[0]
+    assert item["quality"] == "Collector's"
+    assert item["strange_count"] == 7
+    assert item["border_color"] == ip.QUALITY_MAP[ip.STRANGE_QUALITY_ID][1]
+    assert item["quality_color"] == ip.QUALITY_MAP[14][1]
+
+
 def test_plain_craft_weapon_filtered():
     data = {"items": [{"defindex": 10, "quality": 6}]}
     ld.ITEMS_BY_DEFINDEX = {10: {"item_name": "A", "craft_class": "weapon"}}

--- a/tests/test_user_template.py
+++ b/tests/test_user_template.py
@@ -138,8 +138,7 @@ def test_unusual_effect_rendered(app):
     title = soup.find("h2", class_="item-title")
     assert title is not None
     text = title.text.strip()
-    assert text.startswith("Strange Burning Flames Cap")
-    assert "Unusual" not in text
+    assert text == "Burning Flames Cap"
 
 
 def test_war_paint_tool_target_displayed(app):
@@ -252,6 +251,31 @@ def test_uncraftable_class_rendered(app):
     assert "uncraftable" in classes
 
 
+def test_elevated_strange_class_rendered(app):
+    context = {
+        "user": {
+            "items": [
+                {
+                    "name": "Gadget",
+                    "image_url": "",
+                    "quality_color": "#00ff00",
+                    "border_color": "#7a4121",
+                }
+            ]
+        }
+    }
+    with app.test_request_context():
+        app_module = importlib.import_module("app")
+        context["user"] = app_module.normalize_user_payload(context["user"])
+        html = render_template_string(HTML, **context)
+    soup = BeautifulSoup(html, "html.parser")
+    card = soup.find("div", class_="item-card")
+    assert card is not None
+    classes = card.get("class", [])
+    assert "elevated-strange" in classes
+    assert card.get("title") == "Has Strange tracking"
+
+
 def test_australium_name_omits_strange_prefix(app):
     context = {
         "user": {
@@ -276,7 +300,6 @@ def test_australium_name_omits_strange_prefix(app):
     title = soup.find("h2", class_="item-title")
     assert title is not None
     assert title.text.strip() == "Australium Scattergun"
-
 
 
 def test_professional_killstreak_australium_title(app):

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -118,6 +118,12 @@ QUALITY_MAP = {
     15: ("Decorated Weapon", "#949494"),
 }
 
+# Quality ID used for Strange items
+STRANGE_QUALITY_ID = 11
+
+# Qualities that shouldn't get a Strange border
+DEFAULT_QUALITIES = {"Strange", "Unique", "Normal"}
+
 # effect_id -> name mapping loaded from ``local_data``
 EFFECTS_MAP: Dict[int, str] = {
     int(k): v for k, v in getattr(local_data, "EFFECT_NAMES", {}).items()
@@ -1150,6 +1156,11 @@ def _process_item(
     strange_parts = _extract_strange_parts(asset)
     kill_eater_counts, score_types = _extract_kill_eater_info(asset)
 
+    if kill_eater_counts.get(1) is not None and q_name not in DEFAULT_QUALITIES:
+        border_color = QUALITY_MAP[STRANGE_QUALITY_ID][1]
+    else:
+        border_color = q_col
+
     ks_tool_info = _extract_killstreak_tool_info(asset)
     include_stack_key = False
     stack_key = None
@@ -1256,6 +1267,7 @@ def _process_item(
         "is_australium": bool(is_australium),
         "quality": q_name,
         "quality_color": q_col,
+        "border_color": border_color,
         "image_url": image_url,
         "item_type_name": schema_entry.get("item_type_name"),
         "item_name": schema_entry.get("name"),


### PR DESCRIPTION
## Summary
- compute `border_color` during inventory enrichment if an item has strange tracking with elevated quality
- show the new border color in item cards
- update title logic to not prepend 'Strange' for elevated quality items
- adjust tests for the new behavior and add coverage for border color
- use constants and add CSS class for elevated strange
- add glow effect CSS and tooltip for elevated strange items

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files templates/item_card.html static/style.css utils/inventory_processor.py tests/test_inventory_processor.py tests/test_user_template.py`
- `python scripts/check_legacy.py`


------
https://chatgpt.com/codex/tasks/task_e_687a072fd1ac8326a91d11fc35f2939c