### PR TITLE
style: separate item card ring from fill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,3 +105,4 @@ All notable changes to this project will be documented in this file.
 
 - 2025-08-19 - hide failed bucket when empty via toggleFailedBucket; documentation sync
 - 2025-08-19 - hide completed bucket when empty via updateBucketVisibility; documentation sync
+- 2025-08-19 - refine non-border-mode item card background; documentation sync

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -30,6 +30,7 @@ Sticky user headers now isolate their stacking context so they remain above item
 Each `.item-wrapper` now includes a `data-name` attribute so client-side scripts can filter items by name. `static/retry.js` rebinds these per-user searches after inventory refreshes, caching item names and handling legacy and new inventory containers.
 
 Item cards can display a split border in **Border Mode** when an item exposes or infers a secondary quality color. If the backend omits an explicit value, heuristics try common mixes (Unusual, then Genuine, then Strange) to derive an alternate hue. A centered conic gradient divides the ring along the top-left to bottom-right diagonal, filling the first half with the primary quality and the second with the alternate hue.
+Outside of Border Mode, item cards now darken the inner fill while keeping a bright quality-colored ring so items remain distinct without losing their quality identity.
 
 Item cards no longer render inline titles, keeping the grid clean; names appear only in the modal. Unusual effect icons are decorative overlays that ignore pointer events, and a JavaScript fallback removes the icon if it fails to load. Modal clicks are delegated from result containers so dynamically added cards remain interactive.
 

--- a/static/style.css
+++ b/static/style.css
@@ -327,6 +327,29 @@ body.compact .item-name {
 .item-card.trade-hold {
   border-color: #ff4040;
 }
+/* ===== Non-border-mode tweaks: separate ring vs inner background ===== */
+/* In normal mode, keep the border bright, but darken the inner fill so the
+   item stands out without losing the quality color identity. */
+body:not(.border-mode) .item-card {
+  --ring-w: 3px;
+  border-width: var(--ring-w);
+  border-style: solid;
+  border-color: var(--quality-color, #cf6a32);
+  position: relative;
+  background:
+    linear-gradient(var(--quality-bg, #111), var(--quality-bg, #111))
+      padding-box,
+    linear-gradient(
+        var(--quality-color, #cf6a32),
+        var(--quality-color, #cf6a32)
+      )
+      border-box;
+}
+
+/* Derive a slightly darker tone for the background */
+body:not(.border-mode) .item-card {
+  --quality-bg: color-mix(in srgb, var(--quality-color, #cf6a32) 60%, black);
+}
 .item-card.uncraftable {
   border-style: dashed;
   border-width: 2px;


### PR DESCRIPTION
## Summary
- refine item card rendering outside border mode so border uses quality color while inner background is darker
- document non-border-mode item card behavior
- update changelog

## Testing
- `npx --no-install prettier -w static/style.css docs/ARCHITECTURE.md CHANGELOG.md`
- `npx --no-install eslint .`
- `pre-commit run --files static/style.css docs/ARCHITECTURE.md CHANGELOG.md` *(fails: Missing cache/schema/*.json and module errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c1c958dc83268e1606dcc919408f