### PR TITLE
Fix streaming updates

### DIFF
--- a/app.py
+++ b/app.py
@@ -74,6 +74,8 @@ else:
 # Socket.IO runs in ASGI mode with Quart.
 sio = socketio.AsyncServer(async_mode="asgi", cors_allowed_origins="*")
 socketio = socketio.ASGIApp(sio, other_asgi_app=app)
+# Exported ASGI application used by run.py
+asgi_app = socketio
 
 MAX_MERGE_MS = 0
 local_data.load_files(auto_refetch=True, verbose=ARGS.verbose)
@@ -454,16 +456,15 @@ async def handle_start_fetch(sid: str, data: Dict[str, Any]) -> None:
     async for item in ip.process_inventory_streaming(raw):
         item["steamid"] = steamid64
         await sio.emit("item", item, to=sid, namespace="/inventory")
+        await asyncio.sleep(0)
         processed += 1
-        # Emit progress every item
         await sio.emit(
             "progress",
             {"steamid": steamid64, "processed": processed, "total": total},
             to=sid,
             namespace="/inventory",
         )
-        # Yield to event loop for real-time effect
-        await sio.sleep(0)
+        await asyncio.sleep(0)
 
     await sio.emit(
         "done", {"steamid": steamid64, "status": status}, to=sid, namespace="/inventory"
@@ -583,6 +584,6 @@ if __name__ == "__main__":
         config = Config()
         config.bind = [f"0.0.0.0:{port}"]
         config.use_reloader = not TEST_MODE
-        await serve(socketio, config)
+        await serve(asgi_app, config)
 
     asyncio.run(_main())

--- a/run.py
+++ b/run.py
@@ -7,7 +7,8 @@ from hypercorn.config import Config
 
 # Import the Socket.IO ASGI app from app.py. Rename locally to avoid
 # confusion with the `socketio` package which is also used.
-from app import socketio as asgi_app, kill_process_on_port, _setup_test_mode, ARGS
+# Import the exported ASGI application directly from app.py
+from app import asgi_app, kill_process_on_port, _setup_test_mode, ARGS
 from utils.cache_manager import (
     fetch_missing_cache_files,
     COLOR_YELLOW,

--- a/static/socket.js
+++ b/static/socket.js
@@ -11,7 +11,9 @@
     socket = io('/inventory', { transports: ['websocket'] });
     window.inventorySocket = socket;
 
-    socket.on('connect', () => console.log('✅ Socket.IO connected'));
+    socket.on('connect', () => {
+      console.log('✅ Socket.IO connected via', socket.io.engine.transport.name);
+    });
     socket.on('connect_error', err => console.error('❌ Socket.IO error:', err));
 
     registerSocketEvents(socket);
@@ -245,12 +247,12 @@
       const pct = Math.min((data.processed / data.total) * 100, 100);
       p.bar.style.width = pct + '%';
       // force reflow so transition animates
-      // eslint-disable-next-line no-unused-expressions
-      p.bar.offsetWidth;
+      void p.bar.offsetWidth;
       p.bar.textContent = `${data.processed}/${data.total}`;
     });
 
     s.on('item', data => {
+    console.debug('📦 item', data.market_hash_name || data.name || data.defindex);
     const container = document.querySelector(`#user-${data.steamid} .inventory-container`);
     if (!container) return;
     const frag = document.createDocumentFragment();

--- a/static/style.css
+++ b/static/style.css
@@ -393,7 +393,7 @@ button {
   justify-content: center;
 }
 
-.item-name {
+.user-card .item-name {
   color: #000 !important; /* Force black font */
   background: none !important; /* Remove background */
   -webkit-text-stroke: 0 !important; /* Remove text stroke */
@@ -767,7 +767,7 @@ footer {
     width: 88px;
     height: 118px;
   }
-  .item-name {
+  .user-card .item-name {
     font-size: 10px;
   }
 }
@@ -846,7 +846,7 @@ footer {
     padding: 6px;
   }
 
-  .item-name {
+  .user-card .item-name {
     font-size: 13px;
     line-height: 1.3;
     font-weight: 500;


### PR DESCRIPTION
## Summary
- expose `asgi_app` for running server
- yield after each item so Socket.IO can flush events
- fix CSS rule for item name color
- force progress bar reflow when updating width
- import `asgi_app` in run.py
- log active transport and each streamed item

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files run.py app.py static/style.css static/socket.js utils/inventory_processor.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687c07a0b60c8326910ca949e918e4ba