### PR TITLE
Improve item card readability

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -231,7 +231,7 @@ button {
   align-items: center;
   justify-content: flex-start;
   width: 96px;
-  height: 112px;
+  height: 124px;
   padding: 4px;
   margin: 0;
   border: 3px solid var(--quality-color);
@@ -377,17 +377,23 @@ button {
   justify-content: center;
 }
 
-.item-title {
-  font-size: 11px;
-  text-align: center;
-  word-break: break-word;
+.item-name {
   color: #fff;
-  line-height: 1.2em;
+  text-shadow:
+    -1px -1px 0 #000,
+     1px -1px 0 #000,
+    -1px  1px 0 #000,
+     1px  1px 0 #000;
   display: -webkit-box;
   -webkit-box-orient: vertical;
-  -webkit-line-clamp: 3;
+  -webkit-line-clamp: 2;
   overflow: hidden;
-  max-height: 3.6em;
+  word-break: break-word;
+  white-space: normal;
+  text-align: center;
+  line-height: 1.2;
+  font-size: 11px;
+  max-height: 28px;
   position: relative;
   z-index: 3;
 }
@@ -728,6 +734,16 @@ footer {
     height: 12px;
     top: 3px;
     left: 3px;
+  }
+}
+
+@media (max-width: 480px) {
+  .item-card {
+    width: 88px;
+    height: 118px;
+  }
+  .item-name {
+    font-size: 10px;
   }
 }
 

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -98,5 +98,5 @@
     {% set base = 'Australium ' ~ base %}
   {% endif %}
   {% set _ = title_parts.append(base) %}
-  <h2 class="item-title">{{ title_parts | join(' ') }}</h2>
+  <div class="item-name">{{ title_parts | join(' ') }}</div>
 </div>

--- a/tests/test_user_template.py
+++ b/tests/test_user_template.py
@@ -135,7 +135,7 @@ def test_unusual_effect_rendered(app):
         context["user"] = app_module.normalize_user_payload(context["user"])
         html = render_template_string(HTML, **context)
     soup = BeautifulSoup(html, "html.parser")
-    title = soup.find("h2", class_="item-title")
+    title = soup.find("div", class_="item-name")
     assert title is not None
     text = title.text.strip()
     assert text == "Burning Flames Cap"
@@ -185,7 +185,7 @@ def test_decorated_quality_not_shown(app):
         context["user"] = app_module.normalize_user_payload(context["user"])
         html = render_template_string(HTML, **context)
     soup = BeautifulSoup(html, "html.parser")
-    title = soup.find("h2", class_="item-title")
+    title = soup.find("div", class_="item-name")
     assert title is not None
     assert title.text.strip() == "Warhawk Flamethrower"
 
@@ -298,7 +298,7 @@ def test_australium_name_omits_strange_prefix(app):
         context["user"] = app_module.normalize_user_payload(context["user"])
         html = render_template_string(HTML, **context)
     soup = BeautifulSoup(html, "html.parser")
-    title = soup.find("h2", class_="item-title")
+    title = soup.find("div", class_="item-name")
     assert title is not None
     assert title.text.strip() == "Australium Scattergun"
 
@@ -325,6 +325,6 @@ def test_professional_killstreak_australium_title(app):
         context["user"] = app_module.normalize_user_payload(context["user"])
         html = render_template_string(HTML, **context)
     soup = BeautifulSoup(html, "html.parser")
-    title = soup.find("h2", class_="item-title")
+    title = soup.find("div", class_="item-name")
     assert title is not None
     assert title.text.strip() == "Professional Killstreak Australium Scattergun"


### PR DESCRIPTION
## Summary
- tweak item-card layout
- apply text outline and wrap style for item names
- rename markup to `<div class="item-name">`
- update tests for new markup

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files static/style.css templates/item_card.html tests/test_user_template.py`

------
https://chatgpt.com/codex/tasks/task_e_687a4231fc588326945aa9ec857c352e