### PR TITLE
style: drop inner ring on uncraftable items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,13 @@ All notable changes to this project will be documented in this file.
 - Separated scan results into Completed and Failed buckets with a jump-to-new-results button.
 - Updated client scripts with JSDoc comments and synchronized project documentation.
 
+## [2025-08-16]
+
+### Changed
+
+- Removed inner gray ring from uncraftable item cards, relying solely on the dashed quality border.
+- Synchronized documentation.
+
 ## [2025-05-11]
 
 ### Added

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -15,6 +15,7 @@ Client-side JavaScript handles form submission, retry flows, and dynamic UI upda
 `static/ui.js` adds per-user inventory search with sticky headers and provides global
 toggles for compact density and border-only quality modes, both persisted via
 `localStorage` and reflected through `aria-pressed` states and descriptive titles for accessibility.
+Uncraftable items rely solely on a dashed quality border without the previous inner gray ring.
 Sticky user headers now isolate their stacking context so they remain above item cards and prices while scrolling.
 Each `.item-wrapper` now includes a `data-name` attribute so client-side scripts can filter items by name. `static/retry.js` rebinds these per-user searches after inventory refreshes, caching item names and handling legacy and new inventory containers.
 

--- a/docs/DEVELOPERS_GUIDE.md
+++ b/docs/DEVELOPERS_GUIDE.md
@@ -10,6 +10,7 @@
 - Global toggle buttons should update `aria-pressed` and `title` attributes for
   accessibility; follow the pattern in `updateToggleButtons`.
 - Item cards omit inline titles; names surface only within the modal.
+- Uncraftable items rely on dashed borders only; the inner gray ring has been removed to reduce visual clutter.
 - Modal clicks are delegated from result containers. Ensure overlays and badges do not capture pointer events.
 - Unusual effect icons use empty alt text, ignore pointer events, and a helper removes the image if loading fails.
 - Wrap icon elements in `.item-media` to center content and place particle overlays behind; include `onerror="this.remove()"` on effect images so missing assets vanish cleanly.

--- a/static/style.css
+++ b/static/style.css
@@ -324,7 +324,8 @@ body.compact .item-name {
 .item-card.uncraftable {
   border-style: dashed;
   border-width: 2px;
-  box-shadow: inset 0 0 0 2px #aaa; /* inner border inside quality color */
+  /* Remove inner gray ring; rely on dashed quality border only */
+  box-shadow: none;
 }
 
 .particle-overlay {
@@ -752,7 +753,7 @@ footer {
 
 /* --- Center the media inside each card --- */
 .item-card {
-  position: relative;            /* keep cursor rule elsewhere if you have one */
+  position: relative; /* keep cursor rule elsewhere if you have one */
 }
 .item-media {
   /* fill the card and center its contents */
@@ -762,8 +763,8 @@ footer {
   height: 100%;
   width: 100%;
   box-sizing: border-box;
-  padding: 6px;                  /* keeps icons off the border ring */
-  position: relative;            /* containing block for .particle-bg */
+  padding: 6px; /* keeps icons off the border ring */
+  position: relative; /* containing block for .particle-bg */
 }
 .item-media > img.item-img,
 .item-media > .kit-composite,


### PR DESCRIPTION
## Summary
- remove inner box-shadow ring from uncraftable item cards
- document new uncraftable styling in architecture and developer guides
- log style adjustment in changelog

## Testing
- `npx eslint static/**/*.js tests/**/*.js`
- `npx prettier static/style.css docs/ARCHITECTURE.md docs/DEVELOPERS_GUIDE.md CHANGELOG.md -w`
- `SKIP=validate-attributes,pytest pre-commit run --files static/style.css docs/ARCHITECTURE.md docs/DEVELOPERS_GUIDE.md CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_68a1151076d0832695bc04c80846004c