### PR TITLE
Hide completed bucket when all scans succeed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,3 +118,4 @@ All notable changes to this project will be documented in this file.
 - 2025-08-21 - Replace 🔄 emoji in scanning toast with Font Awesome rotating spinner; documentation sync
 - 2025-08-21 - Ensure toast spinner uses same style as Retry pill button
 - 2025-08-21 - Add CSS alignment for toast spinner icon
+- [2025-08-20] - Hide Completed bucket when all scans succeed; documentation synchronized.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,7 +3,7 @@
 This project is an async-enabled Flask application that scans Team Fortress 2 inventories.
 The frontend renders two result buckets:
 
-- **Completed** – successful inventory scans (hidden when empty)
+- **Completed** – successful inventory scans (hidden when empty or when all scans succeed)
 - **Failed** – scans that could not be processed (hidden when empty)
 
 New results are appended to the appropriate bucket. The Completed bucket keeps

--- a/docs/FUNCTIONS_REFERENCE.md
+++ b/docs/FUNCTIONS_REFERENCE.md
@@ -6,7 +6,7 @@
 | `fetchUserCard(id)`                      | Fetch a single user card from the server and append it to the correct bucket.                                 | `id` (string) – Steam identifier                                                   | `Promise<void>` | `static/submit.js`                    |
 | `handleItemClick(event)`                 | Display the item modal using data embedded on the card, logging malformed payloads.                           | `event` (MouseEvent \| HTMLElement) – click event or card element                  | `void`          | `static/retry.js`                     |
 | `appendFestivizedToModal(modalEl, item)` | Append a compact 'Festivized' row to modal details before History when applicable.                            | `modalEl` (HTMLElement) – modal container; `item` (object) – item data             | `void`          | `static/retry.js`                     |
-| `handleSubmit(e)`                        | Process form submission, show the scan toast, and launch parallel scans.                           | `e` (SubmitEvent) – form event                                                     | `Promise<void>`    | `static/submit.js`                    |
+| `handleSubmit(e)`                        | Process form submission, show the scan toast, and launch parallel scans.                                      | `e` (SubmitEvent) – form event                                                     | `Promise<void>` | `static/submit.js`                    |
 | `retryInventory(id)`                     | Retry a failed scan and append the updated card to the proper bucket.                                         | `id` (string) – Steam identifier                                                   | `Promise<void>` | `static/retry.js`                     |
 | `refreshAll()`                           | Batch retry all failed scans with progress feedback.                                                          | –                                                                                  | `Promise<void>` | `static/retry.js`                     |
 | `attachItemModal()`                      | Delegate modal click handling from result containers and attach effect fallback.                              | –                                                                                  | `void`          | `static/retry.js`                     |
@@ -31,14 +31,15 @@
 
 ### Newly Added
 
-| Function                                | Purpose                                               | Parameters                                                        | Returns  | Used In           |
-| --------------------------------------- | ----------------------------------------------------- | ----------------------------------------------------------------- | -------- | ----------------- |
-| `getCompletedUsers()`                   | Count user cards in the Completed bucket.             | –                                                                 | `number` | `static/retry.js` |
-| `toggleCompletedBucket(completedCount)` | Hide or show the Completed results bucket when empty. | `completedCount` (number) – count of completed cards              | `void`   | `static/retry.js` |
-| `updateBucketVisibility()`              | Toggle visibility for Completed and Failed buckets.   | –                                                                 | `void`   | `static/retry.js` |
-| `toggleFailedBucket(failures)`          | Hide or show the Failed results bucket when empty.    | `failures` (number) – count of failed cards                       | `void`   | `static/retry.js` |
-| `updateScanToast(current, total)`       | Display scanning progress with a rotating spinner.    | `current` (number) – current scan; `total` (number) – total scans | `void`   | `static/retry.js` |
-| `hideScanToast()`                       | Hide the scan progress toast after scans finish.      | –                                                                 | `void`   | `static/retry.js` |
+| Function                                | Purpose                                               | Parameters                                                        | Returns  | Used In                               |
+| --------------------------------------- | ----------------------------------------------------- | ----------------------------------------------------------------- | -------- | ------------------------------------- |
+| `getCompletedUsers()`                   | Count user cards in the Completed bucket.             | –                                                                 | `number` | `static/retry.js`                     |
+| `toggleCompletedBucket(completedCount)` | Hide or show the Completed results bucket when empty. | `completedCount` (number) – count of completed cards              | `void`   | `static/retry.js`                     |
+| `updateBucketVisibility()`              | Toggle visibility for Completed and Failed buckets.   | –                                                                 | `void`   | `static/retry.js`                     |
+| `toggleFailedBucket(failures)`          | Hide or show the Failed results bucket when empty.    | `failures` (number) – count of failed cards                       | `void`   | `static/retry.js`                     |
+| `updateScanToast(current, total)`       | Display scanning progress with a rotating spinner.    | `current` (number) – current scan; `total` (number) – total scans | `void`   | `static/retry.js`                     |
+| `hideScanToast()`                       | Hide the scan progress toast after scans finish.      | –                                                                 | `void`   | `static/retry.js`                     |
+| `maybeHideCompletedBucket()`            | Hide the Completed bucket if it contains all results. | –                                                                 | `void`   | `static/retry.js`, `static/submit.js` |
 
 _Updated_: `updateRefreshButton()` now calls `updateBucketVisibility()` to hide empty buckets.
 

--- a/static/retry.js
+++ b/static/retry.js
@@ -216,6 +216,33 @@ function updateBucketVisibility() {
 }
 
 /**
+ * Hide the Completed bucket if all inventories landed in it.
+ * Called after scans finish to collapse redundant bucket headings.
+ *
+ * @returns {void} No return value.
+ * @example
+ * maybeHideCompletedBucket();
+ */
+export function maybeHideCompletedBucket() {
+  const completedBucket = document.getElementById("completed-results");
+  const failedBucket = document.getElementById("failed-results");
+  const publicBucket = document.getElementById("public-results");
+  const privateBucket = document.getElementById("private-results");
+
+  if (!completedBucket) return;
+
+  const hasCompleted = completedBucket.querySelector(".user-card");
+  const hasOthers =
+    (failedBucket && failedBucket.querySelector(".user-card")) ||
+    (publicBucket && publicBucket.querySelector(".user-card")) ||
+    (privateBucket && privateBucket.querySelector(".user-card"));
+
+  if (hasCompleted && !hasOthers) {
+    completedBucket.classList.add("hidden");
+  }
+}
+
+/**
  * Enable or disable the "Refresh Failed" buttons based on failures.
  * Toggles visibility of the floating refresh control.
  *
@@ -317,8 +344,6 @@ function attachHandlers() {
   attachUserSearch();
 }
 
-/**
- * Per-user inventory search that filters item wrappers under each user card.
 /**
  * Per-user inventory search that filters item wrappers under each user card.
  * Falls back to parsing `.item-card[data-item]` when `data-name` is unavailable.

--- a/static/submit.js
+++ b/static/submit.js
@@ -181,12 +181,14 @@ async function handleSubmit(e) {
       if (window.updateScanToast) {
         window.updateScanToast(++current, total);
       }
-    })
+    }),
   );
 
   if (window.hideScanToast) {
     window.hideScanToast();
   }
+
+  import("./retry.js").then((m) => m.maybeHideCompletedBucket());
 }
 
 document.addEventListener("DOMContentLoaded", () => {

--- a/templates/index.html
+++ b/templates/index.html
@@ -278,8 +278,14 @@
     </script>
     <script src="{{ url_for('static', filename='lazyload.js') }}"></script>
     <script src="{{ url_for('static', filename='modal.js') }}"></script>
-    <script src="{{ url_for('static', filename='retry.js') }}"></script>
-    <script src="{{ url_for('static', filename='submit.js') }}"></script>
+    <script
+      type="module"
+      src="{{ url_for('static', filename='retry.js') }}"
+    ></script>
+    <script
+      type="module"
+      src="{{ url_for('static', filename='submit.js') }}"
+    ></script>
     <script src="{{ url_for('static', filename='ui.js') }}"></script>
     <script>
       function attachScrollButtons() {


### PR DESCRIPTION
## Summary
- hide Completed results bucket when it holds every scan result
- call `maybeHideCompletedBucket` after scan completion and load scripts as modules
- document new bucket behavior and function

## Testing
- `npx prettier --write static/retry.js static/submit.js templates/index.html docs/ARCHITECTURE.md docs/FUNCTIONS_REFERENCE.md CHANGELOG.md`
- `npx eslint static/retry.js static/submit.js`
- `pre-commit run --files CHANGELOG.md docs/ARCHITECTURE.md docs/FUNCTIONS_REFERENCE.md static/retry.js static/submit.js templates/index.html` *(fails: missing schema files, pytest argument error)*

------
https://chatgpt.com/codex/tasks/task_e_68a62c4fe8748326bdd8268293c81515