### PR TITLE
Handle failed cards on socket done

### DIFF
--- a/static/socket.js
+++ b/static/socket.js
@@ -520,6 +520,18 @@
       const spin = card.querySelector('.loading-spinner');
       if (spin) spin.remove();
 
+      if (data.status === 'parsed') {
+        card.classList.add('success');
+        card.classList.remove('failed');
+      } else {
+        card.classList.add('failed');
+        card.classList.remove('success');
+      }
+
+      if (typeof window.updateRefreshButton === 'function') {
+        window.updateRefreshButton();
+      }
+
       const header = card.querySelector('.card-header, .user-header');
       if (header) {
         let pill = header.querySelector('.status-pill');


### PR DESCRIPTION
## Summary
- mark user cards with `.success` or `.failed` when socket 'done' fires
- call `updateRefreshButton()` so the refresh button enables correctly

## Testing
- `pre-commit run --files static/socket.js static/retry.js` *(fails: missing schema files)*

------
https://chatgpt.com/codex/tasks/task_e_687d889a4fc08326afe4ce3de84920ee