### PR TITLE
Improve item name layout CSS

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -378,25 +378,23 @@ button {
 }
 
 .item-name {
-  color: #fff;
-  text-shadow:
-    -1px -1px 0 #000,
-     1px -1px 0 #000,
-    -1px  1px 0 #000,
-     1px  1px 0 #000;
+  display: flex;
+  justify-content: center;
+  align-items: flex-end; /* Default: push text to bottom */
 
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 3;
-
-  text-align: center;
-  height: 42px;
+  height: 42px; /* Reserve space for 3 lines */
   overflow: hidden;
 
+  text-align: center;
   font-size: 11px;
   line-height: 1.2;
+  color: #fff;
   word-break: break-word;
   white-space: normal;
+
+  /* Outline for readability */
+  -webkit-text-stroke: 1px #000;
+  paint-order: stroke fill;
 
   position: relative;
   z-index: 3;

--- a/static/style.css
+++ b/static/style.css
@@ -378,23 +378,25 @@ button {
 }
 
 .item-name {
-  display: flex;
-  align-items: flex-end;
-  justify-content: center;
+  color: #fff;
+  text-shadow:
+    -1px -1px 0 #000,
+     1px -1px 0 #000,
+    -1px  1px 0 #000,
+     1px  1px 0 #000;
+
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
 
   text-align: center;
   height: 42px;
   overflow: hidden;
 
-  color: #fff;
   font-size: 11px;
   line-height: 1.2;
   word-break: break-word;
   white-space: normal;
-
-  -webkit-text-stroke: 1px #000;
-  text-stroke: 1px #000;
-  paint-order: stroke fill;
 
   position: relative;
   z-index: 3;

--- a/static/style.css
+++ b/static/style.css
@@ -378,22 +378,24 @@ button {
 }
 
 .item-name {
-  color: #fff;
-  text-shadow:
-    -1px -1px 0 #000,
-     1px -1px 0 #000,
-    -1px  1px 0 #000,
-     1px  1px 0 #000;
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 3;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+
+  text-align: center;
+  height: 42px;
   overflow: hidden;
+
+  color: #fff;
+  font-size: 11px;
+  line-height: 1.2;
   word-break: break-word;
   white-space: normal;
-  text-align: center;
-  line-height: 1.2;
-  font-size: 11px;
-  max-height: 42px;
+
+  -webkit-text-stroke: 1px #000;
+  text-stroke: 1px #000;
+  paint-order: stroke fill;
+
   position: relative;
   z-index: 3;
 }

--- a/static/utils.js
+++ b/static/utils.js
@@ -1,26 +1,23 @@
 /**
- * Adjust vertical alignment for item names inside cards.
- * If text uses fewer than 3 lines, push it down to align visually.
+ * Adjust item name alignment dynamically.
+ * If text uses fewer than 3 lines, keep bottom alignment.
+ * If it uses full height (3 lines), align to top for natural reading.
  */
-function adjustItemNamePadding() {
+function adjustItemNameAlignment() {
   const items = document.querySelectorAll('.item-name');
   items.forEach(el => {
-    const computedStyle = getComputedStyle(el);
-    const lineHeight = parseFloat(computedStyle.lineHeight);
-    const height = el.scrollHeight;
-    const lines = Math.round(height / lineHeight);
-    const maxLines = 3;
-    const reservedHeight = lineHeight * maxLines;
+    const computed = getComputedStyle(el);
+    const lineHeight = parseFloat(computed.lineHeight);
+    const reservedHeight = lineHeight * 3;
+    const textHeight = el.scrollHeight;
 
-    if (lines < maxLines) {
-      const extraSpace = reservedHeight - height;
-      el.style.paddingTop = `${extraSpace}px`;
+    if (textHeight >= reservedHeight) {
+      el.style.alignItems = 'flex-start'; // Long names go top
     } else {
-      el.style.paddingTop = '0';
+      el.style.alignItems = 'flex-end'; // Short names sit at bottom
     }
   });
 }
 
-// Run on page load and resize
-document.addEventListener('DOMContentLoaded', adjustItemNamePadding);
-window.addEventListener('resize', adjustItemNamePadding);
+document.addEventListener('DOMContentLoaded', adjustItemNameAlignment);
+window.addEventListener('resize', adjustItemNameAlignment);

--- a/static/utils.js
+++ b/static/utils.js
@@ -1,0 +1,26 @@
+/**
+ * Adjust vertical alignment for item names inside cards.
+ * If text uses fewer than 3 lines, push it down to align visually.
+ */
+function adjustItemNamePadding() {
+  const items = document.querySelectorAll('.item-name');
+  items.forEach(el => {
+    const computedStyle = getComputedStyle(el);
+    const lineHeight = parseFloat(computedStyle.lineHeight);
+    const height = el.scrollHeight;
+    const lines = Math.round(height / lineHeight);
+    const maxLines = 3;
+    const reservedHeight = lineHeight * maxLines;
+
+    if (lines < maxLines) {
+      const extraSpace = reservedHeight - height;
+      el.style.paddingTop = `${extraSpace}px`;
+    } else {
+      el.style.paddingTop = '0';
+    }
+  });
+}
+
+// Run on page load and resize
+document.addEventListener('DOMContentLoaded', adjustItemNamePadding);
+window.addEventListener('resize', adjustItemNamePadding);

--- a/templates/index.html
+++ b/templates/index.html
@@ -165,7 +165,7 @@
     <script src="{{ url_for('static', filename='modal.js') }}"></script>
     <script src="{{ url_for('static', filename='retry.js') }}"></script>
     <script src="{{ url_for('static', filename='submit.js') }}"></script>
-    <script src="/static/utils.js"></script>
+    <script src="{{ url_for('static', filename='utils.js') }}"></script>
     <script>
       function attachScrollButtons() {
         document.querySelectorAll('.inventory-scroll').forEach(wrapper => {

--- a/templates/index.html
+++ b/templates/index.html
@@ -165,6 +165,7 @@
     <script src="{{ url_for('static', filename='modal.js') }}"></script>
     <script src="{{ url_for('static', filename='retry.js') }}"></script>
     <script src="{{ url_for('static', filename='submit.js') }}"></script>
+    <script src="/static/utils.js"></script>
     <script>
       function attachScrollButtons() {
         document.querySelectorAll('.inventory-scroll').forEach(wrapper => {


### PR DESCRIPTION
## Summary
- adjust `.item-name` styling for better readability

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files static/style.css`
- `STEAM_API_KEY=test pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a515d87cc832690715262af55098e