### PR TITLE
Enable real-time progress updates

### DIFF
--- a/app.py
+++ b/app.py
@@ -450,9 +450,18 @@ async def handle_start_fetch(sid: str, data: Dict[str, Any]) -> None:
         await fetch_missing_cache_files()
         local_data.load_files(auto_refetch=False)
 
+    processed = 0
     async for item in ip.process_inventory_streaming(raw):
         item["steamid"] = steamid64
         await sio.emit("item", item, to=sid, namespace="/inventory")
+        processed += 1
+        await sio.emit(
+            "progress",
+            {"steamid": steamid64, "processed": processed, "total": total},
+            to=sid,
+            namespace="/inventory",
+        )
+        await sio.sleep(0)
 
     await sio.emit(
         "done", {"steamid": steamid64, "status": status}, to=sid, namespace="/inventory"

--- a/static/style.css
+++ b/static/style.css
@@ -1,9 +1,10 @@
 body {
     background-color: #121212;
-    color: #e0e0e0;
-    font-family: "Inter", "Segoe UI", "Helvetica Neue", sans-serif;
+    color: #f5f5f5;
+    font-family: "Inter", "Segoe UI", Roboto, Arial, sans-serif;
     margin: 2em;
-    line-height: 1.5;
+    line-height: 1.6;
+    font-size: 16px;
 }
 
 input,
@@ -642,6 +643,17 @@ html, body {
   transform: scale(1);
 }
 
+.fade-in-item {
+  opacity: 0;
+  transform: scale(0.95);
+  transition: opacity 0.4s ease, transform 0.3s ease;
+}
+
+.fade-in-item.show {
+  opacity: 1;
+  transform: scale(1);
+}
+
 footer {
   padding: 1rem;
   text-align: center;
@@ -762,17 +774,11 @@ footer {
 .user-progress {
   margin-top: 6px;
   width: 90%;
-  height: 10px;
+  height: 12px;
   background: #333;
   border-radius: 5px;
   position: relative;
   overflow: hidden;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 11px;
-  color: #ccc;
-  transition: opacity 0.6s ease;
 }
 
 .user-progress.fade-out {
@@ -780,20 +786,23 @@ footer {
 }
 
 .progress-inner {
-  position: absolute;
-  top: 0;
-  left: 0;
+  position: relative;
+  background: linear-gradient(90deg, #4caf50, #8bc34a);
   height: 100%;
   width: 0%;
-  background: linear-gradient(90deg, #4caf50, #8bc34a);
-  transition: width 0.25s ease;
+  color: #fff;
+  font-size: 11px;
+  text-align: center;
+  line-height: 10px;
+  transition: width 0.3s ease;
 }
 
-.progress-label {
-  position: relative;
-  z-index: 2;
+.eta-label {
   font-size: 10px;
-  color: white;
+  color: #ccc;
+  display: block;
+  margin-top: 2px;
+  text-align: center;
 }
 
 .sort-value-btn {

--- a/static/submit.js
+++ b/static/submit.js
@@ -11,6 +11,17 @@ function createPlaceholder(id) {
   spinner.className = 'loading-spinner';
   spinner.setAttribute('aria-label', 'Loading');
   ph.appendChild(spinner);
+  const bar = document.createElement('div');
+  bar.className = 'user-progress';
+  const inner = document.createElement('div');
+  inner.className = 'progress-inner';
+  inner.id = 'progress-' + id;
+  bar.appendChild(inner);
+  const eta = document.createElement('span');
+  eta.className = 'eta-label';
+  eta.id = 'eta-' + id;
+  bar.appendChild(eta);
+  ph.appendChild(bar);
   return ph;
 }
 
@@ -70,10 +81,9 @@ function extractSteamIds(text) {
 }
 
 function handleSubmit(e) {
-  e.preventDefault();
+  if (e && e.preventDefault) e.preventDefault();
   const container = document.getElementById('user-container');
   if (!container) return;
-  container.innerHTML = '';
   const text = document.getElementById('steamids').value || '';
   const ids = extractSteamIds(text);
   ids.forEach(id => {
@@ -92,8 +102,8 @@ function handleSubmit(e) {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-  const form = document.querySelector('form.input-form');
-  if (form) {
-    form.addEventListener('submit', handleSubmit);
+  const btn = document.getElementById('check-inventory-btn');
+  if (btn) {
+    btn.addEventListener('click', handleSubmit);
   }
 });

--- a/templates/_user.html
+++ b/templates/_user.html
@@ -64,4 +64,8 @@
       </button>
     </div>
   </div>
+  <div class="user-progress">
+    <div class="progress-inner" id="progress-{{ user.steamid }}"></div>
+    <span class="eta-label" id="eta-{{ user.steamid }}"></span>
+  </div>
 </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -96,17 +96,17 @@
             </ul>
         {% endif %}
     {% endwith %}
-    <form method="post" class="input-form" id="scan-form">
+    <div class="input-form">
         <label for="steamids" class="visually-hidden">Steam IDs</label>
         <div class="input-wrapper">
             <i class="fa-brands fa-steam input-steam-icon"></i>
-            <textarea id="steamids" name="steamids" placeholder="Enter SteamID64, SteamID2, or SteamID3…">{{ steamids|default('') }}</textarea>
+            <textarea id="steamids" placeholder="Enter Steam IDs..." rows="4"></textarea>
         </div>
         <div class="form-actions">
-            <button type="submit" class="primary-btn action-button"><i class="fa-solid fa-magnifying-glass"></i> Check Inventories</button>
+            <button id="check-inventory-btn" type="button" class="primary-btn action-button"><i class="fa-solid fa-magnifying-glass"></i> Check Inventory</button>
             <button id="refresh-failed-btn" type="button" disabled class="refresh-btn action-button"><i class="fa-solid fa-arrows-rotate"></i> Refresh Failed</button>
         </div>
-    </form>
+    </div>
 
     <div id="results" class="fade-in">
         <div id="user-container">

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, List, Tuple
 from collections.abc import AsyncGenerator
+import asyncio
 import logging
 import re
 from html import unescape
@@ -1522,7 +1523,7 @@ async def process_inventory_streaming(
         return
 
     for asset in items_raw:
-        item = _process_item(asset, valuation_service)
+        item = await asyncio.to_thread(_process_item, asset, valuation_service)
         if not item:
             continue
 


### PR DESCRIPTION
## Summary
- emit per-item progress from `handle_start_fetch`
- refactor input form to use a button and textarea
- add built-in progress bars for each user card
- update styles for improved readability
- listen for `progress` events client-side
- show ETA and preserve previous results
- add fade-in animations for streamed items

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files static/socket.js static/style.css static/submit.js templates/_user.html`

------
https://chatgpt.com/codex/tasks/task_e_687ac97e0cf48326846354a9a5e2e611