### PR TITLE
Enforce Unusual item card precedence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,3 +121,5 @@ All notable changes to this project will be documented in this file.
 - 2025-08-21 - Add CSS alignment for toast spinner icon
 - 2025-08-21 - restore get_valuation_service compat shim; documentation sync
 - 2025-08-21 - detect Unusual and Strange items via attribute defindexes and expose quality flags; documentation sync
+- 2025-08-22 - enforce Unusual border/quality precedence for decorated items; documentation sync
+- 2025-08-22 - re-expose \_extract_paintkit for tests; documentation sync

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -31,6 +31,7 @@ Sticky user headers now isolate their stacking context so they remain above item
 Each `.item-wrapper` now includes a `data-name` attribute so client-side scripts can filter items by name. `static/retry.js` rebinds these per-user searches after inventory refreshes, caching item names and handling legacy and new inventory containers.
 
 Item cards can display a split border in **Border Mode** when an item exposes or infers a secondary quality color. If the backend omits an explicit value, heuristics try common mixes (Unusual, then Genuine, then Strange) to derive an alternate hue. A centered conic gradient divides the ring along the top-left to bottom-right diagonal, filling the first half with the primary quality and the second with the alternate hue.
+Unusual-quality items take precedence: if an item is Unusual or a decorated weapon with an unusual effect, the card forces the Unusual purple border and quality color, ignoring secondary styling.
 Outside of Border Mode, item cards now darken the inner fill while keeping a bright quality-colored ring so items remain distinct without losing their quality identity.
 
 The inventory enrichment logic lives in the `utils/inventory/` package, which splits

--- a/docs/DEVELOPERS_GUIDE.md
+++ b/docs/DEVELOPERS_GUIDE.md
@@ -22,4 +22,5 @@
 - Uncraftable items rely on dashed borders only; the inner gray ring has been removed to reduce visual clutter.
 - Modal clicks are delegated from result containers. Ensure overlays and badges do not capture pointer events.
 - Unusual effect icons use empty alt text, ignore pointer events, and a helper removes the image if loading fails.
+- Unusual items take precedence over decorated styling; when an item is Unusual or a decorated weapon with an unusual effect, apply `quality-unusual` and `border-unusual` classes and omit dual-quality accents.
 - Wrap icon elements in `.item-media` to center content and place particle overlays behind; include `onerror="this.remove()"` on effect images so missing assets vanish cleanly.

--- a/docs/SYSTEM_MAP.md
+++ b/docs/SYSTEM_MAP.md
@@ -2,6 +2,7 @@
 
 - **app.py** – Flask application with routes for scanning users and retrying failed scans.
 - **templates/index.html** – Displays input form, two result buckets, floating top/refresh buttons, and a settings gear.
+- **templates/item_card.html** – Renders individual item cards and enforces Unusual border and quality precedence.
 - **static/submit.js** – Handles form submission, defines `addCardToBucket`, and keeps public cards before private ones in the Completed bucket.
 - **static/retry.js** – Manages retry logic, modal interactions, per-user search binding, floating controls, and provides an `addCardToBucket` fallback.
 - **static/style.css** – Provides styling including bucket layout, jump button, floating controls, the settings menu, and hard-hides legacy header toggles. Loads Font Awesome for icons.

--- a/static/style.css
+++ b/static/style.css
@@ -308,6 +308,21 @@ button {
   background-color: var(--quality-color, #1e1e1e);
   position: relative; /* ensure badges overlay */
 }
+
+/* --- Minimal Unusual precedence support --- */
+.item-card.border-unusual {
+  border-color: #8650ac !important;
+}
+
+.item-card.quality-unusual {
+  --quality-color: #8650ac;
+  --quality-color-rgb: 134, 80, 172;
+}
+
+/* Ensure decorated/dual styles cannot override Unusual when both classes appear */
+.item-card.quality-unusual.has-dual-quality {
+  --quality-alt: #8650ac;
+}
 /* Base fill in border mode */
 body.border-mode .item-card {
   --ring-w: 4px; /* ring thickness */

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -49,9 +49,15 @@ full_title = (title_parts + [base]) | join(' ') %}
   {% endif %}
 {% endif %}
 
+{# Minimal precedence: force Unusual styling when decorated with an effect #}
+{% set is_unusual_render = item.is_unusual or (item.is_decorated and item.unusual_effect_id) %}
+{% if is_unusual_render %}
+  {% set alt_q = None %}
+{% endif %}
+
 <div
-  class="item-card{% if item.untradable_hold %} trade-hold{% endif %}{% if item.uncraftable %} uncraftable{% endif %}{% if item.has_strange_tracking %} elevated-strange{% endif %}{% if alt_q %} has-dual-quality{% endif %}"
-  style="--quality-color: {{ item.quality_color }};{% if alt_q %} --quality-alt: {{ alt_q }};{% endif %} border-color: {{ item.border_color or item.quality_color }};"
+  class="item-card{% if is_unusual_render %} quality-unusual border-unusual{% endif %}{% if item.untradable_hold %} trade-hold{% endif %}{% if item.uncraftable %} uncraftable{% endif %}{% if item.has_strange_tracking %} elevated-strange{% endif %}{% if alt_q %} has-dual-quality{% endif %}"
+  style="--quality-color: {% if is_unusual_render %}#8650AC{% else %}{{ item.quality_color }}{% endif %};{% if alt_q %} --quality-alt: {{ alt_q }};{% endif %} border-color: {% if is_unusual_render %}#8650AC{% else %}{{ item.border_color or item.quality_color }}{% endif %};"
   title="{{ full_title }}"
   {%
   if

--- a/utils/inventory_processor.py
+++ b/utils/inventory_processor.py
@@ -4,10 +4,12 @@ from .inventory.api import (
     run_enrichment_test,
     get_valuation_service,
 )
+from .inventory.extractors_paint_and_wear import _extract_paintkit
 
 __all__ = [
     "enrich_inventory",
     "process_inventory",
     "run_enrichment_test",
     "get_valuation_service",
+    "_extract_paintkit",
 ]


### PR DESCRIPTION
## Summary
- Ensure Unusual items override decorated styling with purple border and quality
- Document Unusual rendering precedence and export `_extract_paintkit`

## Testing
- `prettier templates/item_card.html static/style.css docs/ARCHITECTURE.md docs/DEVELOPERS_GUIDE.md docs/SYSTEM_MAP.md CHANGELOG.md --write`
- `prettier utils/inventory_processor.py --write` *(fails: No parser could be inferred)*
- `npx eslint .`
- `pre-commit run --files templates/item_card.html static/style.css docs/ARCHITECTURE.md docs/DEVELOPERS_GUIDE.md docs/SYSTEM_MAP.md CHANGELOG.md utils/inventory_processor.py cache/schema/attributes.json cache/schema/items.json cache/schema/qualities.json cache/schema/particles.json cache/currencies.json` *(fails: pytest test failures)*
- `pytest` *(fails: multiple inventory_processor tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a8342ede10832693496c75b71ce2b0