### PR TITLE
Disable caching of static files in dev

### DIFF
--- a/app.py
+++ b/app.py
@@ -63,6 +63,9 @@ STEAM_API_KEY = os.environ["STEAM_API_KEY"]
 app = Quart(__name__, static_folder=None)
 app.config.setdefault("PROVIDE_AUTOMATIC_OPTIONS", True)
 app.config["TEMPLATES_AUTO_RELOAD"] = True
+app.config["SEND_FILE_MAX_AGE_DEFAULT"] = (
+    0  # Disable Flask static caching during development
+)
 app.static_folder = "static"
 
 


### PR DESCRIPTION
## Summary
- disable Flask static file caching in development using `SEND_FILE_MAX_AGE_DEFAULT`

## Testing
- `pre-commit run --files app.py`

------
https://chatgpt.com/codex/tasks/task_e_687d95904f348326b4b3f1aeb3a6ed86