### PR TITLE
feat: add festivized badge support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,3 +109,4 @@ All notable changes to this project will be documented in this file.
 - 2025-08-19 - show dashed outline for uncraftable items; documentation sync
 - 2025-08-19 - refine border-mode dashed outline for uncraftable items; documentation sync
 - 2025-08-20 - remove ring background to reveal dashed uncraftable outline; documentation sync
+- 2025-08-20 - Festivized badge: backend detects defindex 2053 and template renders a small image badge (no glow); documentation sync

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,3 +110,4 @@ All notable changes to this project will be documented in this file.
 - 2025-08-19 - refine border-mode dashed outline for uncraftable items; documentation sync
 - 2025-08-20 - remove ring background to reveal dashed uncraftable outline; documentation sync
 - 2025-08-20 - Festivized badge: backend detects defindex 2053 and template renders a small image badge (no glow); documentation sync
+- 2025-08-20 - Align festive badge with other badges (top-right row) and fine-tune spacing/sizing; documentation sync

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -35,3 +35,5 @@ Outside of Border Mode, item cards now darken the inner fill while keeping a bri
 Item cards no longer render inline titles, keeping the grid clean; names appear only in the modal. Unusual effect icons are decorative overlays that ignore pointer events, and a JavaScript fallback removes the icon if it fails to load. Modal clicks are delegated from result containers so dynamically added cards remain interactive.
 
 Card media sit inside an `.item-media` wrapper that centers the main icon while keeping particle overlays behind it; failed effect images remove themselves to avoid broken placeholders.
+
+Festivized weapons (attribute defindex 2053) are detected during inventory processing. The template renders a small festive badge when this flag is present.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -36,4 +36,4 @@ Item cards no longer render inline titles, keeping the grid clean; names appear 
 
 Card media sit inside an `.item-media` wrapper that centers the main icon while keeping particle overlays behind it; failed effect images remove themselves to avoid broken placeholders.
 
-Festivized weapons (attribute defindex 2053) are detected during inventory processing. The template renders a small festive badge when this flag is present.
+Festivized weapons (attribute defindex 2053) are detected during inventory processing. The template renders a small festive badge in the top-right badge row when this flag is present.

--- a/docs/FUNCTIONS_REFERENCE.md
+++ b/docs/FUNCTIONS_REFERENCE.md
@@ -38,3 +38,11 @@
 | `toggleFailedBucket(failures)`          | Hide or show the Failed results bucket when empty.    | `failures` (number) – count of failed cards          | `void`   | `static/retry.js` |
 
 _Updated_: `updateRefreshButton()` now calls `updateBucketVisibility()` to hide empty buckets.
+
+### Backend Utilities
+
+| Function                         | Purpose                                                               | Parameters                           | Returns                       | Used In                        |
+| -------------------------------- | --------------------------------------------------------------------- | ------------------------------------ | ----------------------------- | ------------------------------ |
+| `_attributes_iter(attrs)`        | Safely iterate a maybe-missing, maybe-non-list attributes collection. | `attrs` (Any) – attributes structure | `Iterable[Mapping[str, Any]]` | `utils/schema_provider.py`     |
+| `has_attribute(attrs, defindex)` | True if any attribute has the given defindex.                         | `attrs` (Any); `defindex` (int)      | `bool`                        | `utils/schema_provider.py`     |
+| `is_festivized(attrs)`           | Detects Festivized weapons by attribute 2053.                         | `attrs` (Any)                        | `bool`                        | `utils/inventory_processor.py` |

--- a/static/style.css
+++ b/static/style.css
@@ -463,6 +463,22 @@ body.border-mode .item-card.has-dual-quality {
   pointer-events: none;
 }
 
+/* Festivized badge — image, no glow, sized to match other badges by height */
+.badge.festive {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0; /* keep tight like other badges */
+  background: transparent; /* no box background */
+}
+.badge.festive .festive-icon {
+  height: 14px; /* align with other ~14px badges */
+  width: auto; /* preserve 32x22 aspect ratio */
+  display: block;
+  object-fit: contain;
+  filter: none; /* no glow */
+}
+
 @media (max-width: 480px) {
   .badge-icon {
     width: 11px;

--- a/static/style.css
+++ b/static/style.css
@@ -433,10 +433,11 @@ body.border-mode .item-card.has-dual-quality {
 }
 .item-badges {
   position: absolute;
-  right: 2px;
-  bottom: 2px;
+  top: 6px; /* align with chevrons row */
+  right: 6px;
   display: flex;
-  gap: 1px;
+  align-items: center;
+  gap: 6px; /* a little breathing room between badges */
   pointer-events: none;
   font-size: 14px;
   z-index: 3;
@@ -472,7 +473,7 @@ body.border-mode .item-card.has-dual-quality {
   background: transparent; /* no box background */
 }
 .badge.festive .festive-icon {
-  height: 14px; /* align with other ~14px badges */
+  height: 13px; /* nudge down to visually match chevrons */
   width: auto; /* preserve 32x22 aspect ratio */
   display: block;
   object-fit: contain;

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -76,6 +76,19 @@ full_title = (title_parts + [base]) | join(' ') %}
       style="background-color: {{ item.paint_hex }};"
       title="Paint: {{ item.paint_name }}"
     ></span>
+    {% endif %} {# Festivized badge (uses small PNG, no glow). Backed by server
+    flag. #} {% if item.is_festivized %}
+    <span class="badge festive" title="Festivized" aria-label="Festivized">
+      <img
+        src="/static/images/logos/festive.png"
+        class="festive-icon"
+        alt=""
+        width="32"
+        height="22"
+        decoding="async"
+        loading="lazy"
+      />
+    </span>
     {% endif %} {% for badge in item.badges %} {% if badge.type != 'statclock'
     and badge.icon != '🎨' %} {% if badge.type == 'killstreak' %}
     <span class="badge" data-icon="{{ badge.icon }}" title="{{ badge.title }}">

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from . import local_data
 from .helpers import best_match_from_keys
+from .schema_provider import is_festivized
 from .valuation_service import ValuationService, get_valuation_service
 from .wear_helpers import _wear_tier, _decode_seed_info
 from .constants import (
@@ -1033,6 +1034,8 @@ def _process_item(
     if valuation_service is None:
         valuation_service = get_valuation_service()
 
+    attrs = asset.get("attributes", [])
+
     origin_raw = asset.get("origin")
     tradable_raw = asset.get("tradable", 1)
     trade_hold_ts = _trade_hold_timestamp(asset)
@@ -1288,6 +1291,8 @@ def _process_item(
         "original_name": original_name,
         "base_name": base_name,
         "display_name": display_name,
+        "attributes": attrs,
+        "is_festivized": bool(is_festivized(attrs)),
         "is_australium": bool(is_australium),
         "quality": q_name,
         "quality_color": q_col,

--- a/utils/schema_provider.py
+++ b/utils/schema_provider.py
@@ -4,10 +4,41 @@ import json
 import logging
 import time
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Iterable, Mapping
 
 import httpx
 import requests
+
+FESTIVIZED_DEFINDEX = 2053  # Valve attribute that marks a Festivized weapon
+
+
+def _attributes_iter(attrs: Any) -> Iterable[Mapping[str, Any]]:
+    """
+    Safely iterate a maybe-missing, maybe-non-list attributes collection.
+    Returns [] if attrs is falsy.
+    """
+    if not attrs:
+        return []
+    if isinstance(attrs, dict):
+        # Some payloads use a dict keyed by index; flatten values.
+        return attrs.values()
+    return attrs  # assume iterable of dicts
+
+
+def has_attribute(attrs: Any, defindex: int) -> bool:
+    """True if any attribute has the given defindex."""
+    for a in _attributes_iter(attrs):
+        try:
+            if int(a.get("defindex")) == int(defindex):
+                return True
+        except Exception:
+            continue
+    return False
+
+
+def is_festivized(attrs: Any) -> bool:
+    """Festivized is defindex 2053."""
+    return has_attribute(attrs, FESTIVIZED_DEFINDEX)
 
 
 class SchemaProvider:


### PR DESCRIPTION
## Summary
- detect defindex 2053 to flag Festivized items
- surface festivized flag in item normalization and render festive badge
- document festive badge flow and schema helpers

## Testing
- `npx prettier -w CHANGELOG.md templates/item_card.html static/style.css docs/ARCHITECTURE.md docs/FUNCTIONS_REFERENCE.md`
- `npx eslint .`
- `pre-commit run --files CHANGELOG.md docs/ARCHITECTURE.md docs/FUNCTIONS_REFERENCE.md static/style.css templates/item_card.html utils/inventory_processor.py utils/schema_provider.py`

------
https://chatgpt.com/codex/tasks/task_e_68a5fc53ff108326b37d2fc061cc5f55