### PR TITLE
Fix item card layout and statclock badge

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -284,7 +284,7 @@ button {
   right:2px;
   bottom:2px;
   display:flex;
-  gap:2px;
+  gap:1px;
   pointer-events:none;
   font-size:14px;
   z-index:3;
@@ -305,16 +305,16 @@ button {
   filter:drop-shadow(0 0 2px #0008);
 }
 .badge-icon {
-  width: 16px;
-  height: 16px;
+  width: 14px;
+  height: 14px;
   filter: drop-shadow(0 0 2px #0008);
   pointer-events: none;
 }
 
 @media (max-width: 480px) {
   .badge-icon {
-    width: 12px;
-    height: 12px;
+    width: 11px;
+    height: 11px;
   }
 }
 .badge[data-icon="⚔"]{
@@ -386,14 +386,14 @@ button {
      1px  1px 0 #000;
   display: -webkit-box;
   -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
+  -webkit-line-clamp: 3;
   overflow: hidden;
   word-break: break-word;
   white-space: normal;
   text-align: center;
   line-height: 1.2;
   font-size: 11px;
-  max-height: 28px;
+  max-height: 42px;
   position: relative;
   z-index: 3;
 }
@@ -710,8 +710,8 @@ footer {
 }
 
 .australium-icon {
-  width: 16px;
-  height: 16px;
+  width: 14px;
+  height: 14px;
   filter: brightness(0) saturate(100%) invert(84%) sepia(43%) saturate(750%) hue-rotate(10deg) brightness(110%);
   margin-left: 4px;
   vertical-align: middle;
@@ -721,8 +721,8 @@ footer {
   position: absolute;
   top: 4px;
   left: 4px;
-  width: 16px;
-  height: 16px;
+  width: 14px;
+  height: 14px;
   z-index: 3;
   opacity: 0.95;
   pointer-events: none;
@@ -730,8 +730,8 @@ footer {
 
 @media (max-width: 480px) {
   .statclock-badge {
-    width: 12px;
-    height: 12px;
+    width: 11px;
+    height: 11px;
     top: 3px;
     left: 3px;
   }

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -1302,7 +1302,6 @@ def test_skin_with_statclock(monkeypatch):
     }
     ld.ITEMS_BY_DEFINDEX = {
         555: {"item_name": "Cool Skin", "image_url": ""},
-        5813: {"image_url": "https://example.com/statclock.png"},
     }
     ld.QUALITIES_BY_INDEX = {15: "Decorated Weapon", 11: "Strange"}
     items = ip.enrich_inventory(data)
@@ -1310,7 +1309,10 @@ def test_skin_with_statclock(monkeypatch):
     assert "(Strange)" in item["display_name"]
     assert any(b["type"] == "statclock" for b in item["badges"])
     assert item["has_strange_tracking"] is True
-    assert item["statclock_badge"] == "https://example.com/statclock.png"
+    assert item["statclock_badge"] == (
+        "http://media.steampowered.com/apps/440/icons/"
+        "stattrack.fea7f754b9ab447df18af382036d7d93ed97aca9.png"
+    )
 
 
 def test_decorated_border_color_with_statclock(monkeypatch):
@@ -1325,7 +1327,6 @@ def test_decorated_border_color_with_statclock(monkeypatch):
     }
     ld.ITEMS_BY_DEFINDEX = {
         888: {"item_name": "Fancy Decorated", "image_url": ""},
-        5813: {"image_url": "https://example.com/statclock.png"},
     }
     ld.QUALITIES_BY_INDEX = {15: "Decorated Weapon", 11: "Strange"}
     items = ip.enrich_inventory(data)

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -1267,7 +1267,10 @@ def _process_item(
             display_name = f"{display_name} (StatTrak\u2122)"
         else:
             display_name = f"{display_name} (Strange)"
-        stat_clock_img = local_data.ITEMS_BY_DEFINDEX.get(5813, {}).get("image_url")
+        stat_clock_img = (
+            "http://media.steampowered.com/apps/440/icons/"
+            "stattrack.fea7f754b9ab447df18af382036d7d93ed97aca9.png"
+        )
         if stat_clock_img:
             badges.insert(
                 0,


### PR DESCRIPTION
## Summary
- expand item name to three lines
- tighten badge layout and icon size
- swap statclock badge to official TF2 image
- update tests for new statclock badge URL

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files static/style.css utils/inventory_processor.py tests/test_inventory_processor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a483717fc8326a52856229ab32757