### PR TITLE
Prefer Steam Community inventory media images for item cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Prefer exact Steam Community inventory icon images as an overlay on parsed Web API inventory items, with schema images preserved as fallback.
+
 ### Added
 
 - Pre-commit configuration for formatting, linting, and secret scanning.

--- a/templates/item_card.html
+++ b/templates/item_card.html
@@ -62,6 +62,7 @@ full_title = (title_parts + [base]) | join(' ') %}
   %}
   data-item='{{ item|tojson|forceescape }}'
   data-craftable="{{ 'true' if item.craftable else 'false' }}"
+  data-image-source="{{ item.image_source or 'unknown' }}"
 >
   <div class="item-badges">
     {% if item.is_australium %}

--- a/tests/test_inventory_processor.py
+++ b/tests/test_inventory_processor.py
@@ -1798,3 +1798,35 @@ def test_killstreak_fabricator_parsing():
     ]
     assert item["stack_key"] is None
     assert item["target_weapon_image"] == "blut.png"
+
+def test_enrich_inventory_prefers_community_image_over_schema():
+    data = {
+        "items": [
+            {
+                "defindex": 111,
+                "quality": 6,
+                "image_url": "https://steamcommunity-a.akamaihd.net/economy/image/exact_skin",
+                "media_source": "steam_community_inventory",
+            }
+        ]
+    }
+    ld.ITEMS_BY_DEFINDEX = {
+        111: {"item_name": "Rocket Launcher", "image_url": "schema_base_weapon.png"}
+    }
+    ld.QUALITIES_BY_INDEX = {6: "Unique"}
+
+    items = ip.enrich_inventory(data)
+    assert items[0]["image_url"] == "https://steamcommunity-a.akamaihd.net/economy/image/exact_skin"
+    assert items[0]["image_source"] == "steam_community_inventory"
+
+
+def test_enrich_inventory_falls_back_to_schema_image_without_media():
+    data = {"items": [{"defindex": 111, "quality": 6}]}
+    ld.ITEMS_BY_DEFINDEX = {
+        111: {"item_name": "Rocket Launcher", "image_url": "schema_base_weapon.png"}
+    }
+    ld.QUALITIES_BY_INDEX = {6: "Unique"}
+
+    items = ip.enrich_inventory(data)
+    assert items[0]["image_url"] == "schema_base_weapon.png"
+    assert items[0]["image_source"] == "schema"

--- a/tests/test_steam_api_client.py
+++ b/tests/test_steam_api_client.py
@@ -81,3 +81,73 @@ def test_convert_vanity_to_steam64(monkeypatch):
 
     monkeypatch.setattr(sac.httpx, "Client", DummyClient)
     assert sac.convert_to_steam64("gaben") == "76561197960287930"
+
+
+@pytest.mark.asyncio
+async def test_fetch_inventory_media_async_paginates(monkeypatch):
+    pages = [
+        {
+            "assets": [{"assetid": "1", "classid": "10", "instanceid": "0"}],
+            "descriptions": [{"classid": "10", "instanceid": "0", "icon_url": "abc"}],
+            "more_items": 1,
+            "last_assetid": "1",
+        },
+        {
+            "assets": [{"assetid": "2", "classid": "20", "instanceid": "0"}],
+            "descriptions": [
+                {"classid": "20", "instanceid": "0", "icon_url_large": "def"}
+            ],
+            "more_items": 0,
+        },
+    ]
+
+    class DummyAsyncClient:
+        def __init__(self, *a, **k):
+            self.calls = 0
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def get(self, *_a, **_k):
+            payload = pages[self.calls]
+            self.calls += 1
+            return types.SimpleNamespace(status_code=200, json=lambda: payload)
+
+    monkeypatch.setattr(sac.httpx, "AsyncClient", DummyAsyncClient)
+    media = await sac.fetch_inventory_media_async("123")
+    assert media["1"]["image_url"] == sac.ECON_IMAGE_CDN + "abc"
+    assert media["1"]["image_url_small"] == sac.ECON_IMAGE_CDN + "abc/96fx96f"
+    assert media["2"]["image_url"] == sac.ECON_IMAGE_CDN + "def"
+
+
+@pytest.mark.asyncio
+async def test_fetch_inventory_async_media_failure_does_not_fail_inventory(monkeypatch):
+    monkeypatch.setattr(sac, "STEAM_API_KEY", "x")
+
+    payload = {"result": {"status": 1, "items": [{"id": "99", "defindex": 1}]}}
+
+    class DummyAsyncClient:
+        def __init__(self, *a, **k):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def get(self, *_a, **_k):
+            return types.SimpleNamespace(status_code=200, json=lambda: payload)
+
+    async def _boom(_steamid):
+        return {}
+
+    monkeypatch.setattr(sac.httpx, "AsyncClient", DummyAsyncClient)
+    monkeypatch.setattr(sac, "fetch_inventory_media_async", _boom)
+
+    status, result = await sac.fetch_inventory_async("123")
+    assert status == "parsed"
+    assert result["items"][0]["id"] == "99"

--- a/utils/inventory/processor.py
+++ b/utils/inventory/processor.py
@@ -55,6 +55,35 @@ from .filters_and_rules import _is_plain_craft_weapon, _has_attr
 logger = logging.getLogger(__name__)
 
 
+ECON_IMAGE_CDN = "https://steamcommunity-a.akamaihd.net/economy/image/"
+
+
+def _economy_image_url(icon_hash: str | None, size: str | None = None) -> str | None:
+    """Return a full Steam economy image URL for an icon hash."""
+
+    if not icon_hash:
+        return None
+    base = ECON_IMAGE_CDN + str(icon_hash).lstrip("/")
+    return f"{base}/{size}" if size else base
+
+
+def _resolve_item_image(asset: dict, schema_entry: dict) -> tuple[str, str | None, str]:
+    """Return preferred item image URL, small URL, and image source label."""
+
+    icon_url_cdn = asset.get("icon_url_cdn") or _economy_image_url(asset.get("icon_url"))
+    icon_url_large_cdn = asset.get("icon_url_large_cdn") or _economy_image_url(asset.get("icon_url_large"))
+    image_url = (
+        asset.get("image_url")
+        or asset.get("image_url_large")
+        or icon_url_large_cdn
+        or icon_url_cdn
+        or schema_entry.get("image_url", "")
+    )
+    image_url_small = asset.get("image_url_small") or _economy_image_url(asset.get("icon_url"), "96fx96f")
+    image_source = "steam_community_inventory" if image_url and image_url != schema_entry.get("image_url", "") else "schema"
+    return image_url, image_url_small, image_source
+
+
 ATTRIBUTE_ALIASES = {
     "attach_particle_effect": [
         "attach particle effect",
@@ -168,7 +197,7 @@ def _process_item(
         return None
 
     defindex = str(defindex_int)
-    image_url = schema_entry.get("image_url", "")
+    image_url, image_url_small, image_source = _resolve_item_image(asset, schema_entry)
 
     warpaintable = _is_warpaintable(schema_entry)
     warpaint_tool = defindex_int in WAR_PAINT_TOOL_DEFINDEXES or _is_warpaint_tool(
@@ -453,6 +482,8 @@ def _process_item(
         "quality_color": q_col,
         "border_color": border_color,
         "image_url": image_url,
+        "image_url_small": image_url_small,
+        "image_source": image_source,
         "item_type_name": schema_entry.get("item_type_name"),
         "item_name": schema_entry.get("name"),
         "craft_class": schema_entry.get("craft_class"),

--- a/utils/steam_api_client.py
+++ b/utils/steam_api_client.py
@@ -13,6 +13,17 @@ STEAM_API_KEY = os.getenv("STEAM_API_KEY")
 
 logger = logging.getLogger(__name__)
 
+ECON_IMAGE_CDN = "https://steamcommunity-a.akamaihd.net/economy/image/"
+
+
+def _economy_image_url(icon_hash: str | None, size: str | None = None) -> str | None:
+    """Return a full Steam economy image URL for an icon hash."""
+
+    if not icon_hash:
+        return None
+    base = ECON_IMAGE_CDN + str(icon_hash).lstrip("/")
+    return f"{base}/{size}" if size else base
+
 
 def _require_key() -> str:
     """Return the Steam API key or raise an error if missing."""
@@ -126,6 +137,87 @@ async def get_player_summaries_async(steamids: List[str]) -> List[Dict[str, Any]
     return results
 
 
+
+
+async def fetch_inventory_media_async(steamid: str) -> dict[str, dict[str, Any]]:
+    """Return Steam Community inventory media metadata keyed by asset ID.
+
+    This endpoint is used as a media overlay only and should not be treated as
+    a hard dependency for inventory parsing.
+    """
+
+    headers = {"User-Agent": "Mozilla/5.0"}
+    url = f"https://steamcommunity.com/inventory/{steamid}/440/2"
+    params: dict[str, Any] = {"l": "english", "count": 5000}
+    media_by_assetid: dict[str, dict[str, Any]] = {}
+
+    async with httpx.AsyncClient(timeout=20) as client:
+        while True:
+            try:
+                resp = await client.get(url, params=params, headers=headers)
+            except httpx.HTTPError as exc:
+                logger.warning("Community media fetch failed for %s: %s", steamid, exc)
+                return {}
+
+            if resp.status_code != 200:
+                logger.warning(
+                    "Community media HTTP %s for %s", resp.status_code, steamid
+                )
+                return {}
+
+            try:
+                payload = resp.json()
+            except ValueError:
+                logger.warning("Community media invalid JSON for %s", steamid)
+                return {}
+
+            descriptions = payload.get("descriptions") or []
+            assets = payload.get("assets") or []
+            description_by_key = {
+                (str(d.get("classid") or ""), str(d.get("instanceid") or "0")): d
+                for d in descriptions
+                if d.get("classid")
+            }
+
+            for asset in assets:
+                assetid = str(asset.get("assetid") or "")
+                if not assetid:
+                    continue
+                classid = str(asset.get("classid") or "")
+                instanceid = str(asset.get("instanceid") or "0")
+                desc = description_by_key.get((classid, instanceid), {})
+
+                icon_url = desc.get("icon_url")
+                icon_url_large = desc.get("icon_url_large")
+                exact_image = _economy_image_url(icon_url_large) or _economy_image_url(icon_url)
+                media_by_assetid[assetid] = {
+                    "assetid": assetid,
+                    "classid": classid,
+                    "instanceid": instanceid,
+                    "image_url": exact_image,
+                    "image_url_small": _economy_image_url(icon_url, "96fx96f"),
+                    "icon_url": icon_url,
+                    "icon_url_large": icon_url_large,
+                    "market_hash_name": desc.get("market_hash_name"),
+                    "market_name": desc.get("market_name"),
+                    "name": desc.get("name"),
+                    "type": desc.get("type"),
+                    "name_color": desc.get("name_color"),
+                    "background_color": desc.get("background_color"),
+                    "descriptions": desc.get("descriptions", []),
+                    "tags": desc.get("tags", []),
+                    "media_source": "steam_community_inventory",
+                }
+
+            if not payload.get("more_items"):
+                break
+            last_assetid = payload.get("last_assetid")
+            if not last_assetid:
+                break
+            params["start_assetid"] = str(last_assetid)
+
+    return media_by_assetid
+
 async def fetch_inventory_async(steamid: str) -> Tuple[str, Dict[str, Any]]:
     """Asynchronously fetch and classify a user's TF2 inventory."""
 
@@ -167,6 +259,29 @@ async def fetch_inventory_async(steamid: str) -> Tuple[str, Dict[str, Any]]:
 
     if status_code == 1:
         if items:
+            media_by_assetid = await fetch_inventory_media_async(steamid)
+            for item in items:
+                asset_id = str(item.get("id") or item.get("original_id") or "")
+                media = media_by_assetid.get(asset_id)
+                if not media:
+                    continue
+                item.update(
+                    {
+                        "image_url": media.get("image_url"),
+                        "image_url_small": media.get("image_url_small"),
+                        "icon_url": media.get("icon_url"),
+                        "icon_url_large": media.get("icon_url_large"),
+                        "market_hash_name": media.get("market_hash_name"),
+                        "market_name": media.get("market_name"),
+                        "steam_name": media.get("name"),
+                        "steam_type": media.get("type"),
+                        "name_color": media.get("name_color"),
+                        "background_color": media.get("background_color"),
+                        "steam_descriptions": media.get("descriptions", []),
+                        "steam_tags": media.get("tags", []),
+                        "media_source": media.get("media_source"),
+                    }
+                )
             logger.info(
                 "Inventory %s: Public and Parsed (%s items)", steamid, len(items)
             )


### PR DESCRIPTION
### Motivation
- Improve item card visuals by preferring exact per-asset Steam Community inventory images (skins, Australiums, decorated weapons, etc.) while preserving the existing Web API enrichment pipeline as the source of truth.
- Add a non-fatal media overlay so Community media availability does not break inventory parsing when private/rate-limited.

### Description
- Added `ECON_IMAGE_CDN` and `_economy_image_url(...)` and a new async `fetch_inventory_media_async(steamid)` which paginates the Community inventory (`more_items`/`last_assetid`) and returns per-asset media keyed by `assetid`; fetch failures are logged and return an empty mapping. (file: `utils/steam_api_client.py`).
- Merged Community media into parsed Web API inventory items inside `fetch_inventory_async(...)` by asset id so items gain `image_url`, `image_url_small`, `icon_url*`, `market_*`, `steam_*`, `steam_descriptions`, `steam_tags` and `media_source` when available. (file: `utils/steam_api_client.py`).
- Added `_resolve_item_image(...)` and economy URL helper to `utils/inventory/processor.py` so `enrich_inventory` prefers Community `image_url`/`icon_url_large`/`icon_url` (converted to full CDN URLs) and falls back to schema `image_url`; processors now emit `image_url_small` and `image_source` alongside existing image fields. (file: `utils/inventory/processor.py`).
- Added `data-image-source="{{ item.image_source or 'unknown' }}"` to item card markup for observability without changing layout. (file: `templates/item_card.html`).
- Updated `CHANGELOG.md` and added tests to assert (a) Community media pagination and URL construction and (b) processor preference for community images with schema fallback. (files: `tests/test_steam_api_client.py`, `tests/test_inventory_processor.py`, `CHANGELOG.md`).

### Testing
- Added unit tests that exercise Community-media pagination and overlay behavior (`tests/test_steam_api_client.py`) and image preference/fallback in the inventory processor (`tests/test_inventory_processor.py`).
- Attempted to run the targeted tests with `pytest tests/test_steam_api_client.py tests/test_inventory_processor.py`, but execution failed due to a missing test runtime dependency (`ModuleNotFoundError: No module named 'pytest_asyncio'`) in this environment, so tests were not executed here.
- Performed repository validations by inspecting changed files to ensure docstrings for new public helpers were added, `CHANGELOG.md` was updated, and there are no obvious undefined symbols or unreachable code introduced by these changes.
- ✅ Docs/comments sync complete. Validations passed (reasoned).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f69d4d056483269db5310db8df1c0a)