### PR TITLE
feat: add dual-quality border support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to this project will be documented in this file.
 - [2025-08-18] - Added floating display settings gear and menu, hiding legacy header toggles. Documentation synchronized.
 - [2025-08-18] - Refined settings FAB styles and added fallback toggle logic. Documentation synchronized.
 - [2025-08-19] - Render dual-quality border splits in Border Mode for multi-quality items, inferring secondary colors heuristically. Documentation synchronized.
+- [2025-08-19] - Refined alternate quality heuristics and conic gradient ring for dual-quality items. Documentation synchronized.
 
 ## [2025-08-16]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to this project will be documented in this file.
 
 - [2025-08-18] - Added floating display settings gear and menu, hiding legacy header toggles. Documentation synchronized.
 - [2025-08-18] - Refined settings FAB styles and added fallback toggle logic. Documentation synchronized.
+- [2025-08-19] - Render dual-quality border splits in Border Mode for multi-quality items. Documentation synchronized.
 
 ## [2025-08-16]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable changes to this project will be documented in this file.
 - [2025-08-18] - Refined settings FAB styles and added fallback toggle logic. Documentation synchronized.
 - [2025-08-19] - Render dual-quality border splits in Border Mode for multi-quality items, inferring secondary colors heuristically. Documentation synchronized.
 - [2025-08-19] - Refined alternate quality heuristics and conic gradient ring for dual-quality items. Documentation synchronized.
+- [2025-08-19] - Use centered conic gradient for exact 50/50 dual-quality split. Documentation synchronized.
 
 ## [2025-08-16]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ All notable changes to this project will be documented in this file.
 
 - [2025-08-18] - Added floating display settings gear and menu, hiding legacy header toggles. Documentation synchronized.
 - [2025-08-18] - Refined settings FAB styles and added fallback toggle logic. Documentation synchronized.
-- [2025-08-19] - Render dual-quality border splits in Border Mode for multi-quality items. Documentation synchronized.
+- [2025-08-19] - Render dual-quality border splits in Border Mode for multi-quality items, inferring secondary colors heuristically. Documentation synchronized.
 
 ## [2025-08-16]
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -29,6 +29,8 @@ Uncraftable items rely solely on a dashed quality border without the previous in
 Sticky user headers now isolate their stacking context so they remain above item cards and prices while scrolling.
 Each `.item-wrapper` now includes a `data-name` attribute so client-side scripts can filter items by name. `static/retry.js` rebinds these per-user searches after inventory refreshes, caching item names and handling legacy and new inventory containers.
 
+Item cards can display a split border in **Border Mode** when an item exposes a secondary quality color. The top-left and bottom-right corners render the alternate color using CSS conic gradients, giving multi-quality items a diagonal ring.
+
 Item cards no longer render inline titles, keeping the grid clean; names appear only in the modal. Unusual effect icons are decorative overlays that ignore pointer events, and a JavaScript fallback removes the icon if it fails to load. Modal clicks are delegated from result containers so dynamically added cards remain interactive.
 
 Card media sit inside an `.item-media` wrapper that centers the main icon while keeping particle overlays behind it; failed effect images remove themselves to avoid broken placeholders.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -29,7 +29,7 @@ Uncraftable items rely solely on a dashed quality border without the previous in
 Sticky user headers now isolate their stacking context so they remain above item cards and prices while scrolling.
 Each `.item-wrapper` now includes a `data-name` attribute so client-side scripts can filter items by name. `static/retry.js` rebinds these per-user searches after inventory refreshes, caching item names and handling legacy and new inventory containers.
 
-Item cards can display a split border in **Border Mode** when an item exposes a secondary quality color. The top-left and bottom-right corners render the alternate color using CSS conic gradients, giving multi-quality items a diagonal ring.
+Item cards can display a split border in **Border Mode** when an item exposes or infers a secondary quality color. Heuristics guess common combinations (e.g., Strange + Unusual) if the backend omits an explicit alt value. The top-left and bottom-right corners render the alternate color via layered gradients, giving multi-quality items a diagonal ring.
 
 Item cards no longer render inline titles, keeping the grid clean; names appear only in the modal. Unusual effect icons are decorative overlays that ignore pointer events, and a JavaScript fallback removes the icon if it fails to load. Modal clicks are delegated from result containers so dynamically added cards remain interactive.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -29,7 +29,7 @@ Uncraftable items rely solely on a dashed quality border without the previous in
 Sticky user headers now isolate their stacking context so they remain above item cards and prices while scrolling.
 Each `.item-wrapper` now includes a `data-name` attribute so client-side scripts can filter items by name. `static/retry.js` rebinds these per-user searches after inventory refreshes, caching item names and handling legacy and new inventory containers.
 
-Item cards can display a split border in **Border Mode** when an item exposes or infers a secondary quality color. Heuristics guess common combinations (e.g., Strange + Unusual) if the backend omits an explicit alt value. The top-left and bottom-right corners render the alternate color via layered gradients, giving multi-quality items a diagonal ring.
+Item cards can display a split border in **Border Mode** when an item exposes or infers a secondary quality color. If the backend omits an explicit value, heuristics try common mixes (Unusual, then Genuine, then Strange) to derive an alternate hue. Top-left and bottom-right corners render that hue via layered conic gradients, yielding a diagonal ring for multi-quality items.
 
 Item cards no longer render inline titles, keeping the grid clean; names appear only in the modal. Unusual effect icons are decorative overlays that ignore pointer events, and a JavaScript fallback removes the icon if it fails to load. Modal clicks are delegated from result containers so dynamically added cards remain interactive.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -29,7 +29,7 @@ Uncraftable items rely solely on a dashed quality border without the previous in
 Sticky user headers now isolate their stacking context so they remain above item cards and prices while scrolling.
 Each `.item-wrapper` now includes a `data-name` attribute so client-side scripts can filter items by name. `static/retry.js` rebinds these per-user searches after inventory refreshes, caching item names and handling legacy and new inventory containers.
 
-Item cards can display a split border in **Border Mode** when an item exposes or infers a secondary quality color. If the backend omits an explicit value, heuristics try common mixes (Unusual, then Genuine, then Strange) to derive an alternate hue. Top-left and bottom-right corners render that hue via layered conic gradients, yielding a diagonal ring for multi-quality items.
+Item cards can display a split border in **Border Mode** when an item exposes or infers a secondary quality color. If the backend omits an explicit value, heuristics try common mixes (Unusual, then Genuine, then Strange) to derive an alternate hue. A centered conic gradient divides the ring along the top-left to bottom-right diagonal, filling the first half with the primary quality and the second with the alternate hue.
 
 Item cards no longer render inline titles, keeping the grid clean; names appear only in the modal. Unusual effect icons are decorative overlays that ignore pointer events, and a JavaScript fallback removes the icon if it fails to load. Modal clicks are delegated from result containers so dynamically added cards remain interactive.
 

--- a/static/style.css
+++ b/static/style.css
@@ -308,8 +308,11 @@ button {
   background-color: var(--quality-color, #1e1e1e);
   position: relative; /* ensure badges overlay */
 }
+/* Base fill in border mode */
 body.border-mode .item-card {
-  background-color: #1e1e1e;
+  --ring-w: 4px; /* ring thickness */
+  --card-fill: #1e1e1e; /* interior fill (same as before) */
+  background-color: var(--card-fill);
 }
 body.compact .item-wrapper {
   margin: 2px;
@@ -331,40 +334,46 @@ body.compact .item-name {
   box-shadow: none;
 }
 
-/* Border mode styles exist already; this only adds the diagonal split for dual-quality items. */
-
-/* ===== Border Mode — 45° diagonal split on outer ring (multi-quality) ===== */
-/* Turn off any older ::after implementation if present */
-body.border-mode .item-card.has-dual-quality::after {
-  content: none !important;
-}
-
-/* New implementation: layered backgrounds clipped to the border box.
-   Broad browser support, keeps rounded corners, and paints only the ring. */
-body.border-mode .item-card.has-dual-quality {
-  --ring-w: 4px;
-  --card-fill: #1e1e1e; /* matches existing border-mode fill */
-  border: var(--ring-w) solid transparent;
-  border-radius: inherit;
+/* ===== Border Mode ring (rounded) ======================================= */
+/* 1) Single-quality: solid ring using layered backgrounds clipped to boxes */
+body.border-mode .item-card {
+  /* the inline border-color would otherwise cover our gradient ring */
+  border: var(--ring-w) solid transparent !important;
   background:
     /* inner fill */
     linear-gradient(var(--card-fill), var(--card-fill)) padding-box,
-    /* top-left wedge (45°) */
+    /* base ring using primary quality */
       linear-gradient(
-        45deg,
-        var(--quality-alt, transparent) 0 49.5%,
-        transparent 50%
+        var(--quality-color, #cf6a32),
+        var(--quality-color, #cf6a32)
+      )
+      border-box;
+}
+
+/* 2) Dual-quality: add two 45° wedges in opposite elbows */
+body.border-mode .item-card.has-dual-quality {
+  background:
+    linear-gradient(var(--card-fill), var(--card-fill)) padding-box,
+    /* top-left wedge (rounded by border-radius) */
+      conic-gradient(
+        from 45deg at 0% 0%,
+        var(--quality-alt, transparent) 0 90deg,
+        transparent 0 1turn
       )
       border-box,
-    /* bottom-right wedge (225°) */
-      linear-gradient(
-        225deg,
-        var(--quality-alt, transparent) 0 49.5%,
-        transparent 50%
+    /* bottom-right wedge */
+      conic-gradient(
+        from 225deg at 100% 100%,
+        var(--quality-alt, transparent) 0 90deg,
+        transparent 0 1turn
       )
       border-box,
-    /* base ring in primary quality */
-      linear-gradient(var(--quality-color), var(--quality-color)) border-box;
+    /* base ring */
+      linear-gradient(
+        var(--quality-color, #cf6a32),
+        var(--quality-color, #cf6a32)
+      )
+      border-box;
 }
 
 .particle-overlay {

--- a/static/style.css
+++ b/static/style.css
@@ -333,58 +333,38 @@ body.compact .item-name {
 
 /* Border mode styles exist already; this only adds the diagonal split for dual-quality items. */
 
-/* ===== Border Mode — 45° split on elbows for multi-quality items ===== */
-/* The base ring uses the primary quality (via border-color). We paint only the
-   ring with the secondary color in the top-left and bottom-right corners. */
-body.border-mode .item-card.has-dual-quality {
-  /* Ensure the ring is visible with the primary quality color. Thickness can be tuned. */
-  --ring-w: 4px;
-  border-width: var(--ring-w);
-  border-style: solid;
-  border-color: var(--quality-color);
-  position: relative;
-}
-
-/* Draw the secondary color wedges on the ring only (not the interior). */
+/* ===== Border Mode — 45° diagonal split on outer ring (multi-quality) ===== */
+/* Turn off any older ::after implementation if present */
 body.border-mode .item-card.has-dual-quality::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: inherit; /* keep rounded corners */
-  pointer-events: none;
-  z-index: 2;
-
-  /* 45° sweep per elbow; adjust if you want more/less of each corner painted */
-  --sweep: 45deg;
-
-  /* Two conic wedges of the alt color in opposite elbows */
-  background:
-    conic-gradient(
-      from 45deg at 0% 0%,
-      var(--quality-alt, transparent) 0 var(--sweep),
-      transparent 0 1turn
-    ),
-    conic-gradient(
-      from 225deg at 100% 100%,
-      var(--quality-alt, transparent) 0 var(--sweep),
-      transparent 0 1turn
-    );
-
-  /* Mask to keep paint only on the ring (XOR content vs border box) */
-  padding: var(--ring-w);
-  -webkit-mask:
-    linear-gradient(#000 0 0) content-box,
-    linear-gradient(#000 0 0);
-  -webkit-mask-composite: xor;
-  mask:
-    linear-gradient(#000 0 0) content-box,
-    linear-gradient(#000 0 0);
-  mask-composite: exclude;
+  content: none !important;
 }
 
-/* Guard: if someone toggled border thickness elsewhere, keep wedges aligned */
+/* New implementation: layered backgrounds clipped to the border box.
+   Broad browser support, keeps rounded corners, and paints only the ring. */
 body.border-mode .item-card.has-dual-quality {
-  --ring-w: max(3px, var(--ring-w));
+  --ring-w: 4px;
+  --card-fill: #1e1e1e; /* matches existing border-mode fill */
+  border: var(--ring-w) solid transparent;
+  border-radius: inherit;
+  background:
+    /* inner fill */
+    linear-gradient(var(--card-fill), var(--card-fill)) padding-box,
+    /* top-left wedge (45°) */
+      linear-gradient(
+        45deg,
+        var(--quality-alt, transparent) 0 49.5%,
+        transparent 50%
+      )
+      border-box,
+    /* bottom-right wedge (225°) */
+      linear-gradient(
+        225deg,
+        var(--quality-alt, transparent) 0 49.5%,
+        transparent 50%
+      )
+      border-box,
+    /* base ring in primary quality */
+      linear-gradient(var(--quality-color), var(--quality-color)) border-box;
 }
 
 .particle-overlay {

--- a/static/style.css
+++ b/static/style.css
@@ -331,6 +331,62 @@ body.compact .item-name {
   box-shadow: none;
 }
 
+/* Border mode styles exist already; this only adds the diagonal split for dual-quality items. */
+
+/* ===== Border Mode — 45° split on elbows for multi-quality items ===== */
+/* The base ring uses the primary quality (via border-color). We paint only the
+   ring with the secondary color in the top-left and bottom-right corners. */
+body.border-mode .item-card.has-dual-quality {
+  /* Ensure the ring is visible with the primary quality color. Thickness can be tuned. */
+  --ring-w: 4px;
+  border-width: var(--ring-w);
+  border-style: solid;
+  border-color: var(--quality-color);
+  position: relative;
+}
+
+/* Draw the secondary color wedges on the ring only (not the interior). */
+body.border-mode .item-card.has-dual-quality::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit; /* keep rounded corners */
+  pointer-events: none;
+  z-index: 2;
+
+  /* 45° sweep per elbow; adjust if you want more/less of each corner painted */
+  --sweep: 45deg;
+
+  /* Two conic wedges of the alt color in opposite elbows */
+  background:
+    conic-gradient(
+      from 45deg at 0% 0%,
+      var(--quality-alt, transparent) 0 var(--sweep),
+      transparent 0 1turn
+    ),
+    conic-gradient(
+      from 225deg at 100% 100%,
+      var(--quality-alt, transparent) 0 var(--sweep),
+      transparent 0 1turn
+    );
+
+  /* Mask to keep paint only on the ring (XOR content vs border box) */
+  padding: var(--ring-w);
+  -webkit-mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  mask-composite: exclude;
+}
+
+/* Guard: if someone toggled border thickness elsewhere, keep wedges aligned */
+body.border-mode .item-card.has-dual-quality {
+  --ring-w: max(3px, var(--ring-w));
+}
+
 .particle-overlay {
   position: absolute;
   inset: 0;

--- a/static/style.css
+++ b/static/style.css
@@ -350,28 +350,17 @@ body.border-mode .item-card {
       border-box;
 }
 
-/* 2) Dual-quality: add two 45° wedges in opposite elbows */
+/* 2) Dual-quality: exact 50/50 split along the TL ↔ BR diagonal.         */
+/*    Primary (e.g., Strange) fills the first half; alt fills the second. */
 body.border-mode .item-card.has-dual-quality {
+  /* Change this angle if you want the split on the other diagonal: 45deg. */
+  --split-angle: 135deg; /* TL ↔ BR */
   background:
     linear-gradient(var(--card-fill), var(--card-fill)) padding-box,
-    /* top-left wedge (rounded by border-radius) */
-      conic-gradient(
-        from 45deg at 0% 0%,
-        var(--quality-alt, transparent) 0 90deg,
-        transparent 0 1turn
-      )
-      border-box,
-    /* bottom-right wedge */
-      conic-gradient(
-        from 225deg at 100% 100%,
-        var(--quality-alt, transparent) 0 90deg,
-        transparent 0 1turn
-      )
-      border-box,
-    /* base ring */
-      linear-gradient(
-        var(--quality-color, #cf6a32),
-        var(--quality-color, #cf6a32)
+    conic-gradient(
+        from var(--split-angle) at 50% 50%,
+        var(--quality-color, #cf6a32) 0 50%,
+        var(--quality-alt, #8650ac) 0 100%
       )
       border-box;
 }

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -17,11 +17,26 @@ item.is_australium %} {% set base = 'Australium ' ~ base %} {% endif %} {% set
 full_title = (title_parts + [base]) | join(' ') %}
 
 <!-- prettier-ignore -->
+{# Try a few common keys for the secondary/alt quality color. If none exist, no dual split will render. #}
+{% set alt_q =
+     item.alt_quality_color
+  or item.secondary_quality_color
+  or item.quality2_color
+  or (item.multi_quality_colors[1] if item.multi_quality_colors is defined and (item.multi_quality_colors|length) > 1 else None)
+%}
+
 <div
-  class="item-card{% if item.untradable_hold %} trade-hold{% endif %}{% if item.uncraftable %} uncraftable{% endif %}{% if item.has_strange_tracking %} elevated-strange{% endif %}"
-  style="--quality-color: {{ item.quality_color }}; border-color: {{ item.border_color or item.quality_color }};"
+  class="item-card{% if item.untradable_hold %} trade-hold{% endif %}{% if item.uncraftable %} uncraftable{% endif %}{% if item.has_strange_tracking %} elevated-strange{% endif %}{% if alt_q %} has-dual-quality{% endif %}"
+  style="--quality-color: {{ item.quality_color }};{% if alt_q %} --quality-alt: {{ alt_q }};{% endif %} border-color: {{ item.border_color or item.quality_color }};"
   title="{{ full_title }}"
-  data-item='{{ item|tojson|safe }}'
+  {%
+  if
+  alt_q
+  %}data-dual="1"
+  {%
+  endif
+  %}
+  data-item="{{ item|tojson|safe }}"
   data-craftable="{{ 'true' if item.craftable else 'false' }}"
 >
   <div class="item-badges">

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -26,24 +26,27 @@ full_title = (title_parts + [base]) | join(' ') %}
   or (item.multi_quality_colors[1] if item.multi_quality_colors is defined and (item.multi_quality_colors|length) > 1 else None)
 %}
 {# Heuristics for common combos if no explicit alt provided #}
-{% set qcolor = {
-  'Strange':  '#CF6A32',
-  'Unusual':  '#8650AC',
-  'Genuine':  '#4D7455',
-  'Vintage':  '#476291',
-  'Haunted':  '#38F3AB'
-} %}
-{% set primary_name = item.quality %}
-{# Strange + Unusual #}
-{% if not alt_q and item.unusual_effect_id and primary_name != 'Unusual' %}
-  {% set alt_q = qcolor['Unusual'] %}
-{% endif %}
-{% if not alt_q and item.has_strange_tracking and primary_name != 'Strange' %}
-  {% set alt_q = qcolor['Strange'] %}
-{% endif %}
-{# Strange + Genuine (or similar secondary tag) #}
-{% if not alt_q and (item.is_genuine or (item.quality2 is defined and item.quality2 == 'Genuine')) and primary_name != 'Genuine' %}
-  {% set alt_q = qcolor['Genuine'] %}
+{% if not alt_q %}
+  {% set qcolor = {
+    'Strange':  '#CF6A32',
+    'Unusual':  '#8650AC',
+    'Genuine':  '#4D7455',
+    'Vintage':  '#476291',
+    'Haunted':  '#38F3AB'
+  } %}
+  {% set primary_name = item.quality %}
+  {# Strange + Unusual #}
+  {% if item.unusual_effect_id and primary_name != 'Unusual' %}
+    {% set alt_q = qcolor['Unusual'] %}
+  {% endif %}
+  {# Strange + Genuine (or similar secondary tag) #}
+  {% if not alt_q and (item.is_genuine or (item.quality2 is defined and item.quality2 == 'Genuine')) and primary_name != 'Genuine' %}
+    {% set alt_q = qcolor['Genuine'] %}
+  {% endif %}
+  {# Unusual item whose primary is Unusual but also Strange #}
+  {% if not alt_q and item.has_strange_tracking and primary_name != 'Strange' %}
+    {% set alt_q = qcolor['Strange'] %}
+  {% endif %}
 {% endif %}
 
 <div

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -17,13 +17,34 @@ item.is_australium %} {% set base = 'Australium ' ~ base %} {% endif %} {% set
 full_title = (title_parts + [base]) | join(' ') %}
 
 <!-- prettier-ignore -->
-{# Try a few common keys for the secondary/alt quality color. If none exist, no dual split will render. #}
+{# --- Derive an alternate quality color for dual-quality borders --- #}
+{# Direct field if backend provides it #}
 {% set alt_q =
      item.alt_quality_color
   or item.secondary_quality_color
   or item.quality2_color
   or (item.multi_quality_colors[1] if item.multi_quality_colors is defined and (item.multi_quality_colors|length) > 1 else None)
 %}
+{# Heuristics for common combos if no explicit alt provided #}
+{% set qcolor = {
+  'Strange':  '#CF6A32',
+  'Unusual':  '#8650AC',
+  'Genuine':  '#4D7455',
+  'Vintage':  '#476291',
+  'Haunted':  '#38F3AB'
+} %}
+{% set primary_name = item.quality %}
+{# Strange + Unusual #}
+{% if not alt_q and item.unusual_effect_id and primary_name != 'Unusual' %}
+  {% set alt_q = qcolor['Unusual'] %}
+{% endif %}
+{% if not alt_q and item.has_strange_tracking and primary_name != 'Strange' %}
+  {% set alt_q = qcolor['Strange'] %}
+{% endif %}
+{# Strange + Genuine (or similar secondary tag) #}
+{% if not alt_q and (item.is_genuine or (item.quality2 is defined and item.quality2 == 'Genuine')) and primary_name != 'Genuine' %}
+  {% set alt_q = qcolor['Genuine'] %}
+{% endif %}
 
 <div
   class="item-card{% if item.untradable_hold %} trade-hold{% endif %}{% if item.uncraftable %} uncraftable{% endif %}{% if item.has_strange_tracking %} elevated-strange{% endif %}{% if alt_q %} has-dual-quality{% endif %}"
@@ -36,7 +57,7 @@ full_title = (title_parts + [base]) | join(' ') %}
   {%
   endif
   %}
-  data-item="{{ item|tojson|safe }}"
+  data-item="{{ item|tojson|forceescape }}"
   data-craftable="{{ 'true' if item.craftable else 'false' }}"
 >
   <div class="item-badges">

--- a/tests/test_user_template.py
+++ b/tests/test_user_template.py
@@ -135,10 +135,9 @@ def test_unusual_effect_rendered(app):
         context["user"] = app_module.normalize_user_payload(context["user"])
         html = render_template_string(HTML, **context)
     soup = BeautifulSoup(html, "html.parser")
-    title = soup.find("div", class_="item-name")
-    assert title is not None
-    text = title.text.strip()
-    assert text == "Burning Flames Cap"
+    card = soup.find("div", class_="item-card")
+    assert card is not None
+    assert card.get("title") == "Burning Flames Cap"
 
 
 def test_war_paint_tool_target_displayed(app):
@@ -185,9 +184,9 @@ def test_decorated_quality_not_shown(app):
         context["user"] = app_module.normalize_user_payload(context["user"])
         html = render_template_string(HTML, **context)
     soup = BeautifulSoup(html, "html.parser")
-    title = soup.find("div", class_="item-name")
-    assert title is not None
-    assert title.text.strip() == "Warhawk Flamethrower"
+    card = soup.find("div", class_="item-card")
+    assert card is not None
+    assert card.get("title") == "Warhawk Flamethrower"
 
 
 def test_failed_user_has_retry_class(app):
@@ -274,7 +273,7 @@ def test_elevated_strange_class_rendered(app):
     assert card is not None
     classes = card.get("class", [])
     assert "elevated-strange" in classes
-    assert card.get("title") == "Has Strange tracking"
+    assert card.get("title") == "Gadget"
 
 
 def test_australium_name_omits_strange_prefix(app):
@@ -298,9 +297,9 @@ def test_australium_name_omits_strange_prefix(app):
         context["user"] = app_module.normalize_user_payload(context["user"])
         html = render_template_string(HTML, **context)
     soup = BeautifulSoup(html, "html.parser")
-    title = soup.find("div", class_="item-name")
-    assert title is not None
-    assert title.text.strip() == "Australium Scattergun"
+    card = soup.find("div", class_="item-card")
+    assert card is not None
+    assert card.get("title") == "Australium Scattergun"
 
 
 def test_professional_killstreak_australium_title(app):
@@ -325,6 +324,6 @@ def test_professional_killstreak_australium_title(app):
         context["user"] = app_module.normalize_user_payload(context["user"])
         html = render_template_string(HTML, **context)
     soup = BeautifulSoup(html, "html.parser")
-    title = soup.find("div", class_="item-name")
-    assert title is not None
-    assert title.text.strip() == "Professional Killstreak Australium Scattergun"
+    card = soup.find("div", class_="item-card")
+    assert card is not None
+    assert card.get("title") == "Professional Killstreak Australium Scattergun"


### PR DESCRIPTION
## Summary
- support secondary quality colors on item cards and dual-color border rendering
- document dual-quality border behavior
- record change in changelog

## Testing
- `npx prettier --write templates/item_card.html static/style.css docs/ARCHITECTURE.md CHANGELOG.md`
- `npx eslint . && echo 'ESLint passed'`
- `pre-commit run --files templates/item_card.html static/style.css docs/ARCHITECTURE.md CHANGELOG.md` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68a4ab72ef908326b41c9304d8aa3202