### PR TITLE
Fix item name outline readability

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -379,11 +379,8 @@ button {
 
 .item-name {
   color: #fff;
-  text-shadow:
-    -1px -1px 0 #000,
-     1px -1px 0 #000,
-    -1px  1px 0 #000,
-     1px  1px 0 #000;
+  -webkit-text-stroke: 1px #000; /* Clean outline */
+  paint-order: stroke fill;
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 3;


### PR DESCRIPTION
## Summary
- update item name CSS to use `-webkit-text-stroke` for a consistent outline

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files static/style.css`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a629aa3348326a7ab9ea4d139cfd5