### PR TITLE
Use canonical schema.autobot wear/grade caches for enrichment

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -32,7 +32,7 @@ async def main() -> None:
 - **`utils/price_service.py`** – Formats raw price values into readable strings.
 - **`utils/valuation_service.py`** – Builds a price map and exposes helpers to attach price info to items.
 - **`utils/local_data.py`** – Loads cached schema files and constant mappings such as paints and qualities.
-- **`utils/schema_provider.py`** – Fetches and caches TF2 schema data from `schema.autobot.tf`.
+- **`utils/schema_provider.py`** – Fetches and caches TF2 schema data from `schema.autobot.tf`, including canonical wear (`/properties/wears`) and grade (`/getItemGrade/v2`) maps.
 
 ## Templates
 
@@ -57,7 +57,8 @@ async def main() -> None:
 1. Input text is parsed with `extract_steam_ids()` to collect valid Steam IDs.
 2. For each ID, the app fetches profile summaries, playtime and inventory data asynchronously via `steam_api_client`.
 3. `inventory_processor.process_inventory()` enriches each item with schema details and pricing via `valuation_service`.
+   - Wear uses this order: Steam Econ `Exterior` tag → cached `/properties/wears` lookup → safe float fallback.
+   - Grade uses this order: Steam Econ `Rarity`/`Grade` tags → cached `/getItemGrade/v2` lookup → cached per-defindex endpoint fallback → name parser fallback.
 4. User cards are rendered server‑side using `_user.html` and `item_card.html` and inserted into `index.html`.
 5. JavaScript enhances the page with lazy loading, modal dialogs and retry functionality.
 6. Price and schema data are cached under `cache/` to speed up processing and reduce network calls.
-

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -10,6 +10,8 @@ import pytest
 def reset_data(monkeypatch):
     ld.ITEMS_BY_DEFINDEX = {}
     ld.SCHEMA_ATTRIBUTES = {}
+    ld.WEAR_NAMES_BY_ID = {}
+    ld.ITEM_GRADE_BY_DEFINDEX = {}
 
 
 @pytest.fixture
@@ -1384,7 +1386,36 @@ def test_grade_tier_extracted_from_schema_tags(monkeypatch):
     assert item["grade_name"] == "Elite Grade"
     assert item["tier_name"] != "Elite Grade"
     assert item["grade_color"] == "#FF5E5E"
+    assert item["grade_source"] == "econ_tag"
     assert any(b.get("type") == "grade" for b in item["badges"])
+
+
+def test_grade_tier_from_econ_tag_category_name_grade():
+    data = {
+        "items": [
+            {
+                "defindex": 15141,
+                "quality": 15,
+                "attributes": [{"defindex": 834, "value": 350}],
+                "tags": [{"category_name": "Grade", "localized_tag_name": "Assassin Grade"}],
+            }
+        ]
+    }
+    ld.ITEMS_BY_DEFINDEX = {15141: {"item_name": "Flame Thrower", "craft_class": "weapon"}}
+    ld.QUALITIES_BY_INDEX = {15: "Decorated Weapon"}
+    item = ip.enrich_inventory(data)[0]
+    assert item["grade_name"] == "Assassin Grade"
+    assert item["grade_source"] == "econ_tag"
+
+
+def test_grade_tier_from_cached_defindex_map():
+    data = {"items": [{"defindex": 3001, "quality": 6, "attributes": []}]}
+    ld.ITEMS_BY_DEFINDEX = {3001: {"item_name": "Some Hat", "item_class": "hat"}}
+    ld.QUALITIES_BY_INDEX = {6: "Unique"}
+    ld.ITEM_GRADE_BY_DEFINDEX = {3001: "Freelance Grade"}
+    item = ip.enrich_inventory(data)[0]
+    assert item["grade_name"] == "Freelance Grade"
+    assert item["grade_source"] == "schema_grade_v2"
 
 
 def test_grade_tier_fallback_extracted_from_item_name():
@@ -1394,7 +1425,62 @@ def test_grade_tier_fallback_extracted_from_item_name():
     item = ip.enrich_inventory(data)[0]
     assert item["grade_name"] == "Mercenary Grade"
     assert item["tier"] == "Mercenary Grade"
+    assert item["grade_source"] == "name_fallback"
     assert item["grade_color"] == "#8C63FF"
+
+
+def test_wear_name_from_econ_tag_exterior():
+    data = {
+        "items": [
+            {
+                "defindex": 15141,
+                "quality": 15,
+                "attributes": [{"defindex": 725, "float_value": 0.01}],
+                "tags": [{"category": "Exterior", "localized_tag_name": "Field-Tested"}],
+            }
+        ]
+    }
+    ld.ITEMS_BY_DEFINDEX = {15141: {"item_name": "Flamethrower", "craft_class": "weapon"}}
+    ld.QUALITIES_BY_INDEX = {15: "Decorated Weapon"}
+    item = ip.enrich_inventory(data)[0]
+    assert item["wear_name"] == "Field-Tested"
+    assert item["exterior"] == "Field-Tested"
+    assert item["wear_source"] == "econ_tag"
+
+
+def test_wear_from_schema_wears_mapping():
+    ld.WEAR_NAMES_BY_ID = {0: "Factory New", 1: "Minimal Wear", 2: "Field-Tested"}
+    data = {
+        "items": [
+            {
+                "defindex": 15141,
+                "quality": 15,
+                "attributes": [{"defindex": 725, "float_value": 0.2}],
+            }
+        ]
+    }
+    ld.ITEMS_BY_DEFINDEX = {15141: {"item_name": "Flamethrower", "craft_class": "weapon"}}
+    ld.QUALITIES_BY_INDEX = {15: "Decorated Weapon"}
+    item = ip.enrich_inventory(data)[0]
+    assert item["wear_name"] == "Field-Tested"
+    assert item["wear_source"] == "schema_wears"
+
+
+def test_invalid_wear_does_not_default_factory_new():
+    data = {
+        "items": [
+            {
+                "defindex": 15141,
+                "quality": 15,
+                "attributes": [{"defindex": 725, "float_value": "not-a-float"}],
+            }
+        ]
+    }
+    ld.ITEMS_BY_DEFINDEX = {15141: {"item_name": "Flamethrower", "craft_class": "weapon"}}
+    ld.QUALITIES_BY_INDEX = {15: "Decorated Weapon"}
+    item = ip.enrich_inventory(data)[0]
+    assert item["wear_name"] is None
+    assert item["wear_source"] == "none"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -1466,6 +1466,43 @@ def test_wear_from_schema_wears_mapping():
     assert item["wear_source"] == "schema_wears"
 
 
+def test_wear_float_one_point_zero_is_not_treated_as_schema_id():
+    ld.WEAR_NAMES_BY_ID = {0: "Factory New", 1: "Minimal Wear", 4: "Battle Scarred"}
+    data = {
+        "items": [
+            {
+                "defindex": 15141,
+                "quality": 15,
+                "attributes": [{"defindex": 725, "float_value": 1.0}],
+            }
+        ]
+    }
+    ld.ITEMS_BY_DEFINDEX = {15141: {"item_name": "Flamethrower", "craft_class": "weapon"}}
+    ld.QUALITIES_BY_INDEX = {15: "Decorated Weapon"}
+    item = ip.enrich_inventory(data)[0]
+    assert item["wear_name"] == "Battle Scarred"
+    assert item["wear_float"] == 1.0
+
+
+def test_wear_integer_id_still_uses_schema_wear_lookup():
+    ld.WEAR_NAMES_BY_ID = {1: "Minimal Wear"}
+    data = {
+        "items": [
+            {
+                "defindex": 15141,
+                "quality": 15,
+                "attributes": [{"defindex": 725, "float_value": 1}],
+            }
+        ]
+    }
+    ld.ITEMS_BY_DEFINDEX = {15141: {"item_name": "Flamethrower", "craft_class": "weapon"}}
+    ld.QUALITIES_BY_INDEX = {15: "Decorated Weapon"}
+    item = ip.enrich_inventory(data)[0]
+    assert item["wear_name"] == "Minimal Wear"
+    assert item["wear_source"] == "schema_wears"
+    assert item["wear_float"] is None
+
+
 def test_invalid_wear_does_not_default_factory_new():
     data = {
         "items": [

--- a/tests/test_item_modal_template.py
+++ b/tests/test_item_modal_template.py
@@ -99,3 +99,18 @@ def test_grade_and_wear_badges(app):
     assert soup.find("span", class_="grade-assassin-grade") is not None
     assert "Minimal Wear" in soup.text
     assert "Warhawk" in soup.text
+
+
+def test_grade_and_wear_badges_render_once_per_modal(app):
+    item = {
+        "grade_name": "Elite Grade",
+        "wear_name": "Factory New",
+        "paintkit_name": "Warhawk",
+    }
+    with app.app_context():
+        html = render_template("_modal.html", item=item)
+    soup = BeautifulSoup(html, "html.parser")
+    badges = soup.select("span.grade-badge")
+    wear_badges = soup.select("span.wear-badge")
+    assert len(badges) == 1
+    assert len(wear_badges) == 1

--- a/tests/test_local_data.py
+++ b/tests/test_local_data.py
@@ -153,6 +153,46 @@ def test_load_files_name_key_quality(tmp_path, monkeypatch):
     assert ld.QUALITIES_BY_INDEX == {1: "Unique"}
 
 
+def test_load_files_item_grade_list_shape(tmp_path, monkeypatch):
+    attr_file = tmp_path / "attributes.json"
+    particles_file = tmp_path / "particles.json"
+    items_file = tmp_path / "items.json"
+    qual_file = tmp_path / "qualities.json"
+    currencies_file = tmp_path / "currencies.json"
+    item_grade_file = tmp_path / "item_grade_v2.json"
+
+    attr_file.write_text(json.dumps([{"defindex": 1, "name": "Attr"}]))
+    particles_file.write_text(json.dumps([{"id": 1, "name": "P"}]))
+    items_file.write_text(json.dumps([{"defindex": 1, "name": "One"}]))
+    qual_file.write_text(json.dumps({"1": "Unique"}))
+    currencies_file.write_text(json.dumps({"metal": {"value_raw": 1.0}}))
+    item_grade_file.write_text(
+        json.dumps(
+            {
+                "value": [
+                    {"defindex": 15141, "grade": "Elite Grade"},
+                    {"defindex": "15142", "grade": "Mercenary Grade"},
+                    {"defindex": "abc", "grade": "Ignored"},
+                ]
+            }
+        )
+    )
+
+    monkeypatch.setattr(ld, "ATTRIBUTES_FILE", attr_file)
+    monkeypatch.setattr(ld, "PARTICLES_FILE", particles_file)
+    monkeypatch.setattr(ld, "ITEMS_FILE", items_file)
+    monkeypatch.setattr(ld, "QUALITIES_FILE", qual_file)
+    monkeypatch.setattr(ld, "CURRENCIES_FILE", currencies_file)
+    monkeypatch.setattr(ld, "ITEM_GRADE_FILE", item_grade_file)
+
+    ld.ITEM_GRADE_BY_DEFINDEX = {}
+    ld.load_files()
+    assert ld.ITEM_GRADE_BY_DEFINDEX == {
+        15141: "Elite Grade",
+        15142: "Mercenary Grade",
+    }
+
+
 def test_clean_items_game_parses_all():
     sample = {
         "items_game": {

--- a/tests/test_local_data.py
+++ b/tests/test_local_data.py
@@ -83,6 +83,8 @@ def test_load_files_auto_refetch(tmp_path, monkeypatch, caplog):
         "items": [{"defindex": 1, "name": "One"}],
         "particles": [{"id": 1, "name": "P"}],
         "qualities": {"1": "Unique"},
+        "wears": {"0": "Factory New"},
+        "item_grade_v2": {"15141": "Elite Grade"},
         "paintkits": [],
         "string_lookups": {
             "value": [

--- a/tests/test_schema_provider.py
+++ b/tests/test_schema_provider.py
@@ -24,6 +24,8 @@ def test_schema_provider(monkeypatch, tmp_path):
         "/raw/schema/originNames": {"0": "Timed Drop"},
         "/properties/strangeParts": {"Kills": {"id": 64, "name": "Kills"}},
         "/properties/qualities": {"Normal": 0},
+        "/properties/wears": {"0": "Factory New"},
+        "/getItemGrade/v2": {"15141": "Elite Grade"},
         "/properties/defindexes": {"5021": "Key"},
         "/raw/schema/string_lookups": {"KillEaterEventType": "Kills"},
     }
@@ -47,6 +49,8 @@ def test_schema_provider(monkeypatch, tmp_path):
     assert provider.get_origins() == {0: "Timed Drop"}
     assert provider.get_parts() == {64: {"id": 64, "name": "Kills"}}
     assert provider.get_qualities() == {"Normal": 0}
+    assert provider.get_wears() == {0: "Factory New"}
+    assert provider.get_item_grade_map() == {15141: "Elite Grade"}
     assert provider.get_string_lookups() == {"KillEaterEventType": "Kills"}
     assert provider.get_defindexes() == {5021: "Key"}
 
@@ -58,6 +62,8 @@ def test_schema_provider(monkeypatch, tmp_path):
     provider.get_origins()
     provider.get_parts()
     provider.get_qualities()
+    provider.get_wears()
+    provider.get_item_grade_map()
     provider.get_string_lookups()
 
     for endpoint in payloads:
@@ -80,6 +86,8 @@ def test_schema_provider_list_payload(monkeypatch, tmp_path):
         "/raw/schema/originNames": {"value": [{"id": 0, "name": "Timed Drop"}]},
         "/properties/strangeParts": {"value": [{"id": 64, "name": "Kills"}]},
         "/properties/qualities": {"value": [{"id": 0, "name": "Normal"}]},
+        "/properties/wears": {"value": [{"id": 0, "name": "Factory New"}]},
+        "/getItemGrade/v2": {"value": [{"defindex": 15141, "grade": "Elite Grade"}]},
         "/raw/schema/string_lookups": {
             "value": [{"key": "KillEaterEventType", "value": "Kills"}]
         },
@@ -103,7 +111,32 @@ def test_schema_provider_list_payload(monkeypatch, tmp_path):
     assert provider.get_origins() == {0: "Timed Drop"}
     assert provider.get_parts() == {64: {"id": 64, "name": "Kills"}}
     assert provider.get_qualities() == {"Normal": 0}
+    assert provider.get_wears() == {0: "Factory New"}
+    assert provider.get_item_grade_map() == {15141: "Elite Grade"}
     assert provider.get_string_lookups() == {"KillEaterEventType": "Kills"}
+
+
+def test_item_grade_endpoint_fallback(monkeypatch, tmp_path):
+    provider = sp.SchemaProvider(base_url="https://example.com", cache_dir=tmp_path)
+
+    payloads = {
+        "/getItemGrade/v2": {},
+        "/getItemGrade/fromDefindex/9999": {"value": {"grade": "Assassin Grade"}},
+    }
+    calls = {key: 0 for key in payloads}
+
+    def fake_get(self, url, timeout=20):
+        endpoint = url.replace(provider.base_url, "")
+        calls[endpoint] += 1
+        return DummyResp(payloads[endpoint])
+
+    monkeypatch.setattr(sp.requests.Session, "get", fake_get)
+
+    assert provider.get_item_grade_from_defindex(9999) == "Assassin Grade"
+    # second call should come from fallback cache and not re-fetch
+    assert provider.get_item_grade_from_defindex(9999) == "Assassin Grade"
+    assert calls["/getItemGrade/v2"] == 1
+    assert calls["/getItemGrade/fromDefindex/9999"] == 1
 
 
 def test_refresh_all_resets_attributes_and_creates_files(monkeypatch, tmp_path):

--- a/utils/inventory/extractors_grade_tier.py
+++ b/utils/inventory/extractors_grade_tier.py
@@ -1,9 +1,12 @@
-"""Helpers for extracting TF2 item grade/tier metadata."""
+"""Helpers for extracting TF2 item grade metadata while keeping killstreak tiers separate."""
 
 from __future__ import annotations
 
 from typing import Any, Dict, Iterable
 import re
+
+from .. import local_data
+from ..schema_provider import SchemaProvider
 
 
 GRADE_COLOR_MAP: Dict[str, str] = {
@@ -19,6 +22,9 @@ _GRADE_REGEX = re.compile(
     r"\b(Civilian Grade|Freelance Grade|Mercenary Grade|Commando Grade|Assassin Grade|Elite Grade)\b",
     re.IGNORECASE,
 )
+
+_GRADE_ENDPOINT_LOOKUPS: dict[int, str | None] = {}
+_GRADE_PROVIDER: SchemaProvider | None = None
 
 
 def _normalize_grade_name(raw: str | None) -> str | None:
@@ -49,34 +55,72 @@ def _iter_string_candidates(schema_entry: Dict[str, Any], asset: Dict[str, Any])
             yield val
 
 
+def _extract_grade_from_tags(asset: Dict[str, Any], schema_entry: Dict[str, Any]) -> str | None:
+    """Resolve grade name from Steam Econ tags first, then schema tags."""
+
+    for tag_source in (asset.get("tags"), schema_entry.get("tags")):
+        if not isinstance(tag_source, list):
+            continue
+        for tag in tag_source:
+            if not isinstance(tag, dict):
+                continue
+            category = str(tag.get("category", "")).lower()
+            category_name = str(tag.get("category_name", "")).lower()
+            if category != "rarity" and category_name != "grade":
+                continue
+            for key in ("localized_tag_name", "name", "internal_name"):
+                parsed = _normalize_grade_name(tag.get(key))
+                if parsed:
+                    return parsed
+    return None
+
+
+def _grade_provider() -> SchemaProvider:
+    """Return a singleton schema provider used for grade endpoint fallback."""
+
+    global _GRADE_PROVIDER
+    if _GRADE_PROVIDER is None:
+        _GRADE_PROVIDER = SchemaProvider(cache_dir=local_data.ITEM_GRADE_FILE.parent)
+    return _GRADE_PROVIDER
+
+
+def _resolve_grade_from_defindex(defindex: int | None) -> tuple[str | None, str]:
+    """Resolve grade from cached v2 map and defindex endpoint fallback."""
+
+    if defindex is None:
+        return None, "none"
+
+    cached = local_data.ITEM_GRADE_BY_DEFINDEX.get(int(defindex))
+    normalized = _normalize_grade_name(cached)
+    if normalized:
+        return normalized, "schema_grade_v2"
+
+    if int(defindex) in _GRADE_ENDPOINT_LOOKUPS:
+        normalized = _normalize_grade_name(_GRADE_ENDPOINT_LOOKUPS[int(defindex)])
+        return normalized, "grade_endpoint" if normalized else "none"
+
+    fetched = _grade_provider().get_item_grade_from_defindex(int(defindex))
+    _GRADE_ENDPOINT_LOOKUPS[int(defindex)] = fetched
+    normalized = _normalize_grade_name(fetched)
+    if normalized:
+        return normalized, "grade_endpoint"
+    return None, "none"
+
+
 def _extract_grade_tier(
     asset: Dict[str, Any],
     schema_entry: Dict[str, Any],
     display_name: str | None = None,
     resolved_name: str | None = None,
+    defindex: int | None = None,
 ) -> Dict[str, str | None]:
-    """Return normalized grade/tier fields for cosmetics, war paints, and skins.
+    """Return normalized grade fields; never aliases killstreak tiers into grade."""
 
-    The extraction prefers schema-provided tag metadata and then falls back to
-    parsing known grade labels from name-like fields.
-    """
+    grade_name = _extract_grade_from_tags(asset, schema_entry)
+    grade_source = "econ_tag" if grade_name else "none"
 
-    grade_name: str | None = None
-
-    tags = schema_entry.get("tags")
-    if isinstance(tags, list):
-        for tag in tags:
-            if not isinstance(tag, dict):
-                continue
-            if str(tag.get("category", "")).lower() != "rarity":
-                continue
-            for key in ("localized_tag_name", "name", "internal_name"):
-                parsed = _normalize_grade_name(tag.get(key))
-                if parsed:
-                    grade_name = parsed
-                    break
-            if grade_name:
-                break
+    if not grade_name:
+        grade_name, grade_source = _resolve_grade_from_defindex(defindex)
 
     if not grade_name:
         for text in (
@@ -87,20 +131,23 @@ def _extract_grade_tier(
             parsed = _normalize_grade_name(text)
             if parsed:
                 grade_name = parsed
+                grade_source = "name_fallback"
                 break
 
     color = GRADE_COLOR_MAP.get(grade_name or "")
+    grade_slug = (grade_name or "").lower().replace(" ", "-") if grade_name else None
     return {
         "grade": grade_name,
         "grade_name": grade_name,
         "grade_color": color,
+        "grade_slug": grade_slug,
         "tier": grade_name,
         "item_tier": grade_name,
         "item_tier_name": grade_name,
         "tier_color": color,
         "item_tier_color": color,
+        "grade_source": grade_source if grade_name else "none",
     }
 
 
 __all__ = ["GRADE_COLOR_MAP", "_extract_grade_tier"]
-

--- a/utils/inventory/extractors_paint_and_wear.py
+++ b/utils/inventory/extractors_paint_and_wear.py
@@ -53,72 +53,143 @@ def _extract_pattern_seed(asset: Dict[str, Any]) -> int | None:
     return seed
 
 
-def _extract_wear(asset: Dict[str, Any]) -> str | None:
-    """Return wear tier name if present."""
+def _extract_econ_tag(
+    asset: Dict[str, Any], *, category: str, category_name: str | None = None
+) -> str | None:
+    """Return localized Steam Econ tag value for a category if present."""
+
+    tags = asset.get("tags")
+    if not isinstance(tags, list):
+        return None
+    category = category.lower()
+    category_name = category_name.lower() if category_name else None
+    for tag in tags:
+        if not isinstance(tag, dict):
+            continue
+        tag_category = str(tag.get("category", "")).lower()
+        tag_category_name = str(tag.get("category_name", "")).lower()
+        if tag_category != category and (
+            category_name is None or tag_category_name != category_name
+        ):
+            continue
+        raw = (
+            tag.get("localized_tag_name")
+            or tag.get("name")
+            or tag.get("internal_name")
+        )
+        if isinstance(raw, str) and raw.strip():
+            return raw.strip()
+    return None
+
+
+def _extract_wear_attr_value(asset: Dict[str, Any]) -> tuple[float | None, Any | None]:
+    """Return ``(wear_float, raw_value)`` when a wear attribute can be parsed."""
 
     refresh_attr_classes()
     for attr in asset.get("attributes", []):
         idx = attr.get("defindex")
         attr_class = get_attr_class(idx)
-        if attr_class in WEAR_CLASSES:
-            raw = attr.get("float_value")
-            if raw is None:
-                raw = attr.get("value")
-            try:
-                val = float(raw)
-            except (TypeError, ValueError):
-                logger.warning("Invalid wear value: %r", raw)
-                continue
-            if not 0 <= val <= 1:
-                logger.warning("Wear value out of range: %s", val)
-            name = local_data.WEAR_NAMES.get(str(int(val)))
-            return name or _wear_tier(val)
-        elif idx in (725, 749):
-            logger.warning("Using numeric fallback for wear index %s", idx)
-            raw = attr.get("float_value")
-            if raw is None:
-                raw = attr.get("value")
-            try:
-                val = float(raw)
-            except (TypeError, ValueError):
-                logger.warning("Invalid wear value: %r", raw)
-                continue
-            if not 0 <= val <= 1:
-                logger.warning("Wear value out of range: %s", val)
-            name = local_data.WEAR_NAMES.get(str(int(val)))
-            return name or _wear_tier(val)
+        if attr_class not in WEAR_CLASSES and idx not in (725, 749):
+            continue
+        raw = attr.get("float_value")
+        if raw is None:
+            raw = attr.get("value")
+        try:
+            val = float(raw)
+        except (TypeError, ValueError):
+            logger.warning("Invalid wear value: %r", raw)
+            continue
+        if not 0 <= val <= 1 and val not in (0, 1, 2, 3, 4):
+            logger.warning("Wear value out of range: %s", val)
+        return val, raw
 
     wear_float, _ = _decode_seed_info(asset.get("attributes", []))
     if wear_float is not None:
-        name = local_data.WEAR_NAMES.get(str(int(wear_float)))
-        return name or _wear_tier(wear_float)
+        return wear_float, wear_float
+    return None, None
 
-    return None
+
+def resolve_wear(asset: Dict[str, Any]) -> Dict[str, Any]:
+    """Resolve wear metadata using econ tag, schema map, then float fallback."""
+
+    econ_wear = _extract_econ_tag(asset, category="Exterior")
+    if econ_wear:
+        wear_float, wear_raw = _extract_wear_attr_value(asset)
+        if wear_float is not None and not (0 <= wear_float <= 1):
+            wear_float = None
+        return {
+            "wear": econ_wear,
+            "wear_name": econ_wear,
+            "exterior": econ_wear,
+            "wear_float": wear_float,
+            "wear_raw": wear_raw,
+            "wear_source": "econ_tag",
+        }
+
+    wear_float, wear_raw = _extract_wear_attr_value(asset)
+    if wear_float is not None:
+        if wear_float in (0, 1, 2, 3, 4):
+            mapped = local_data.WEAR_NAMES_BY_ID.get(int(wear_float))
+            if mapped:
+                return {
+                    "wear": mapped,
+                    "wear_name": mapped,
+                    "exterior": mapped,
+                    "wear_float": None,
+                    "wear_raw": wear_raw,
+                    "wear_source": "schema_wears",
+                }
+
+        if 0 <= wear_float <= 1:
+            # Prefer canonical schema names when they include this float tier.
+            fallback_name = _wear_tier(wear_float)
+            mapped = next(
+                (
+                    schema_name
+                    for schema_name in local_data.WEAR_NAMES_BY_ID.values()
+                    if str(schema_name).lower() == fallback_name.lower()
+                ),
+                None,
+            )
+            if mapped:
+                return {
+                    "wear": mapped,
+                    "wear_name": mapped,
+                    "exterior": mapped,
+                    "wear_float": wear_float,
+                    "wear_raw": wear_raw,
+                    "wear_source": "schema_wears",
+                }
+
+            return {
+                "wear": fallback_name,
+                "wear_name": fallback_name,
+                "exterior": fallback_name,
+                "wear_float": wear_float,
+                "wear_raw": wear_raw,
+                "wear_source": "float",
+            }
+
+    return {
+        "wear": None,
+        "wear_name": None,
+        "exterior": None,
+        "wear_float": None,
+        "wear_raw": wear_raw,
+        "wear_source": "none",
+    }
+
+
+def _extract_wear(asset: Dict[str, Any]) -> str | None:
+    """Backward-compatible wear extractor returning only the wear name."""
+
+    return resolve_wear(asset).get("wear_name")
 
 
 def _extract_wear_float(asset: Dict[str, Any]) -> float | None:
-    """Return wear float value if present."""
+    """Backward-compatible helper returning normalized wear float when available."""
 
-    refresh_attr_classes()
-    for attr in asset.get("attributes", []):
-        idx = attr.get("defindex")
-        attr_class = get_attr_class(idx)
-        if attr_class in WEAR_CLASSES or idx in (725, 749):
-            raw = attr.get("float_value")
-            if raw is None:
-                raw = attr.get("value")
-            try:
-                val = float(raw)
-            except (TypeError, ValueError):
-                logger.warning("Invalid wear value: %r", raw)
-                continue
-            if 0 <= val <= 1:
-                return val
-
-    wear_float, _ = _decode_seed_info(asset.get("attributes", []))
-    if wear_float is not None and 0 <= wear_float <= 1:
-        return wear_float
-    return None
+    return resolve_wear(asset).get("wear_float")
 
 
 def _slug_to_paintkit_name(slug: str) -> str:
@@ -232,4 +303,5 @@ __all__ = [
     "_extract_pattern_seed",
     "_slug_to_paintkit_name",
     "_extract_paintkit",
+    "resolve_wear",
 ]

--- a/utils/inventory/extractors_paint_and_wear.py
+++ b/utils/inventory/extractors_paint_and_wear.py
@@ -109,6 +109,31 @@ def _extract_wear_attr_value(asset: Dict[str, Any]) -> tuple[float | None, Any |
     return None, None
 
 
+def _is_schema_wear_id_value(wear_float: float, wear_raw: Any) -> bool:
+    """Return True when wear metadata is encoded as an integer schema ID."""
+
+    if wear_float not in (0, 1, 2, 3, 4):
+        return False
+
+    # Steam can serialize true boundary floats as float values like ``1.0``.
+    # Treat explicit floats as float-based wear, not schema IDs.
+    if isinstance(wear_raw, float):
+        return False
+
+    if isinstance(wear_raw, int):
+        return True
+
+    if isinstance(wear_raw, str):
+        raw = wear_raw.strip()
+        if not raw:
+            return False
+        if raw in {"0", "1", "2", "3", "4"}:
+            return True
+        return False
+
+    return False
+
+
 def resolve_wear(asset: Dict[str, Any]) -> Dict[str, Any]:
     """Resolve wear metadata using econ tag, schema map, then float fallback."""
 
@@ -128,7 +153,7 @@ def resolve_wear(asset: Dict[str, Any]) -> Dict[str, Any]:
 
     wear_float, wear_raw = _extract_wear_attr_value(asset)
     if wear_float is not None:
-        if wear_float in (0, 1, 2, 3, 4):
+        if _is_schema_wear_id_value(wear_float, wear_raw):
             mapped = local_data.WEAR_NAMES_BY_ID.get(int(wear_float))
             if mapped:
                 return {

--- a/utils/inventory/processor.py
+++ b/utils/inventory/processor.py
@@ -26,10 +26,9 @@ from .extractors_unusual_killstreak import (
 )
 from .extractors_paint_and_wear import (
     _extract_paint,
-    _extract_wear,
-    _extract_wear_float,
     _extract_pattern_seed,
     _extract_paintkit,
+    resolve_wear,
 )
 from .extractors_grade_tier import _extract_grade_tier
 from .extractors_misc import (
@@ -178,8 +177,9 @@ def _process_item(
 
     paintkit_id = paintkit_name = None
     target_weapon_def = target_weapon_name = None
-    wear_name = _extract_wear(asset)
-    wear_float = _extract_wear_float(asset)
+    wear_meta = resolve_wear(asset)
+    wear_name = wear_meta.get("wear_name")
+    wear_float = wear_meta.get("wear_float")
 
     if warpaint_tool:
         (
@@ -357,8 +357,9 @@ def _process_item(
         schema_entry,
         display_name=display_name,
         resolved_name=resolved_name,
+        defindex=defindex_int,
     )
-    wear_exterior = wear_name
+    wear_exterior = wear_meta.get("exterior")
     original_name = name if is_unusual else None
     if is_unusual:
         name = display_name
@@ -490,7 +491,9 @@ def _process_item(
         "wear": wear_exterior,
         "wear_name": wear_name,
         "wear_float": wear_float,
+        "wear_raw": wear_meta.get("wear_raw"),
         "exterior": wear_exterior,
+        "wear_source": wear_meta.get("wear_source", "none"),
         "pattern_seed": pattern_seed,
         "skin_name": skin_name,
         "composite_name": composite_name,

--- a/utils/local_data.py
+++ b/utils/local_data.py
@@ -209,6 +209,36 @@ def _load_paint_id_map(path: Path) -> Dict[str, str]:
     return {}
 
 
+def _load_item_grade_by_defindex(path: Path) -> Dict[int, str]:
+    """Return a defindex->grade map from dict or list cache shapes."""
+
+    if not path.exists():
+        return {}
+    try:
+        with path.open() as f:
+            data = json.load(f)
+    except Exception:
+        return {}
+
+    raw = data.get("value") if isinstance(data, dict) and "value" in data else data
+
+    if isinstance(raw, dict):
+        return {int(k): str(v) for k, v in raw.items() if str(k).isdigit()}
+
+    if isinstance(raw, list):
+        out: Dict[int, str] = {}
+        for entry in raw:
+            if not isinstance(entry, dict):
+                continue
+            defindex = entry.get("defindex")
+            grade = entry.get("grade")
+            if str(defindex).isdigit() and isinstance(grade, str) and grade.strip():
+                out[int(defindex)] = grade.strip()
+        return out
+
+    return {}
+
+
 def load_files(
     *, auto_refetch: bool = False, verbose: bool = False
 ) -> Tuple[Dict[int, Any], Dict[int, Any]]:
@@ -398,10 +428,7 @@ def load_files(
     KILLSTREAK_EFFECT_NAMES = _load_json_map(KILLSTREAK_EFFECT_FILE)
     STRANGE_PART_NAMES = _load_json_map(STRANGE_PART_FILE)
     CRATE_SERIES_NAMES = _load_json_map(CRATE_SERIES_FILE)
-    item_grade_raw = _load_json_map(ITEM_GRADE_FILE)
-    ITEM_GRADE_BY_DEFINDEX = {
-        int(k): str(v) for k, v in item_grade_raw.items() if str(k).isdigit()
-    }
+    ITEM_GRADE_BY_DEFINDEX = _load_item_grade_by_defindex(ITEM_GRADE_FILE)
 
     FOOTPRINT_SPELL_MAP = {}
     PAINT_SPELL_MAP = {}

--- a/utils/local_data.py
+++ b/utils/local_data.py
@@ -20,7 +20,9 @@ PARTICLE_NAMES: Dict[int, str] = {}
 EFFECT_NAMES: Dict[str, str] = {}
 PAINT_NAMES: Dict[str, str] = {}
 WEAR_NAMES: Dict[str, str] = {}
+WEAR_NAMES_BY_ID: Dict[int, str] = {}
 KILLSTREAK_NAMES: Dict[str, str] = {}
+ITEM_GRADE_BY_DEFINDEX: Dict[int, str] = {}
 STRANGE_PART_NAMES: Dict[str, str] = {}
 # will be populated at import time
 PAINTKIT_NAMES: Dict[str, str]
@@ -68,7 +70,8 @@ QUALITIES_FILE = Path(os.getenv("TF2_QUALITIES_FILE", DEFAULT_QUALITIES_FILE))
 CURRENCIES_FILE = Path(os.getenv("TF2_CURRENCIES_FILE", DEFAULT_CURRENCIES_FILE))
 DEFAULT_EFFECT_FILE = BASE_DIR / "cache" / "schema" / "effects.json"
 DEFAULT_PAINT_FILE = BASE_DIR / "cache" / "schema" / "paints.json"
-DEFAULT_WEAR_FILE = BASE_DIR / "cache" / "wear_names.json"
+DEFAULT_WEAR_FILE = BASE_DIR / "cache" / "schema" / "wears.json"
+DEFAULT_ITEM_GRADE_FILE = BASE_DIR / "cache" / "schema" / "item_grade_v2.json"
 DEFAULT_KILLSTREAK_FILE = BASE_DIR / "cache" / "killstreak_names.json"
 DEFAULT_KS_EFFECT_FILE = BASE_DIR / "cache" / "killstreak_effect_names.json"
 DEFAULT_STRANGE_PART_FILE = BASE_DIR / "cache" / "strange_part_names.json"
@@ -94,6 +97,7 @@ DEFAULT_EFFECT_NAMES_FILE = BASE_DIR / "data" / "effect_names.json"
 EFFECT_NAMES_FILE = Path(os.getenv("TF2_EFFECT_NAMES_FILE", DEFAULT_EFFECT_NAMES_FILE))
 PAINT_FILE = Path(os.getenv("TF2_PAINT_FILE", DEFAULT_PAINT_FILE))
 WEAR_FILE = Path(os.getenv("TF2_WEAR_FILE", DEFAULT_WEAR_FILE))
+ITEM_GRADE_FILE = Path(os.getenv("TF2_ITEM_GRADE_FILE", DEFAULT_ITEM_GRADE_FILE))
 KILLSTREAK_FILE = Path(os.getenv("TF2_KILLSTREAK_FILE", DEFAULT_KILLSTREAK_FILE))
 KILLSTREAK_EFFECT_FILE = Path(os.getenv("TF2_KS_EFFECT_FILE", DEFAULT_KS_EFFECT_FILE))
 STRANGE_PART_FILE = Path(os.getenv("TF2_STRANGE_PART_FILE", DEFAULT_STRANGE_PART_FILE))
@@ -211,7 +215,9 @@ def load_files(
     """Load local schema files from the schema.autobot.tf cache."""
 
     global SCHEMA_ATTRIBUTES, ITEMS_BY_DEFINDEX, QUALITIES_BY_INDEX, PARTICLE_NAMES
-    global EFFECT_NAMES, PAINT_NAMES, WEAR_NAMES, KILLSTREAK_NAMES, STRANGE_PART_NAMES, PAINTKIT_NAMES, CRATE_SERIES_NAMES
+    global EFFECT_NAMES, PAINT_NAMES, WEAR_NAMES, WEAR_NAMES_BY_ID
+    global KILLSTREAK_NAMES, STRANGE_PART_NAMES, PAINTKIT_NAMES, CRATE_SERIES_NAMES
+    global ITEM_GRADE_BY_DEFINDEX
     global FOOTPRINT_SPELL_MAP, PAINT_SPELL_MAP
 
     cleanup_legacy_files(verbose)
@@ -223,7 +229,11 @@ def load_files(
         "particles": PARTICLES_FILE.resolve(),
         "currencies": CURRENCIES_FILE.resolve(),
     }
-    optional = {"string_lookups": STRING_LOOKUPS_FILE.resolve()}
+    optional = {
+        "string_lookups": STRING_LOOKUPS_FILE.resolve(),
+        "wears": WEAR_FILE.resolve(),
+        "item_grade_v2": ITEM_GRADE_FILE.resolve(),
+    }
 
     missing = {k: p for k, p in required.items() if not p.exists()}
     if missing:
@@ -381,10 +391,17 @@ def load_files(
         EFFECT_NAMES.update(extra)
     PAINT_NAMES = _load_paint_id_map(PAINT_FILE)
     WEAR_NAMES = _load_json_map(WEAR_FILE)
+    WEAR_NAMES_BY_ID = {
+        int(k): str(v) for k, v in WEAR_NAMES.items() if str(k).isdigit()
+    }
     KILLSTREAK_NAMES = _load_json_map(KILLSTREAK_FILE)
     KILLSTREAK_EFFECT_NAMES = _load_json_map(KILLSTREAK_EFFECT_FILE)
     STRANGE_PART_NAMES = _load_json_map(STRANGE_PART_FILE)
     CRATE_SERIES_NAMES = _load_json_map(CRATE_SERIES_FILE)
+    item_grade_raw = _load_json_map(ITEM_GRADE_FILE)
+    ITEM_GRADE_BY_DEFINDEX = {
+        int(k): str(v) for k, v in item_grade_raw.items() if str(k).isdigit()
+    }
 
     FOOTPRINT_SPELL_MAP = {}
     PAINT_SPELL_MAP = {}
@@ -435,6 +452,7 @@ def load_files(
         ("effects", EFFECT_NAMES, EFFECT_NAMES_FILE),
         ("paints", PAINT_NAMES, PAINT_FILE),
         ("wears", WEAR_NAMES, WEAR_FILE),
+        ("item grades", ITEM_GRADE_BY_DEFINDEX, ITEM_GRADE_FILE),
         ("killstreaks", KILLSTREAK_NAMES, KILLSTREAK_FILE),
         ("killstreak effects", KILLSTREAK_EFFECT_NAMES, KILLSTREAK_EFFECT_FILE),
         ("strange parts", STRANGE_PART_NAMES, STRANGE_PART_FILE),

--- a/utils/schema_provider.py
+++ b/utils/schema_provider.py
@@ -56,6 +56,8 @@ class SchemaProvider:
         "paintkits": "/properties/paintkits",
         "qualities": "/properties/qualities",
         "defindexes": "/properties/defindexes",
+        "wears": "/properties/wears",
+        "item_grade_v2": "/getItemGrade/v2",
         "string_lookups": "/raw/schema/string_lookups",
     }
 
@@ -81,6 +83,9 @@ class SchemaProvider:
         self.defindex_names: Dict[int, str] | None = None
         self.origins_by_index: Dict[int, str] | None = None
         self.string_lookups: Dict[str, str] | None = None
+        self.wears_map: Dict[int, str] | None = None
+        self.item_grade_map: Dict[int, str] | None = None
+        self._item_grade_endpoint_cache: Dict[int, str | None] = {}
 
     # ------------------------------------------------------------------
     def _fetch(self, endpoint: str) -> Any:
@@ -203,6 +208,9 @@ class SchemaProvider:
         self.effects_by_index = None
         self.origins_by_index = None
         self.string_lookups = None
+        self.wears_map = None
+        self.item_grade_map = None
+        self._item_grade_endpoint_cache = {}
 
     async def refresh_all_async(self, verbose: bool = False) -> None:
         """Asynchronously refresh all schema files."""
@@ -228,6 +236,9 @@ class SchemaProvider:
         self.effects_by_index = None
         self.origins_by_index = None
         self.string_lookups = None
+        self.wears_map = None
+        self.item_grade_map = None
+        self._item_grade_endpoint_cache = {}
 
     def _to_int_map(self, data: dict) -> Dict[int, Any]:
         mapping: Dict[int, Any] = {}
@@ -422,7 +433,110 @@ class SchemaProvider:
         return {}
 
     def get_wears(self, *, force: bool = False) -> Dict[int, str]:
-        return {}
+        """Return a mapping of wear id -> wear name from ``/properties/wears``."""
+
+        if self.wears_map is None or force:
+            data = self._load("wears", self.ENDPOINTS["wears"], force)
+            mapping: Dict[int, str] = {}
+            if isinstance(data, list):
+                for entry in data:
+                    if not isinstance(entry, dict):
+                        continue
+                    raw_id = entry.get("id")
+                    raw_name = entry.get("name") or entry.get("value")
+                    if raw_id is None or raw_name is None:
+                        continue
+                    try:
+                        mapping[int(raw_id)] = str(raw_name)
+                    except (TypeError, ValueError):
+                        continue
+            elif isinstance(data, dict):
+                for key, value in data.items():
+                    try:
+                        if str(key).isdigit():
+                            mapping[int(key)] = str(value)
+                        elif isinstance(value, dict):
+                            raw_id = value.get("id")
+                            raw_name = value.get("name") or value.get("value")
+                            if raw_id is not None and raw_name is not None:
+                                mapping[int(raw_id)] = str(raw_name)
+                        elif str(value).isdigit():
+                            mapping[int(value)] = str(key)
+                    except (TypeError, ValueError):
+                        continue
+            self.wears_map = mapping
+        return self.wears_map
+
+    def get_item_grade_map(self, *, force: bool = False) -> Dict[int, str]:
+        """Return a mapping of item defindex -> canonical grade name from v2."""
+
+        if self.item_grade_map is None or force:
+            data = self._load("item_grade_v2", self.ENDPOINTS["item_grade_v2"], force)
+            mapping: Dict[int, str] = {}
+            if isinstance(data, list):
+                for entry in data:
+                    if not isinstance(entry, dict):
+                        continue
+                    raw_defindex = entry.get("defindex") or entry.get("id")
+                    raw_grade = entry.get("grade") or entry.get("name") or entry.get("value")
+                    if raw_defindex is None or raw_grade is None:
+                        continue
+                    try:
+                        mapping[int(raw_defindex)] = str(raw_grade)
+                    except (TypeError, ValueError):
+                        continue
+            elif isinstance(data, dict):
+                # Common shape: {"5021": "Civilian Grade"}
+                for key, value in data.items():
+                    if str(key).isdigit() and value is not None:
+                        mapping[int(key)] = str(value)
+                        continue
+                    if isinstance(value, dict):
+                        raw_defindex = value.get("defindex") or value.get("id")
+                        raw_grade = value.get("grade") or value.get("name") or value.get("value")
+                        if raw_defindex is None or raw_grade is None:
+                            continue
+                        try:
+                            mapping[int(raw_defindex)] = str(raw_grade)
+                        except (TypeError, ValueError):
+                            continue
+            self.item_grade_map = mapping
+        return self.item_grade_map
+
+    def get_item_grade_from_defindex(
+        self, defindex: int, *, force: bool = False
+    ) -> str | None:
+        """Return canonical grade for a defindex using cached endpoint fallback."""
+
+        grade_map = self.get_item_grade_map(force=force)
+        if int(defindex) in grade_map:
+            return grade_map[int(defindex)]
+        if int(defindex) in self._item_grade_endpoint_cache and not force:
+            return self._item_grade_endpoint_cache[int(defindex)]
+
+        endpoint = f"/getItemGrade/fromDefindex/{int(defindex)}"
+        try:
+            data = self._fetch(endpoint)
+        except Exception:
+            self._item_grade_endpoint_cache[int(defindex)] = None
+            return None
+
+        resolved: str | None = None
+        if isinstance(data, dict):
+            value = data.get("value") if "value" in data else data
+            if isinstance(value, dict):
+                for key in ("grade", "name", "value"):
+                    raw = value.get(key)
+                    if isinstance(raw, str) and raw.strip():
+                        resolved = raw.strip()
+                        break
+            elif isinstance(value, str) and value.strip():
+                resolved = value.strip()
+
+        self._item_grade_endpoint_cache[int(defindex)] = resolved
+        if resolved:
+            grade_map[int(defindex)] = resolved
+        return resolved
 
     def get_crateseries(self, *, force: bool = False) -> Dict[int, int]:
         return {}


### PR DESCRIPTION
### Motivation
- Prevent inferring wear/grade from fragile heuristics by using canonical data from schema.autobot.tf and avoid per-item API spam for grade lookups.
- Ensure enrichment code prefers Steam Econ tags and schema-provided maps, and expose clear source/debug fields for wear/grade resolution.
- Keep killstreak tier logic separate from grade/tier identity to avoid conflation of concepts in UI and pricing logic.

### Description
- Added schema cache support in `SchemaProvider` for `/properties/wears` and `/getItemGrade/v2` and a cached per-defindex fallback via `/getItemGrade/fromDefindex/{defindex}` to avoid repeated per-item fetches (`utils/schema_provider.py`).
- Hydrated new local cache maps in `utils/local_data.py`: `WEAR_NAMES_BY_ID` and `ITEM_GRADE_BY_DEFINDEX`, and made the new cache files optional with auto-refetch support (`cache/schema/wears.json`, `cache/schema/item_grade_v2.json`).
- Reworked wear extraction/resolution (`utils/inventory/extractors_paint_and_wear.py`) to implement the ordered resolution: 1) Steam Econ tag category `Exterior` (econ_tag), 2) cached `/properties/wears` lookup (schema_wears), 3) safe float→exterior fallback (float), 4) otherwise `None`; added `wear_raw` and `wear_source` fields.
- Reworked grade extraction (`utils/inventory/extractors_grade_tier.py`) to implement the ordered resolution: 1) Steam Econ `Rarity`/`category_name == "Grade"` tags (econ_tag), 2) cached `/getItemGrade/v2` map (schema_grade_v2), 3) cached `/getItemGrade/fromDefindex/{defindex}` fallback (grade_endpoint), 4) name-parser fallback (name_fallback), 5) otherwise `None`; added `grade_source` and `grade_slug` while preserving existing UI fields such as `grade_name` and `grade_color`.
- Integrated the new wear/grade resolution into enrichment output and preserved killstreak-specific fields (e.g., `killstreak_tier`, `killstreak_tier_name`) while emitting separate grade/tier fields for backward compatibility (`utils/inventory/processor.py`).
- Added/updated unit tests to cover: `/properties/wears` and `/getItemGrade/v2` cache loading, grade endpoint fallback caching, econ-tag precedence for grade and wear, schema-grade and schema-wears usage, float fallback behavior, invalid wear handling (no accidental Factory New), and modal badge rendering deduplication (`tests/*.py`).
- Documentation: updated `docs/overview.md` to mention canonical wear/grade sources and the implemented precedence order.

### Testing
- Installed test requirements via `python -m pip install -r requirements-test.txt` and ran the full test suite with `pytest -q`, which completed successfully (all tests passed in this environment, full run recorded passing tests).
- Ran targeted test runs for the modified areas: `tests/test_schema_provider.py`, `tests/test_inventory_processor.py`, `tests/test_item_modal_template.py`, and `tests/test_enrichment.py`; all passed after the changes.
- Static/compile checks: ran `python -m compileall app.py utils tests` successfully and `node --check static/modal.js` succeeded.
- JS modal unit runner `node tests/test_modal.js` could not be executed in this environment due to a missing `jsdom` dependency (environment-only limitation), so that JS unit runner was not run here.
- Live endpoint checks: fetched `https://schema.autobot.tf/properties/wears` and `https://schema.autobot.tf/getItemGrade/v2` to confirm shape/count (summary-only, not large dumps) successfully; attempted a public Steam inventory fetch but it was blocked by an outbound proxy restriction (`httpx.ProxyError: 403 Forbidden`).

✅ Docs/comments sync complete. Validations passed (reasoned).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee24a2b60483268f35b9cf9fa87eb0)