### PR TITLE
Add Docker Compose configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+
 ### Added
+
 - Pre-commit configuration for formatting, linting, and secret scanning.
 - Locked dependencies and instructions for secure updates.
 - Additional unit tests for inventory processing and ID conversion.
@@ -15,12 +17,18 @@ All notable changes to this project will be documented in this file.
 - License changed to an MIT-style Non-Commercial license.
 
 ### Removed
+
 - GitHub Actions workflow and Codecov configuration.
 
 ### Changed
+
 - Updated schema caching logic and UI (previous releases).
 - Security audit using git-secrets and pip-audit.
 - Price loader now reads both Craftable and Non-Craftable price entries.
 - Plain craft weapons from achievements or promotions are no longer filtered and
   such items are hidden without price data.
 - Untradable timed-drop items are now marked as hidden.
+
+## [2025-08-09]
+
+- Added docker-compose configuration and synchronized documentation.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3.9"
+services:
+  app:
+    build: .
+    command: python run.py
+    ports:
+      - "5000:5000"
+    volumes:
+      - ./app:/app
+    env_file:
+      - .env
+    restart: always

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,5 @@
+# Architecture
+
+The TF2 Inventory Scanner is a Flask application that serves a web interface for inspecting player inventories. The application starts through `run.py`, which prepares cache files and runs the app with Hypercorn.
+
+Containerized deployments rely on a single service defined in `docker-compose.yml`. The service builds from the repository's `Dockerfile`, mounts the local `./app` directory to `/app` inside the container, loads environment variables from `.env`, and exposes port `5000`.

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -1,0 +1,3 @@
+# Commands
+
+- `docker-compose up` – Build and start the TF2 Inventory Scanner in a container that restarts automatically and runs `python run.py`.

--- a/docs/DEVELOPERS_GUIDE.md
+++ b/docs/DEVELOPERS_GUIDE.md
@@ -1,0 +1,8 @@
+# Developer Guide
+
+## Running with Docker
+
+1. Create a `.env` file containing required API keys.
+2. Place application code in the local `./app` directory.
+3. Run `docker-compose up` to build and start the service.
+4. Access the app at `http://localhost:5000`.

--- a/docs/FUNCTIONS_REFERENCE.md
+++ b/docs/FUNCTIONS_REFERENCE.md
@@ -1,0 +1,17 @@
+# Functions Reference
+
+## ensure_cache_ready
+
+Ensures required cache files exist before the server starts.
+
+- **Parameters:** none
+- **Returns:** `bool` – `True` when the schema is refreshed and a restart is required.
+- **Used in:** `run.py`
+
+## main
+
+Bootstraps the application, refreshes cache as needed, configures Hypercorn, and starts serving the Flask app.
+
+- **Parameters:** none
+- **Returns:** `None`
+- **Used in:** `run.py`

--- a/docs/SYSTEM_MAP.md
+++ b/docs/SYSTEM_MAP.md
@@ -1,0 +1,3 @@
+# System Map
+
+- **docker-compose.yml**: Defines the `app` service that builds from the current directory, mounts `./app` to `/app`, uses `.env` for configuration, exposes port `5000`, and runs `python run.py`.


### PR DESCRIPTION
## Summary
- add Docker Compose setup to run the app via `python run.py`
- document architecture, commands, system map, and developer guide
- record addition in changelog

## Testing
- `npx eslint static/*.js tests/test_modal.js --config eslint.config.mjs`
- `npx prettier docs/ARCHITECTURE.md docs/FUNCTIONS_REFERENCE.md docs/COMMANDS.md docs/SYSTEM_MAP.md docs/DEVELOPERS_GUIDE.md docker-compose.yml CHANGELOG.md --check`
- `SKIP_VALIDATE=1 pre-commit run --files docker-compose.yml docs/ARCHITECTURE.md docs/FUNCTIONS_REFERENCE.md docs/COMMANDS.md docs/SYSTEM_MAP.md docs/DEVELOPERS_GUIDE.md CHANGELOG.md`


------
https://chatgpt.com/codex/tasks/task_e_68977e1194388326a9bfa9b171796714