### PR TITLE
Fix caching during development

### DIFF
--- a/static/submit.js
+++ b/static/submit.js
@@ -57,7 +57,7 @@ function createPlaceholder(steamid) {
 
 async function fetchUserCard(id) {
   try {
-    const resp = await fetch('/api/users', {
+    const resp = await fetch(`/api/users?_=${Date.now()}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ ids: [id] })

--- a/templates/index.html
+++ b/templates/index.html
@@ -163,7 +163,7 @@
     </script>
     <script src="{{ url_for('static', filename='lazyload.js') }}"></script>
     <script src="{{ url_for('static', filename='modal.js') }}"></script>
-    <script src="{{ url_for('static', filename='retry.js') }}"></script>
+    <script src="{{ url_for('static', filename='retry.js') }}?v={{ cache_bust }}"></script>
     <!-- ✅ Load Socket.IO v4 -->
     <script src="https://cdn.socket.io/4.7.5/socket.io.min.js" defer></script>
 

--- a/tests/test_refresh_button.py
+++ b/tests/test_refresh_button.py
@@ -8,7 +8,7 @@ import pytest
 async def test_refresh_button_has_button_type(app):
     async with app.test_request_context("/"):
         html = await render_template(
-            "index.html", steamids="", users=[], ids=[], failed_ids=[]
+            "index.html", steamids="", users=[], ids=[], failed_ids=[], cache_bust=0
         )
     soup = BeautifulSoup(html, "html.parser")
     refresh_btn = soup.find("button", id="refresh-failed-btn")


### PR DESCRIPTION
## Summary
- disable HTTP caching with an `after_request` handler
- add cache bust query parameter to retry.js
- force API calls to always get fresh results
- adjust template tests for new parameter

## Testing
- `pre-commit run --files app.py templates/index.html static/submit.js tests/test_refresh_button.py`
- `python scripts/check_legacy.py`

------
https://chatgpt.com/codex/tasks/task_e_687d8dfe6584832694a965b2412ec785