### PR TITLE
Fix stale error banners after successful inventory fetch

### DIFF
--- a/static/socket.js
+++ b/static/socket.js
@@ -523,6 +523,13 @@
       if (data.status === 'parsed') {
         card.classList.add('success');
         card.classList.remove('failed');
+        /* ---------- SUCCESS CLEAN-UP ---------- */
+        // Remove any stale “Inventory unavailable” banners left from a previous failure
+        card.querySelectorAll('.error-banner').forEach(el => el.remove());
+        // Some templates render a one-liner outside card-body; remove that too
+        const failLine = card.querySelector('.failed-label, .inventory-failed-msg');
+        if (failLine) failLine.remove();
+        /* -------------------------------------- */
       } else {
         card.classList.add('failed');
         card.classList.remove('success');


### PR DESCRIPTION
## Summary
- remove old error banners when a retry succeeds

## Testing
- `pre-commit run --files static/socket.js`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687d8c8dae5083269570101c37dba943