### PR TITLE
Enable dev cache busting for all static assets

### DIFF
--- a/app.py
+++ b/app.py
@@ -62,8 +62,19 @@ STEAM_API_KEY = os.environ["STEAM_API_KEY"]
 
 app = Quart(__name__, static_folder=None)
 app.config.setdefault("PROVIDE_AUTOMATIC_OPTIONS", True)
+app.config["TEMPLATES_AUTO_RELOAD"] = True
 app.static_folder = "static"
-app.add_url_rule("/static/<path:filename>", "static", app.send_static_file)
+
+
+@app.route("/static/<path:filename>", endpoint="static")
+async def custom_static(filename: str) -> Response:
+    """Serve static files with no caching during development."""
+    response = await app.send_static_file(filename)
+    response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = "0"
+    return response
+
 
 enable_secret = os.getenv("ENABLE_SECRET", "true").lower() == "true"
 if enable_secret:

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>TF2 Inventory Checker</title>
-    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}?v={{ cache_bust }}">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" rel="stylesheet">
     <style>
         img { vertical-align: middle; }
@@ -161,15 +161,15 @@
     <script>
       window.initialIds = {{ failed_ids|tojson|safe }};
     </script>
-    <script src="{{ url_for('static', filename='lazyload.js') }}"></script>
-    <script src="{{ url_for('static', filename='modal.js') }}"></script>
+    <script src="{{ url_for('static', filename='lazyload.js') }}?v={{ cache_bust }}"></script>
+    <script src="{{ url_for('static', filename='modal.js') }}?v={{ cache_bust }}"></script>
     <script src="{{ url_for('static', filename='retry.js') }}?v={{ cache_bust }}"></script>
     <!-- ✅ Load Socket.IO v4 -->
     <script src="https://cdn.socket.io/4.7.5/socket.io.min.js" defer></script>
 
     <!-- ✅ Load custom scripts AFTER DOM & socket.io -->
-    <script src="/static/socket.js" defer></script>
-    <script src="/static/submit.js" defer></script>
+    <script src="{{ url_for('static', filename='socket.js') }}?v={{ cache_bust }}" defer></script>
+    <script src="{{ url_for('static', filename='submit.js') }}?v={{ cache_bust }}" defer></script>
     <script>
       function attachScrollButtons() {
         document.querySelectorAll('.inventory-scroll').forEach(wrapper => {


### PR DESCRIPTION
## Summary
- serve `/static` files with cache headers disabled
- enable template auto-reload in the Quart app
- append cache bust query params to JS and CSS assets

## Testing
- `pre-commit run --files app.py templates/index.html`

------
https://chatgpt.com/codex/tasks/task_e_687d90b1c0788326b868908e9e34b3fd