### PR TITLE
Add StatTrak handling for decorated weapons

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -713,9 +713,29 @@ footer {
   vertical-align: middle;
 }
 
+.statclock-badge {
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  width: 16px;
+  height: 16px;
+  z-index: 3;
+  opacity: 0.95;
+  pointer-events: none;
+}
+
+@media (max-width: 480px) {
+  .statclock-badge {
+    width: 12px;
+    height: 12px;
+    top: 3px;
+    left: 3px;
+  }
+}
+
 .item-card.elevated-strange {
   position: relative;
-  box-shadow: 0 0 6px rgba(122, 65, 33, 0.7);
+  box-shadow: 0 0 6px rgba(122, 65, 33, 0.6);
   border-width: 3px;
   animation: strangePulse 2s infinite ease-in-out;
 }
@@ -723,9 +743,9 @@ footer {
 @keyframes strangePulse {
   0%,
   100% {
-    box-shadow: 0 0 6px rgba(122, 65, 33, 0.7);
+    box-shadow: 0 0 6px rgba(122, 65, 33, 0.6);
   }
   50% {
-    box-shadow: 0 0 12px rgba(122, 65, 33, 0.9);
+    box-shadow: 0 0 12px rgba(122, 65, 33, 1);
   }
 }

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -1,6 +1,6 @@
-<div class="item-card{% if item.untradable_hold %} trade-hold{% endif %}{% if item.uncraftable %} uncraftable{% endif %}{% if item.border_color and item.border_color != item.quality_color %} elevated-strange{% endif %}"
+<div class="item-card{% if item.untradable_hold %} trade-hold{% endif %}{% if item.uncraftable %} uncraftable{% endif %}{% if item.has_strange_tracking %} elevated-strange{% endif %}"
      style="--quality-color: {{ item.quality_color }}; border-color: {{ item.border_color or item.quality_color }};"
-     {% if item.border_color and item.border_color != item.quality_color %}title="Has Strange tracking"{% endif %}
+     {% if item.has_strange_tracking %}title="Has Strange tracking"{% endif %}
      data-item='{{ item|tojson|safe }}'
      data-craftable="{{ 'true' if item.craftable else 'false' }}">
   <div class="item-badges">
@@ -11,7 +11,7 @@
       <span class="paint-dot" style="background-color: {{ item.paint_hex }};" title="Paint: {{ item.paint_name }}"></span>
     {% endif %}
       {% for badge in item.badges %}
-        {% if badge.icon != '🎨' %}
+        {% if badge.type != 'statclock' and badge.icon != '🎨' %}
           {% if badge.type == 'killstreak' %}
             <span class="badge" data-icon="{{ badge.icon }}" title="{{ badge.title }}">
               <span class="chevron-icon"
@@ -30,6 +30,9 @@
   </div>
   {% if item.quantity and item.quantity > 1 %}
     <span class="item-qty">x{{ item.quantity }}</span>
+  {% endif %}
+  {% if item.statclock_badge %}
+    <img src="{{ item.statclock_badge }}" class="statclock-badge" alt="StatTrak™" title="StatTrak™ Active">
   {% endif %}
   {% if item.unusual_effect_id %}
     <img

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -1289,6 +1289,29 @@ def test_skin_attribute_order(monkeypatch):
     assert item["wear_float"] == 0.04
 
 
+def test_skin_with_statclock(monkeypatch):
+    data = {
+        "items": [
+            {
+                "defindex": 555,
+                "quality": 15,
+                "attributes": [{"defindex": 214, "value": 42}],
+            }
+        ]
+    }
+    ld.ITEMS_BY_DEFINDEX = {
+        555: {"item_name": "Cool Skin", "image_url": ""},
+        5813: {"image_url": "https://example.com/statclock.png"},
+    }
+    ld.QUALITIES_BY_INDEX = {15: "Decorated Weapon", 11: "Strange"}
+    items = ip.enrich_inventory(data)
+    item = items[0]
+    assert "(Strange)" in item["display_name"]
+    assert any(b["type"] == "statclock" for b in item["badges"])
+    assert item["has_strange_tracking"] is True
+    assert item["statclock_badge"] == "https://example.com/statclock.png"
+
+
 def test_extract_wear_attr_749(monkeypatch):
     ld.SCHEMA_ATTRIBUTES = {749: {"attribute_class": "texture_wear_default"}}
     asset = {"attributes": [{"defindex": 749, "float_value": 0.04}]}

--- a/tests/test_user_template.py
+++ b/tests/test_user_template.py
@@ -260,6 +260,7 @@ def test_elevated_strange_class_rendered(app):
                     "image_url": "",
                     "quality_color": "#00ff00",
                     "border_color": "#7a4121",
+                    "has_strange_tracking": True,
                 }
             ]
         }

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -1156,7 +1156,11 @@ def _process_item(
     strange_parts = _extract_strange_parts(asset)
     kill_eater_counts, score_types = _extract_kill_eater_info(asset)
 
-    if kill_eater_counts.get(1) is not None and q_name not in DEFAULT_QUALITIES:
+    has_strange_tracking = kill_eater_counts.get(1) is not None
+
+    if quality_id == 15:
+        border_color = q_col
+    elif has_strange_tracking and q_name not in DEFAULT_QUALITIES:
         border_color = QUALITY_MAP[STRANGE_QUALITY_ID][1]
     else:
         border_color = q_col
@@ -1257,6 +1261,24 @@ def _process_item(
     if warpaint_tool or (warpaintable and paintkit_id is not None):
         display_name = resolved_name
 
+    has_statclock = has_strange_tracking and quality_id == 15
+    stat_clock_img = None
+    if has_statclock:
+        if warpaint_tool:
+            display_name = f"{display_name} (StatTrak\u2122)"
+        else:
+            display_name = f"{display_name} (Strange)"
+        stat_clock_img = local_data.ITEMS_BY_DEFINDEX.get(5813, {}).get("image_url")
+        if stat_clock_img:
+            badges.insert(
+                0,
+                {
+                    "icon_url": stat_clock_img,
+                    "type": "statclock",
+                    "title": "StatTrak\u2122",
+                },
+            )
+
     item = {
         "id": asset.get("id"),
         "defindex": defindex,
@@ -1344,6 +1366,8 @@ def _process_item(
         "killstreak_effect": ks_effect,
         "spells": spells,
         "badges": badges,  # always present, may be empty
+        "has_strange_tracking": has_strange_tracking,
+        "statclock_badge": stat_clock_img,
         "strange_parts": strange_parts,
         "strange_count": kill_eater_counts.get(1),
         "score_type": (


### PR DESCRIPTION
## Summary
- support StatTrak/Strange for decorated weapon skins and warpaints
- show Stat Clock badge if kill tracker present
- preserve decorated border color but add glow with `elevated-strange`
- responsive badge styling and tooltip
- new fields `has_strange_tracking` and `statclock_badge`

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files static/style.css templates/item_card.html tests/test_inventory_processor.py utils/inventory_processor.py tests/test_user_template.py`

------
https://chatgpt.com/codex/tasks/task_e_687a16b1dda08326a345f7b391d8d7e1