### PR TITLE
Fix lazy loading after value sort

### DIFF
--- a/static/lazyload.js
+++ b/static/lazyload.js
@@ -2,7 +2,7 @@
 // Basic image lazy loading using IntersectionObserver
 // Applies to images with a `data-src` attribute.
 
-let lazyObserver;
+let observer;
 
 function loadImage(img) {
   img.src = img.dataset.src;
@@ -14,19 +14,19 @@ function initLazyLoad() {
   if (!images.length) return;
 
   if ('IntersectionObserver' in window) {
-    lazyObserver = new IntersectionObserver(
+    observer = new IntersectionObserver(
       entries => {
         entries.forEach(entry => {
           if (entry.isIntersecting) {
             loadImage(entry.target);
-            lazyObserver.unobserve(entry.target);
+            observer.unobserve(entry.target);
           }
         });
       },
       { rootMargin: '50px' }
     );
 
-    images.forEach(img => lazyObserver.observe(img));
+    images.forEach(img => observer.observe(img));
   } else {
     // Fallback: load all images immediately
     images.forEach(loadImage);
@@ -34,9 +34,13 @@ function initLazyLoad() {
 }
 
 window.refreshLazyLoad = function () {
+  if (!observer && 'IntersectionObserver' in window) {
+    initLazyLoad();
+    return;
+  }
   document.querySelectorAll('img[data-src]').forEach(img => {
-    if (lazyObserver) {
-      lazyObserver.observe(img);
+    if (observer) {
+      observer.observe(img);
     } else {
       loadImage(img);
     }

--- a/static/socket.js
+++ b/static/socket.js
@@ -618,6 +618,9 @@
                 return vb - va;
               });
               wrappers.forEach(w => container.appendChild(w));
+              if (window.refreshLazyLoad) {
+                window.refreshLazyLoad();
+              }
             });
             body.insertBefore(btn, body.firstChild);
           }


### PR DESCRIPTION
## Summary
- ensure sort by value triggers lazy load refresh
- provide global `refreshLazyLoad` helper so DOM reordering still loads images

## Testing
- `SKIP_VALIDATE=1 pre-commit run --files static/socket.js static/lazyload.js`

------
https://chatgpt.com/codex/tasks/task_e_687d981561708326acc32e4986ecb4c0