### PR TITLE
Refactor retry logic

### DIFF
--- a/static/socket.js
+++ b/static/socket.js
@@ -196,32 +196,6 @@
     removeQueued(steamid);
   }
 
-  function resetCardForRetry(steamid) {
-    const card = document.getElementById('user-' + steamid);
-    if (!card) return;
-
-    const errorBanner = card.querySelector('.error-banner');
-    if (errorBanner) errorBanner.remove();
-
-    const invContainer = card.querySelector('.inventory-container');
-    if (invContainer) invContainer.innerHTML = '';
-
-    let spinner = card.querySelector('.loading-spinner');
-    if (!spinner) {
-      spinner = document.createElement('div');
-      spinner.className = 'loading-spinner';
-      spinner.setAttribute('aria-label', 'Loading');
-      card.appendChild(spinner);
-    }
-
-    const bar = card.querySelector('.progress-inner');
-    if (bar) {
-      bar.style.width = '0%';
-      bar.textContent = '0';
-    }
-
-    card.classList.add('loading');
-  }
 
   function insertUserPlaceholder(id) {
     const container = document.getElementById('user-container');
@@ -656,41 +630,4 @@
       if (container) container.scrollBy({ left: 200, behavior: 'smooth' });
     }
   });
-
-  document.addEventListener('click', e => {
-    const retryBtn = e.target.closest('.retry-button');
-    if (!retryBtn) return;
-    const steamid = retryBtn.dataset.steamid;
-    if (!steamid) return;
-
-    console.log(`\u{1F501} Retrying inventory fetch for ${steamid}`);
-
-    resetCardForRetry(steamid);
-
-    if (typeof window.startInventoryFetch === 'function') {
-      window.startInventoryFetch(steamid);
-    } else {
-      console.error('startInventoryFetch is not defined');
-    }
-  });
-
-  const refreshBtn = document.getElementById('refresh-failed-btn');
-  if (refreshBtn) {
-    refreshBtn.addEventListener('click', () => {
-      console.log('\u{1F504} Refreshing all failed inventories...');
-      const cards = document.querySelectorAll('.retry-button[data-steamid], .user-card.failed');
-      const seen = new Set();
-      cards.forEach((el, idx) => {
-        const id = el.dataset.steamid || el.closest('.user-card')?.dataset.steamid;
-        if (!id || seen.has(id)) return;
-        seen.add(id);
-        setTimeout(() => {
-          resetCardForRetry(id);
-          if (typeof window.startInventoryFetch === 'function') {
-            window.startInventoryFetch(id);
-          }
-        }, idx * 200);
-      });
-    });
-  }
 })();


### PR DESCRIPTION
## Summary
- move resetCardForRetry helper to retry.js
- remove retry event handlers from socket.js
- use new helper when retrying a user
- improve batch refresh to display progress toast

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files static/retry.js static/socket.js`

------
https://chatgpt.com/codex/tasks/task_e_687d4ae2ef0c8326a235ddca558754d5