### PR TITLE
style: show dashed outline for uncraftable items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,3 +107,4 @@ All notable changes to this project will be documented in this file.
 - 2025-08-19 - hide completed bucket when empty via updateBucketVisibility; documentation sync
 - 2025-08-19 - refine non-border-mode item card background; documentation sync
 - 2025-08-19 - show dashed outline for uncraftable items; documentation sync
+- 2025-08-19 - refine border-mode dashed outline for uncraftable items; documentation sync

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -25,7 +25,7 @@ toggles for compact density and border-only quality modes, both persisted via
 `localStorage` and reflected through `aria-pressed` states and descriptive titles for accessibility.
 
 Legacy header toggles are hard-hidden in favor of the new floating settings menu, which synchronizes with the existing body classes, mirrors legacy icons into the menu, and keeps display options consistent on all layouts.
-Uncraftable items now display a dashed outline in the item's primary quality color. In normal mode the painted ring is removed so the dashed border stays visible, while in border mode any secondary-color wedges are suppressed.
+Uncraftable items now display a dashed outline in the item's primary quality color. In normal mode the painted ring is removed so the dashed border stays visible, while in border mode all painted rings and overlay wedges are suppressed so the dashed stroke remains unobstructed.
 Sticky user headers now isolate their stacking context so they remain above item cards and prices while scrolling.
 Each `.item-wrapper` now includes a `data-name` attribute so client-side scripts can filter items by name. `static/retry.js` rebinds these per-user searches after inventory refreshes, caching item names and handling legacy and new inventory containers.
 

--- a/static/style.css
+++ b/static/style.css
@@ -364,12 +364,19 @@ body:not(.border-mode) .item-card.uncraftable {
 
 /* Border mode: dashed outline; no conic wedges / split ring. */
 body.border-mode .item-card.uncraftable {
+  /* Always show a true dashed outline in border mode */
   border-style: dashed !important;
-  border-width: 3px;
-  border-color: var(--quality-color, #cf6a32);
+  border-width: 3px !important;
+  border-color: var(--quality-color, #cf6a32) !important;
+  /* Remove any painted rings so the dashed stroke is visible */
+  background: var(--tf2-card, #0f1216) !important;
+  background-clip: padding-box;
+  box-shadow: none !important;
 }
-body.border-mode .item-card.uncraftable.has-dual-quality::after {
-  content: none !important; /* disable the secondary-color wedges */
+/* Disable any ring overlays that could cover the dashed stroke */
+body.border-mode .item-card.uncraftable::before,
+body.border-mode .item-card.uncraftable::after {
+  content: none !important;
 }
 
 /* ===== Border Mode ring (rounded) ======================================= */


### PR DESCRIPTION
## Summary
- show dashed outline for uncraftable items in item cards across modes
- document uncraftable item border behavior
- add changelog entry

## Testing
- `npx prettier static/style.css docs/ARCHITECTURE.md CHANGELOG.md --write`
- `npx eslint .`
- `pre-commit run black --files static/style.css docs/ARCHITECTURE.md CHANGELOG.md`
- `pre-commit run ruff --files static/style.css docs/ARCHITECTURE.md CHANGELOG.md`


------
https://chatgpt.com/codex/tasks/task_e_68a4c71219f48326a09f594031d60f20