### PR TITLE
Add toast notifications for consecutive refresh failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,3 +109,4 @@ All notable changes to this project will be documented in this file.
 - 2025-08-19 - show dashed outline for uncraftable items; documentation sync
 - 2025-08-19 - refine border-mode dashed outline for uncraftable items; documentation sync
 - 2025-08-20 - remove ring background to reveal dashed uncraftable outline; documentation sync
+- 2025-08-20 - add toast notifications for repeated refresh failures; documentation sync

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -18,6 +18,9 @@ buttons. Font Awesome icons are loaded via CDN and injected to keep gear, Compac
 
 The server exposes REST endpoints for initiating scans and retrying failed ones.
 Client-side JavaScript handles form submission, retry flows, and dynamic UI updates.
+A toast container pinned to the bottom-left surfaces ephemeral messages. After
+ten consecutive refresh failures, a toast links to the Steam API health page so
+users can quickly check whether upstream services are degraded.
 The Steam ID input auto-focuses on load via HTML `autofocus` with a JavaScript
 fallback to ensure it's ready for pasting immediately.
 `static/ui.js` adds per-user inventory search with sticky headers and provides global

--- a/docs/DEVELOPERS_GUIDE.md
+++ b/docs/DEVELOPERS_GUIDE.md
@@ -18,3 +18,4 @@
 - Modal clicks are delegated from result containers. Ensure overlays and badges do not capture pointer events.
 - Unusual effect icons use empty alt text, ignore pointer events, and a helper removes the image if loading fails.
 - Wrap icon elements in `.item-media` to center content and place particle overlays behind; include `onerror="this.remove()"` on effect images so missing assets vanish cleanly.
+- Use `showToast(message, opts)` to surface transient messages; repeated refresh failures trigger a toast linking to the Steam API health page.

--- a/docs/FUNCTIONS_REFERENCE.md
+++ b/docs/FUNCTIONS_REFERENCE.md
@@ -38,3 +38,10 @@
 | `toggleFailedBucket(failures)`          | Hide or show the Failed results bucket when empty.    | `failures` (number) – count of failed cards          | `void`   | `static/retry.js` |
 
 _Updated_: `updateRefreshButton()` now calls `updateBucketVisibility()` to hide empty buckets.
+
+| Function                                               | Purpose                                                                                       | Parameters                                                                                                   | Returns  | Used In           |
+| ------------------------------------------------------ | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | -------- | ----------------- |
+| `showToast(message, opts)`                             | Display a temporary toast notification with an optional link and auto-dismiss.                | `message` (string) – text to show; `opts` (object) – `{href?: string, linkText?: string, duration?: number}` | `void`   | `static/retry.js` |
+| `getConsecutiveFailures()`                             | Retrieve the current consecutive refresh failure count from `localStorage`.                   | –                                                                                                            | `number` | `static/retry.js` |
+| `setConsecutiveFailures(n)`                            | Persist a new consecutive failure count into `localStorage`.                                  | `n` (number) – new count                                                                                     | `void`   | `static/retry.js` |
+| `maybeShowSteamHealthToast(prevFailures, newFailures)` | Increment or reset consecutive failure tracking and toast Steam API health every 10 failures. | `prevFailures` (number) – failure count before refresh; `newFailures` (number) – count after refresh         | `void`   | `static/retry.js` |

--- a/docs/SYSTEM_MAP.md
+++ b/docs/SYSTEM_MAP.md
@@ -1,8 +1,8 @@
 # System Map
 
 - **app.py** – Flask application with routes for scanning users and retrying failed scans.
-- **templates/index.html** – Displays input form, two result buckets, floating top/refresh buttons, and a settings gear.
+- **templates/index.html** – Displays input form, two result buckets, a toast container, floating top/refresh buttons, and a settings gear.
 - **static/submit.js** – Handles form submission, defines `addCardToBucket`, and keeps public cards before private ones in the Completed bucket.
-- **static/retry.js** – Manages retry logic, modal interactions, per-user search binding, floating controls, and provides an `addCardToBucket` fallback.
-- **static/style.css** – Provides styling including bucket layout, jump button, floating controls, the settings menu, and hard-hides legacy header toggles. Loads Font Awesome for icons.
+- **static/retry.js** – Manages retry logic, modal interactions, per-user search binding, floating controls, toast notifications, and provides an `addCardToBucket` fallback.
+- **static/style.css** – Provides styling including bucket layout, jump button, floating controls, toast notifications, the settings menu, and hard-hides legacy header toggles. Loads Font Awesome for icons.
 - **static/ui.js** – Provides global display toggles, floating settings menu logic, injects Font Awesome gear, Compact, and Border Mode icons, mirrors legacy icons, and extends handler binding.

--- a/static/style.css
+++ b/static/style.css
@@ -1144,3 +1144,54 @@ button[data-role="toggle-border"] {
     left: calc(12px + env(safe-area-inset-left, 0px));
   }
 }
+
+/* ===== Toasts ===== */
+#toast-container {
+  position: fixed;
+  left: calc(16px + env(safe-area-inset-left, 0px));
+  bottom: calc(
+    84px + env(safe-area-inset-bottom, 0px)
+  ); /* clears the gear FAB */
+  display: grid;
+  gap: 10px;
+  z-index: 2500;
+}
+.toast {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  max-width: min(90vw, 640px);
+  padding: 12px 14px;
+  border-radius: 12px;
+  background: var(--tf2-bg-2, #182028);
+  border: 1px solid var(--tf2-ring, rgba(255, 255, 255, 0.12));
+  color: var(--tf2-text, #e9edf3);
+  box-shadow: 0 16px 46px rgba(0, 0, 0, 0.55);
+  opacity: 0;
+  transform: translateY(8px);
+  transition:
+    opacity 0.18s ease,
+    transform 0.18s ease;
+}
+.toast.show {
+  opacity: 1;
+  transform: translateY(0);
+}
+.toast a {
+  color: #8ab4ff;
+  text-decoration: underline;
+}
+.toast .close {
+  margin-left: auto;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 8px;
+}
+.toast .close:hover {
+  background: rgba(255, 255, 255, 0.06);
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -204,6 +204,10 @@
           </div>
         </dialog>
       </main>
+
+      <!-- Toasts (bottom-left). Kept outside main so it overlays reliably. -->
+      <div id="toast-container" aria-live="polite" aria-atomic="true"></div>
+
       <footer class="site-footer">
         <p class="attribution">
           Pricing and particles provided by


### PR DESCRIPTION
## Summary
- add toast container and styles for bottom-left notifications
- show Steam API health toast after 10 consecutive refresh failures
- document toast utilities and sync developer docs

## Testing
- `npx prettier --write templates/index.html static/style.css static/retry.js docs/ARCHITECTURE.md docs/FUNCTIONS_REFERENCE.md docs/DEVELOPERS_GUIDE.md docs/SYSTEM_MAP.md CHANGELOG.md`
- `npx eslint .`
- `SKIP_VALIDATE=1 pre-commit run --files templates/index.html static/style.css static/retry.js docs/ARCHITECTURE.md docs/FUNCTIONS_REFERENCE.md docs/DEVELOPERS_GUIDE.md docs/SYSTEM_MAP.md CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_68a59a17864083268386dd53cf9189e1