### PR TITLE
feat: add border color variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,3 +121,4 @@ All notable changes to this project will be documented in this file.
 - 2025-08-21 - Add CSS alignment for toast spinner icon
 - 2025-08-21 - restore get_valuation_service compat shim; documentation sync
 - 2025-08-21 - detect Unusual and Strange items via attribute defindexes and expose quality flags; documentation sync
+- 2025-08-22 - compute border color variables for item cards and add CSS support; documentation sync

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,3 +122,4 @@ All notable changes to this project will be documented in this file.
 - 2025-08-21 - restore get_valuation_service compat shim; documentation sync
 - 2025-08-21 - detect Unusual and Strange items via attribute defindexes and expose quality flags; documentation sync
 - 2025-08-22 - compute border color variables for item cards and add CSS support; documentation sync
+- 2025-08-22 - enable Jinja 'do' extension for template list operations and update warpaint script import; documentation sync

--- a/app.py
+++ b/app.py
@@ -56,6 +56,12 @@ TEST_API_RESULTS_DIR: Path | None = None
 STEAM_API_KEY = os.environ["STEAM_API_KEY"]
 
 app = Flask(__name__)
+# Enable Jinja "do" extension so templates can use `{% do %}` for side-effects (e.g., list.append)
+try:
+    app.jinja_env.add_extension("jinja2.ext.do")
+except Exception:
+    # If the environment lacks the extension, fail gracefully (templates that use `{% do %}` would still error)
+    app.logger.warning("Jinja 'do' extension not available; templates using `{% do %}` may fail.")
 
 MAX_MERGE_MS = 0
 local_data.load_files(auto_refetch=True, verbose=ARGS.verbose)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -33,6 +33,8 @@ Each `.item-wrapper` now includes a `data-name` attribute so client-side scripts
 Item cards can display a split border in **Border Mode** when an item exposes or infers a secondary quality color. If the backend omits an explicit value, heuristics try common mixes (Unusual, then Genuine, then Strange) to derive an alternate hue. A centered conic gradient divides the ring along the top-left to bottom-right diagonal, filling the first half with the primary quality and the second with the alternate hue.
 Outside of Border Mode, item cards now darken the inner fill while keeping a bright quality-colored ring so items remain distinct without losing their quality identity.
 
+The template now sets `--border-primary` and `--border-alt` CSS variables on each item card. Unusual coloration takes precedence, even for decorated skins with effects, while the alternate ring defaults to Strange orange when applicable.
+
 The inventory enrichment logic lives in the `utils/inventory/` package, which splits
 helpers into focused modules for attribute-class caching, extraction routines, and
 the thin processing core.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -35,6 +35,8 @@ Outside of Border Mode, item cards now darken the inner fill while keeping a bri
 
 The template now sets `--border-primary` and `--border-alt` CSS variables on each item card. Unusual coloration takes precedence, even for decorated skins with effects, while the alternate ring defaults to Strange orange when applicable.
 
+The Flask app enables Jinja's optional `do` extension so templates can execute side-effectful statements, such as building class lists with `{% do %}`.
+
 The inventory enrichment logic lives in the `utils/inventory/` package, which splits
 helpers into focused modules for attribute-class caching, extraction routines, and
 the thin processing core.

--- a/scripts/list_warpaints.py
+++ b/scripts/list_warpaints.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from utils.inventory_processor import _extract_paintkit
+from utils.inventory.extractors_paint_and_wear import _extract_paintkit
 from utils import local_data
 
 

--- a/static/style.css
+++ b/static/style.css
@@ -1198,3 +1198,58 @@ button[data-role="toggle-border"] {
     left: calc(12px + env(safe-area-inset-left, 0px));
   }
 }
+
+/* === quality & border tokens already exist above === */
+
+/* Ensure quality tokens exist (no-op if already defined) */
+.item-card.quality-unusual {
+  --quality-color: #8650ac; /* Unusual (purple) */
+}
+.item-card.quality-strange {
+  --quality-color: #cf6a32; /* Strange (orange) */
+}
+
+/* Use the provided variables for the NORMAL (non-split) border by default */
+.item-card[data-border-vars] {
+  border: 2px solid var(--border-primary, currentColor);
+}
+
+/* If you already had explicit border classes, they still work,
+   but the inline --border-primary will be the source of truth. */
+.item-card.border-unusual {
+  border-color: #8650ac;
+}
+.item-card.border-strange {
+  border-color: #cf6a32;
+}
+
+/* Split ring (when your Border Mode applies .border-split or equivalent) can keep using the same variables */
+.item-card.border-mode.border-split {
+  position: relative;
+  border: 0; /* ring drawn by ::before */
+}
+.item-card.border-mode.border-split::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 2px; /* ring thickness */
+  background: conic-gradient(
+    from 315deg,
+    var(--border-primary, currentColor) 0 50%,
+    var(--border-alt, currentColor) 50% 100%
+  );
+  /* Hollow center so only the ring shows */
+  -webkit-mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  pointer-events: none;
+}
+
+/* If decorated adds overlays that could hide the border, keep them from masking our border variables */
+.item-card.quality-unusual.quality-decorated {
+  box-shadow: none;
+  background-image: none;
+}

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -49,9 +49,34 @@ full_title = (title_parts + [base]) | join(' ') %}
   {% endif %}
 {% endif %}
 
+{# --- Border color variables + Unusual precedence for skins/warpaints --- #}
+{% set is_unusual_render = item.is_unusual or (item.is_decorated and item.unusual_effect_id) %}
+{% set is_strange = item.has_strange_tracking or item.is_strange %}
+
+{# Build classes: include existing flags and force quality-unusual if Unusual render #}
+{% set classes = ['item-card'] %}
+{% if item.untradable_hold %}{% do classes.append('trade-hold') %}{% endif %}
+{% if item.uncraftable %}{% do classes.append('uncraftable') %}{% endif %}
+{% if item.has_strange_tracking %}{% do classes.append('elevated-strange') %}{% endif %}
+{% if alt_q %}{% do classes.append('has-dual-quality') %}{% endif %}
+{% if is_unusual_render %}
+  {% do classes.append('quality-unusual') %}
+{% elif item.quality_class %}
+  {% do classes.append(item.quality_class) %}
+{% endif %}
+
+{# Determine border colors for normal and split displays #}
+{% if is_unusual_render %}
+  {% set border_primary = '#8650AC' %}
+  {% set border_alt = (alt_q or ('#CF6A32' if is_strange else '#8650AC')) %}
+{% else %}
+  {% set border_primary = item.quality_color %}
+  {% set border_alt = (alt_q or ('#CF6A32' if is_strange else item.quality_color)) %}
+{% endif %}
+
 <div
-  class="item-card{% if item.untradable_hold %} trade-hold{% endif %}{% if item.uncraftable %} uncraftable{% endif %}{% if item.has_strange_tracking %} elevated-strange{% endif %}{% if alt_q %} has-dual-quality{% endif %}"
-  style="--quality-color: {{ item.quality_color }};{% if alt_q %} --quality-alt: {{ alt_q }};{% endif %} border-color: {{ item.border_color or item.quality_color }};"
+  class="{{ ' '.join(classes) }}"
+  style="--quality-color: {{ border_primary }}; --border-primary: {{ border_primary }}; --border-alt: {{ border_alt }};{% if alt_q %} --quality-alt: {{ border_alt }};{% endif %}"
   title="{{ full_title }}"
   {%
   if
@@ -60,6 +85,7 @@ full_title = (title_parts + [base]) | join(' ') %}
   {%
   endif
   %}
+  data-border-vars="1"
   data-item="{{ item|tojson|forceescape }}"
   data-craftable="{{ 'true' if item.craftable else 'false' }}"
 >


### PR DESCRIPTION
## Summary
- compute border color variables for item cards and prioritize unusual rendering
- support border-primary/alt CSS tokens and split ring styling
- document border variable usage in architecture guide

## Testing
- `npx --yes prettier -w templates/item_card.html static/style.css docs/ARCHITECTURE.md CHANGELOG.md`
- `npx --yes eslint .`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_68a83c389eb88326a8c6dc6f6befd94b