### PR TITLE
fix: refine uncraftable border mode style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,3 +108,4 @@ All notable changes to this project will be documented in this file.
 - 2025-08-19 - refine non-border-mode item card background; documentation sync
 - 2025-08-19 - show dashed outline for uncraftable items; documentation sync
 - 2025-08-19 - refine border-mode dashed outline for uncraftable items; documentation sync
+- 2025-08-20 - remove ring background to reveal dashed uncraftable outline; documentation sync

--- a/static/style.css
+++ b/static/style.css
@@ -368,8 +368,10 @@ body.border-mode .item-card.uncraftable {
   border-style: dashed !important;
   border-width: 3px !important;
   border-color: var(--quality-color, #cf6a32) !important;
-  /* Remove any painted rings so the dashed stroke is visible */
-  background: var(--tf2-card, #0f1216) !important;
+  /* Remove any painted rings so the dashed stroke is visible
+     and make the inner background match other cards */
+  background: none !important;
+  background-color: inherit !important; /* use body.border-mode .item-card background */
   background-clip: padding-box;
   box-shadow: none !important;
 }


### PR DESCRIPTION
## Summary
- expose dashed border on uncraftable items by clearing ring background
- document CSS tweak in changelog

## Testing
- `npx --yes prettier@latest static/style.css CHANGELOG.md -w`
- `npx --yes eslint@latest .`
- `SKIP_VALIDATE=1 pre-commit run --files static/style.css CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_68a52411b4e483269f6f9ac935e6d941