### PR TITLE
Improve inventory streaming responsiveness

### DIFF
--- a/app.py
+++ b/app.py
@@ -500,6 +500,7 @@ async def stream_inventory(sid: str, steamid64: int) -> None:
 
             if len(batch) >= batch_size:
                 emit_start = time.monotonic()
+                print(f"Emitting batch: {len(batch)} items for {steamid64}")
                 await sio.emit(
                     "items_batch",
                     {"steamid": steamid64, "items": batch},
@@ -557,6 +558,7 @@ async def stream_inventory(sid: str, steamid64: int) -> None:
                 return
 
         if batch:
+            print(f"Emitting batch: {len(batch)} items for {steamid64}")
             await sio.emit(
                 "items_batch",
                 {"steamid": steamid64, "items": batch},

--- a/app.py
+++ b/app.py
@@ -506,6 +506,7 @@ async def stream_inventory(sid: str, steamid64: int) -> None:
                     to=sid,
                     namespace="/inventory",
                 )
+                await sio.sleep(0)
                 batch.clear()
 
                 eta = int(
@@ -527,6 +528,9 @@ async def stream_inventory(sid: str, steamid64: int) -> None:
                     },
                     to=sid,
                     namespace="/inventory",
+                )
+                print(
+                    f"\U0001f4e4 Emitted batch: processed={processed}/{total}, ETA={eta}s"
                 )
                 await sio.sleep(0)
 

--- a/static/socket.js
+++ b/static/socket.js
@@ -37,6 +37,7 @@
     }
     if (window.refreshLazyLoad) window.refreshLazyLoad();
     const frameTime = performance.now() - start;
+    console.log(`Processed batch of ${batch.length}, remaining: ${itemQueue.length}`);
     if (frameTime < 10 && domBatchSize < 100) {
       domBatchSize += 5;
       console.debug('⚡ DOM batch ->', domBatchSize);
@@ -52,6 +53,7 @@
 
   function enqueueItem(container, el, steamid) {
     itemQueue.push({ container, el, steamid: String(steamid) });
+    console.log('Queue length after enqueue:', itemQueue.length);
     if (!queueHandle) {
       queueHandle = scheduler.run(processQueue);
     }
@@ -422,8 +424,13 @@
       const container = document.querySelector(
         `#user-${data.steamid} .inventory-container`
       );
-      if (!container) return;
+      if (!container) {
+        console.error('Container not found for', data.steamid);
+        return;
+      }
       const batch = data.items || [];
+      console.log(`📦 Received ${batch.length} items for ${data.steamid}`);
+      if (batch.length) console.log('Sample item:', batch[0]);
       batch.forEach(item => {
         const el = createItemElement(item);
         enqueueItem(container, el, data.steamid);

--- a/static/socket.js
+++ b/static/socket.js
@@ -438,6 +438,7 @@
       console.debug(
         `📦 Received batch of ${batch.length}, remaining approx: ${itemQueue.length}`
       );
+      if (window.DEBUG_FORCE_RENDER) drainQueue();
     });
 
     s.on('done', data => {
@@ -566,4 +567,8 @@
       queueHandle = null;
     }
   };
+
+  window._debugQueue = itemQueue;
+  window._debugProcessQueue = processQueue;
+  window.DEBUG_FORCE_RENDER = false;
 })();

--- a/static/socket.js
+++ b/static/socket.js
@@ -413,7 +413,9 @@
           p.eta.textContent = '';
         }
       }
-      console.debug('ETA', data.eta);
+      console.debug(
+        `Progress: ${data.processed}/${data.total}, ETA: ${data.eta}s`
+      );
     });
 
     s.on('items_batch', data => {
@@ -426,7 +428,9 @@
         const el = createItemElement(item);
         enqueueItem(container, el, data.steamid);
       });
-      console.debug('📦 batch', batch.length, 'remaining:', itemQueue.length);
+      console.debug(
+        `📦 Received batch of ${batch.length}, remaining approx: ${itemQueue.length}`
+      );
     });
 
     s.on('done', data => {

--- a/static/socket.js
+++ b/static/socket.js
@@ -1,7 +1,81 @@
 
+
 (function () {
   const progressMap = new Map(); // steamid -> { el, bar }
+  const itemQueue = [];
+  let queueHandle = null;
+  let domBatchSize = window.innerWidth > 1024 ? 30 : 10;
+  let lastFrame = performance.now();
   let socket;
+
+  function processQueue() {
+    queueHandle = null;
+    if (!itemQueue.length) return;
+    const start = performance.now();
+    const batch = itemQueue.splice(0, domBatchSize);
+    const fragMap = new Map();
+    batch.forEach(({ container, el }) => {
+      let frag = fragMap.get(container);
+      if (!frag) {
+        frag = document.createDocumentFragment();
+        fragMap.set(container, frag);
+      }
+      frag.appendChild(el);
+    });
+    fragMap.forEach((frag, container) => {
+      container.appendChild(frag);
+      if (frag.firstChild) void frag.firstChild.offsetHeight;
+    });
+    if (window.attachItemModal) {
+      window.attachItemModal();
+    } else if (window.attachHandlers) {
+      window.attachHandlers();
+    }
+    if (window.refreshLazyLoad) window.refreshLazyLoad();
+    const frameTime = performance.now() - start;
+    if (frameTime < 10 && domBatchSize < 100) {
+      domBatchSize += 5;
+      console.debug('⚡ DOM batch ->', domBatchSize);
+    } else if (frameTime > 20 && domBatchSize > 10) {
+      domBatchSize = Math.max(10, domBatchSize - 5);
+      console.debug('🐢 DOM batch ->', domBatchSize);
+    }
+    if (itemQueue.length) {
+      lastFrame = performance.now();
+      queueHandle = requestAnimationFrame(processQueue);
+    }
+  }
+
+  function enqueueItem(container, el, steamid) {
+    itemQueue.push({ container, el, steamid: String(steamid) });
+    if (!queueHandle) {
+      const cb = window.requestIdleCallback || requestAnimationFrame;
+      queueHandle = cb(processQueue);
+    }
+  }
+
+  function removeQueued(id) {
+    const sid = String(id);
+    for (let i = itemQueue.length - 1; i >= 0; i--) {
+      if (itemQueue[i].steamid === sid) {
+        itemQueue.splice(i, 1);
+      }
+    }
+    if (!itemQueue.length && queueHandle) {
+      cancelAnimationFrame(queueHandle);
+      queueHandle = null;
+    }
+  }
+
+  function drainQueue() {
+    while (itemQueue.length) {
+      processQueue();
+    }
+    if (queueHandle) {
+      cancelAnimationFrame(queueHandle);
+      queueHandle = null;
+    }
+  }
 
   function initSocket(retry = 0) {
     if (!window.io) {
@@ -27,18 +101,39 @@
     if (!card) return;
     let barWrap = card.querySelector('.user-progress');
     let inner;
+    let eta;
     if (!barWrap) {
       barWrap = document.createElement('div');
       barWrap.className = 'user-progress';
       inner = document.createElement('div');
       inner.className = 'progress-inner';
       inner.id = 'progress-' + steamid;
+      eta = document.createElement('span');
+      eta.className = 'eta-label';
+      eta.id = 'eta-' + steamid;
       barWrap.appendChild(inner);
+      barWrap.appendChild(eta);
       card.appendChild(barWrap);
     } else {
       inner = barWrap.querySelector('.progress-inner');
+      eta = barWrap.querySelector('.eta-label');
+      barWrap.classList.remove('fade-out');
     }
-    progressMap.set(String(steamid), { el: barWrap, bar: inner });
+    inner.style.width = '0%';
+    // reset transition start point
+    void inner.offsetWidth;
+    progressMap.set(String(steamid), { el: barWrap, bar: inner, eta });
+  }
+
+  function clearExisting(steamid) {
+    const card = document.getElementById('user-' + steamid);
+    if (!card) return;
+    const container = card.querySelector('.inventory-container');
+    if (container) container.innerHTML = '';
+    const bar = card.querySelector('.user-progress');
+    if (bar) bar.remove();
+    progressMap.delete(String(steamid));
+    removeQueued(steamid);
   }
 
   function insertUserPlaceholder(id) {
@@ -50,7 +145,9 @@
     div.innerHTML =
       '<div class="card-header">' +
       id +
-      '</div><div class="card-body"><div class="inventory-container"></div></div>';
+      '<button class="cancel-btn" type="button" onclick="cancelInventoryFetch(' +
+      id +
+      ')">&#x2716;</button></div><div class="card-body"><div class="inventory-container"></div></div>';
     const spinner = document.createElement('div');
     spinner.className = 'loading-spinner';
     div.appendChild(spinner);
@@ -231,6 +328,8 @@
     }
     if (p) {
       p.bar.style.width = '0%';
+      // force reflow to restart transition
+      void p.bar.offsetWidth;
       p.bar.textContent = `0/${data.total || 0}`;
     }
   });
@@ -245,31 +344,30 @@
         if (spin) spin.remove();
       }
       const pct = Math.min((data.processed / data.total) * 100, 100);
-      p.bar.style.width = pct + '%';
-      // force reflow so transition animates
       void p.bar.offsetWidth;
+      p.bar.style.width = pct + '%';
       p.bar.textContent = `${data.processed}/${data.total}`;
+      if (p.eta) {
+        if (data.eta && data.eta > 0) {
+          p.eta.textContent = `~${data.eta}s remaining`;
+        } else {
+          p.eta.textContent = '';
+        }
+      }
     });
 
-    s.on('item', data => {
-    console.debug('📦 item', data.market_hash_name || data.name || data.defindex);
-    const container = document.querySelector(`#user-${data.steamid} .inventory-container`);
-    if (!container) return;
-    const frag = document.createDocumentFragment();
-    const el = createItemElement(data);
-    frag.appendChild(el);
-    container.appendChild(frag);
-    // force repaint so newly added item appears immediately
-    void el.offsetHeight;
-    if (window.attachItemModal) {
-      window.attachItemModal();
-    } else if (window.attachHandlers) {
-      window.attachHandlers();
-    }
-    if (window.refreshLazyLoad) {
-      window.refreshLazyLoad();
-    }
-  });
+    s.on('items_batch', data => {
+      const container = document.querySelector(
+        `#user-${data.steamid} .inventory-container`
+      );
+      if (!container) return;
+      const batch = data.items || [];
+      batch.forEach(item => {
+        const el = createItemElement(item);
+        enqueueItem(container, el, data.steamid);
+      });
+      console.debug('📦 batch', batch.length, 'remaining:', itemQueue.length);
+    });
 
     s.on('done', data => {
     const card = document.getElementById('user-' + data.steamid);
@@ -303,6 +401,8 @@
           msg.textContent =
             data.status === 'private'
               ? 'Inventory private'
+              : data.status === 'timeout'
+              ? 'Timed out'
               : 'Inventory unavailable';
           body.insertBefore(msg, body.firstChild);
         }
@@ -347,12 +447,17 @@
     const p = progressMap.get(String(data.steamid));
     if (p) {
       p.bar.style.width = '100%';
+      // ensure final width transition flushes
+      void p.bar.offsetWidth;
       p.bar.textContent = data.status === 'parsed' ? 'Done' : 'Failed';
+      if (p.eta) p.eta.textContent = '';
       setTimeout(() => {
         p.el.classList.add('fade-out');
         setTimeout(() => p.el.remove(), 600);
       }, 4000);
       progressMap.delete(String(data.steamid));
+      removeQueued(data.steamid);
+      drainQueue();
     }
   });
 
@@ -364,7 +469,13 @@
       fetchUserCard(steamid);
       return;
     }
+    clearExisting(steamid);
     insertProgressBar(steamid);
     socket.emit('start_fetch', { steamid });
+  };
+
+  window.cancelInventoryFetch = function (steamid) {
+    if (socket) socket.emit('cancel_fetch', { steamid });
+    clearExisting(steamid);
   };
 })();

--- a/static/socket.js
+++ b/static/socket.js
@@ -382,18 +382,61 @@
   function registerSocketEvents(s) {
 
     s.on('info', data => {
-    let p = progressMap.get(String(data.steamid));
-    if (!p) {
-      insertProgressBar(data.steamid);
-      p = progressMap.get(String(data.steamid));
-    }
-    if (p) {
-      p.bar.style.width = '0%';
-      // force reflow to restart transition
-      void p.bar.offsetWidth;
-      p.bar.textContent = `0/${data.total || 0}`;
-    }
-  });
+      const card = document.getElementById('user-' + data.steamid);
+      if (card) {
+        const header = card.querySelector('.card-header');
+        if (header) {
+          header.innerHTML = `
+            <div class="user-header">
+              <div class="user-profile">
+                <a href="${data.profile}" target="_blank" class="avatar-link">
+                  <img src="${data.avatar}" alt="Avatar" class="profile-pic" loading="lazy"/>
+                </a>
+                <div class="profile-details">
+                  <div class="username">${data.username}</div>
+                  <div class="tf2-hours">TF2 Playtime: ${data.playtime} hrs</div>
+                  <div class="profile-link">
+                    <a href="${data.backpack}" class="backpack-link" target="_blank" rel="noopener">
+                      Backpack.tf
+                      <img src="/static/images/logos/bptf_small.PNG" alt="Backpack.tf" class="inline-icon"/>
+                    </a>
+                  </div>
+                </div>
+              </div>
+              <div class="header-right">
+                <button class="cancel-btn" type="button" onclick="cancelInventoryFetch(${data.steamid})">&#x2716;</button>
+              </div>
+            </div>`;
+        }
+        const invContainer = card.querySelector('.inventory-container');
+        if (invContainer && !card.querySelector('.inventory-scroll')) {
+          const scrollWrapper = document.createElement('div');
+          scrollWrapper.className = 'inventory-scroll';
+          const leftBtn = document.createElement('button');
+          leftBtn.className = 'scroll-arrow left';
+          leftBtn.innerHTML = '<i class="fa-solid fa-chevron-left"></i>';
+          const rightBtn = document.createElement('button');
+          rightBtn.className = 'scroll-arrow right';
+          rightBtn.innerHTML = '<i class="fa-solid fa-chevron-right"></i>';
+          scrollWrapper.appendChild(leftBtn);
+          scrollWrapper.appendChild(invContainer);
+          scrollWrapper.appendChild(rightBtn);
+          const body = card.querySelector('.card-body');
+          if (body) body.appendChild(scrollWrapper);
+        }
+      }
+      let p = progressMap.get(String(data.steamid));
+      if (!p) {
+        insertProgressBar(data.steamid);
+        p = progressMap.get(String(data.steamid));
+      }
+      if (p) {
+        p.bar.style.width = '0%';
+        // force reflow to restart transition
+        void p.bar.offsetWidth;
+        p.bar.textContent = `0/${data.total || 0}`;
+      }
+    });
 
 
     s.on('progress', data => {
@@ -571,4 +614,17 @@
   window._debugQueue = itemQueue;
   window._debugProcessQueue = processQueue;
   window.DEBUG_FORCE_RENDER = false;
+
+  document.addEventListener('click', e => {
+    const left = e.target.closest('.scroll-arrow.left');
+    if (left) {
+      const container = left.closest('.inventory-scroll')?.querySelector('.inventory-container');
+      if (container) container.scrollBy({ left: -200, behavior: 'smooth' });
+    }
+    const right = e.target.closest('.scroll-arrow.right');
+    if (right) {
+      const container = right.closest('.inventory-scroll')?.querySelector('.inventory-container');
+      if (container) container.scrollBy({ left: 200, behavior: 'smooth' });
+    }
+  });
 })();

--- a/static/socket.js
+++ b/static/socket.js
@@ -343,6 +343,7 @@
 
     setTimeout(() => wrapper.classList.add('show'), 10);
     return wrapper;
+  }
   
   function registerSocketEvents(s) {
 

--- a/static/style.css
+++ b/static/style.css
@@ -71,6 +71,12 @@ button,
   padding: 0 1rem;
 }
 
+.header-right {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 .user-profile {
   display: flex;
   align-items: center;
@@ -797,7 +803,8 @@ footer {
   font-weight: bold;
   text-align: center;
   line-height: 14px;
-  transition: width 0.3s ease;
+  transition: width 0.35s ease;
+  will-change: width;
 }
 
 .eta-label {
@@ -817,6 +824,18 @@ footer {
   padding: 4px 8px;
   cursor: pointer;
   font-size: 0.8rem;
+}
+
+.cancel-btn {
+  background: transparent;
+  border: none;
+  color: #ccc;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.cancel-btn:hover {
+  color: #fff;
 }
 
 .error-banner {

--- a/static/style.css
+++ b/static/style.css
@@ -661,6 +661,11 @@ html, body {
   transform: scale(1);
 }
 
+.fade-out {
+  opacity: 0;
+  transition: opacity 0.6s ease;
+}
+
 footer {
   padding: 1rem;
   text-align: center;

--- a/static/style.css
+++ b/static/style.css
@@ -843,6 +843,31 @@ footer {
   color: #fff;
 }
 
+.inventory-scroll {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.inventory-scroll .inventory-container {
+  display: flex;
+  overflow-x: auto;
+  scroll-behavior: smooth;
+  gap: 6px;
+}
+
+.scroll-arrow.left {
+  left: 0;
+}
+
+.scroll-arrow.right {
+  right: 0;
+}
+
+.inventory-scroll:hover .scroll-arrow {
+  display: block;
+}
+
 .error-banner {
   color: #ffaaaa;
   font-size: 0.9rem;

--- a/static/submit.js
+++ b/static/submit.js
@@ -7,9 +7,9 @@ function createPlaceholder(id) {
   ph.innerHTML =
     '<div class="card-header">' +
     id +
-    '<button class="cancel-btn" type="button" onclick="cancelInventoryFetch(' +
+    '<div class="header-right"><button class="cancel-btn" type="button" onclick="cancelInventoryFetch(' +
     id +
-    ')">&#x2716;</button></div><div class="card-body"><div class="inventory-container"></div></div>';
+    ')">&#x2716;</button></div></div><div class="card-body"><div class="inventory-container"></div></div>';
   const spinner = document.createElement('div');
   spinner.className = 'loading-spinner';
   spinner.setAttribute('aria-label', 'Loading');

--- a/static/submit.js
+++ b/static/submit.js
@@ -1,3 +1,4 @@
+(function () {
 function createPlaceholder(id) {
   const ph = document.createElement('div');
   ph.id = 'user-' + id;
@@ -119,12 +120,15 @@ function handleSubmit(e) {
 
 document.addEventListener('DOMContentLoaded', () => {
   const btn = document.getElementById('check-inventory-btn');
-  if (btn) {
-    btn.addEventListener('click', e => {
-      if (!window.inventorySocket || window.inventorySocket.disconnected) {
-        console.warn('⚠ Socket not ready, will use fallback.');
-      }
-      handleSubmit(e);
-    });
-  }
+  if (!btn) return;
+  btn.disabled = true;
+  btn.addEventListener('click', e => {
+    handleSubmit(e);
+  });
 });
+
+window.enableSubmitButton = function () {
+  const btn = document.getElementById('check-inventory-btn');
+  if (btn) btn.disabled = false;
+};
+})();

--- a/static/submit.js
+++ b/static/submit.js
@@ -6,7 +6,9 @@ function createPlaceholder(id) {
   ph.innerHTML =
     '<div class="card-header">' +
     id +
-    '</div><div class="card-body"><div class="inventory-container"></div></div>';
+    '<button class="cancel-btn" type="button" onclick="cancelInventoryFetch(' +
+    id +
+    ')">&#x2716;</button></div><div class="card-body"><div class="inventory-container"></div></div>';
   const spinner = document.createElement('div');
   spinner.className = 'loading-spinner';
   spinner.setAttribute('aria-label', 'Loading');

--- a/templates/_user.html
+++ b/templates/_user.html
@@ -15,7 +15,9 @@
         </div>
       </div>
     </div>
-    <div class="privacy-status">
+    <div class="header-right">
+      <button class="cancel-btn" type="button" onclick="cancelInventoryFetch({{ user.steamid }})">&#x2716;</button>
+      <div class="privacy-status">
       {% if user.status == 'failed' %}
         <button
           class="pill status-pill failed retry-button"
@@ -36,6 +38,7 @@
           {% endif %}
         </span>
       {% endif %}
+      </div>
     </div>
   </div>
   <div class="card-body">


### PR DESCRIPTION
## Summary
- queue incoming item cards to batch DOM updates
- clear old progress bars and item lists on retry
- yield final progress bar flush on server side
- implement adaptive batch streaming with ETA and cancellation
- add cancel buttons in card headers
- remove redundant cancel fetch emit from `clearExisting`

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files static/socket.js static/style.css static/submit.js templates/_user.html app.py utils/inventory_processor.py`

------
https://chatgpt.com/codex/tasks/task_e_687c454f27f0832693aa1501fe7d8f26